### PR TITLE
Pass repo index overlays to configure_ros2

### DIFF
--- a/repos/config/defs.bzl
+++ b/repos/config/defs.bzl
@@ -16,7 +16,7 @@ load("@rules_ros//repos/config/detail:ros2_config.bzl", "ros2_config")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@rules_ros//repos/config:distros.bzl", "DISTROS")
 
-def _configure_ros2(*, name, distro_src):
+def _configure_ros2(*, name, distro_src, repo_index_overlays):
     distro_src_wo_index = {k: v for k, v in distro_src.items() if k != "repo_index"}
     distro_src_wo_index["build_file_content"] = 'exports_files(["ros2.repos"])'
 
@@ -27,10 +27,10 @@ def _configure_ros2(*, name, distro_src):
         repo_index = distro_src["repo_index"],
         repo_index_overlays = [
             "@rules_ros//repos/config:bazel.repos",
-        ],
+        ] + repo_index_overlays,
     )
 
-def configure_ros2(*, name = "ros2_config", distro):
+def configure_ros2(*, name = "ros2_config", repo_index_overlays = [], distro):
     """
     """
     if type(distro) == type(""):
@@ -41,4 +41,6 @@ def configure_ros2(*, name = "ros2_config", distro):
         if not type(distro) == type({}) or not "repo_rule" in distro:
             fail("Distro either needs to be a string (e.g. 'iron') or a dict with arguments for the maybe repo rule")
         distro_src = distro
-    _configure_ros2(name = name, distro_src = distro_src)
+    if not type(repo_index_overlays) == type([]):
+        fail("repo_index_overlays needs to be a list of *.repos files")
+    _configure_ros2(name = name, distro_src = distro_src, repo_index_overlays = repo_index_overlays)


### PR DESCRIPTION
Provide a client with the possibility of providing repo index overlay files in the `configure_ros2` call. This enables clients to use the repo index file (`ros2.repos`) from the official ROS 2 distribution while providing additional repositories or overriding the original.

The call on the client side will look as follows:

```python
configure_ros2(
    distro = "humble",
    repo_index_overlays = [
        ":more_repos.repos",
    ],
)
```