### PR TITLE
Make repo locking more flexible

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test
         run: bazel test --keep_going -- //repos/config/detail/... //thirdparty/... $(cat repos/config/bazel.repos | sed -e '/^[#r]/d' -e '/^    /d' -e 's%/%.%' -e 's%  \(.*\):%@\1//...%' -e '/@ros2.rosidl/d' -e '/@ros2.rcl_interfaces/d' -e '/@ros2.common_interfaces/d')
       - name: Store the bazel-testlogs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ matrix.os }}-${{ matrix.version }}-bazel-testlogs

--- a/0001-Remove-hardcoded-paths-from-rules_ros-config-impleme.patch
+++ b/0001-Remove-hardcoded-paths-from-rules_ros-config-impleme.patch
@@ -1,0 +1,19159 @@
+From 06d50e698117a1d22f537a342f50eb3f208968af Mon Sep 17 00:00:00 2001
+From: Revati Naik <revati.naik@apex.ai>
+Date: Tue, 11 Feb 2025 11:27:10 -0800
+Subject: [PATCH] Remove hardcoded paths from rules_ros config implementation
+
+Fix the generation of repos lock file
+
+Avoid creating .bzl files in config workspace
+
+Update actual lock target
+
+Remove duplicate py_binary target
+---
+ 0001-Add-apex_http_archive.patch              |    86 +
+ ...reate-a-MACRO-for-the-py_binary-rule.patch |   100 +
+ ...ix-the-generation-fo-repos-lock-file.patch |    70 +
+ repos/config/BUILD.bazel                      |     2 +-
+ repos/config/defs.bzl                         |     3 +-
+ repos/config/detail/BUILD.bazel               |    18 +-
+ repos/config/detail/generate_repos_lock.bzl   |    18 +
+ repos/config/detail/ros2_config.bzl           |    28 +-
+ .../detail/test/test_repos_index_sha256.sh    |    23 +
+ rules_ros.patch                               | 18692 ++++++++++++++++
+ 10 files changed, 19017 insertions(+), 23 deletions(-)
+ create mode 100644 0001-Add-apex_http_archive.patch
+ create mode 100644 0001-Create-a-MACRO-for-the-py_binary-rule.patch
+ create mode 100644 0002-Fix-the-generation-fo-repos-lock-file.patch
+ create mode 100644 repos/config/detail/generate_repos_lock.bzl
+ create mode 100755 repos/config/detail/test/test_repos_index_sha256.sh
+ create mode 100644 rules_ros.patch
+
+diff --git a/0001-Add-apex_http_archive.patch b/0001-Add-apex_http_archive.patch
+new file mode 100644
+index 0000000..eaa4a83
+--- /dev/null
++++ b/0001-Add-apex_http_archive.patch
+@@ -0,0 +1,86 @@
++From e859c13e36e0f15167b5fbcc4970768c4d973d3d Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Thu, 19 Sep 2024 17:35:38 -0700
++Subject: [PATCH] Add apex_http_archive
++
++---
++ repos/config/detail/generate_ros2_config.py | 17 +++++++++++++++++
++ repos/config/detail/lock_repos.py           |  6 +++---
++ 2 files changed, 20 insertions(+), 3 deletions(-)
++
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 184315b..428e7e0 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -21,6 +21,7 @@ HEADER = """#
++ # To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE
++ #
++ 
+++load("@apex//tools/bazel/rules_repo:defs.bzl", "apex_http_archive")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++ load("@rules_ros//repos/config/detail:git_repository.bzl", "git_repository")
++ load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
++@@ -43,6 +44,7 @@ def build_load_command(repo, spec):
++         "git": build_git_load_command,
++         "http_archive": build_http_archive_load_command,
++         "local": build_local_load_command,
+++        "apex_http_archive": build_apex_http_archive_load_command
++     }
++     if spec.get('type') not in builder.keys():
++         return f"""
++@@ -60,6 +62,21 @@ def build_build_files_attr(build_files):
++         }},"""
++ 
++ 
+++def build_apex_http_archive_load_command(repo, spec):
+++    spec_string = "\n        ".join(
+++        f'{k} = "{v}",'
+++        for k,v in spec.items()
+++        if k not in ["type", "bazel"]
+++    )
+++    return f"""\
+++    _maybe(
+++        name = "{repo.replace('/','.')}",
+++        {spec_string}
+++        repo_rule = apex_http_archive,
+++    )
+++"""
+++
+++
++ def build_http_archive_load_command(repo, spec):
++     return f"""\
++     _maybe(
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index 08eebc4..40a458d 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -23,7 +23,7 @@ import hashlib
++ from pathlib import Path
++ from generate_ros2_config import print_setup_file
++ 
++-REPO_TYPES = ["git", "tar"]
+++REPO_TYPES = ["git", "tar", "apex_http_archive"]
++ 
++ def main():
++     parser = argparse.ArgumentParser(description='Generate a Bazel setup file containing repo '
++@@ -55,7 +55,7 @@ def main():
++ 
++ 
++ def fetch_dependency_details(*, use_tar, type, **kwargs):
++-    if type == "tar" or use_tar:
+++    if type in ["tar", "apex_http_archive"] or use_tar:
++         return fetch_http_details(type = type, **kwargs)
++     return fetch_git_details(type = type, **kwargs)
++ 
++@@ -64,7 +64,7 @@ def add_attributes(dictionary, additional_attributes):
++         dictionary[k] = v
++ 
++ def fetch_http_details(*, type, version = None, url = None, **kwargs):
++-    forward_type = "http_archive"
+++    forward_type = "apex_http_archive" if type == "apex_http_archive" else "http_archive"
++     if "sha256" in kwargs:
++         return { "type": forward_type}
++     with tempfile.TemporaryDirectory() as tempdir:
++-- 
++2.34.1
++
+diff --git a/0001-Create-a-MACRO-for-the-py_binary-rule.patch b/0001-Create-a-MACRO-for-the-py_binary-rule.patch
+new file mode 100644
+index 0000000..9056096
+--- /dev/null
++++ b/0001-Create-a-MACRO-for-the-py_binary-rule.patch
+@@ -0,0 +1,100 @@
++From 62a75641a0909673f60870a07fb9abcb42338b74 Mon Sep 17 00:00:00 2001
++From: Revati Naik <revati.naik@apex.ai>
++Date: Tue, 11 Feb 2025 11:27:10 -0800
++Subject: [PATCH 1/2] Create a MACRO for the py_binary rule
++
++---
++ repos/config/defs.bzl                       |  3 ++-
++ repos/config/detail/generate_repos_lock.bzl | 24 +++++++++++++++++++++
++ repos/config/detail/ros2_config.bzl         | 20 +++++++++++++++--
++ 3 files changed, 44 insertions(+), 3 deletions(-)
++ create mode 100644 repos/config/detail/generate_repos_lock.bzl
++
++diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
++index ed10d70..ef35ef9 100644
++--- a/repos/config/defs.bzl
+++++ b/repos/config/defs.bzl
++@@ -46,11 +46,12 @@ def configure_ros2(*, name = "ros2_config", repos_index_overlays = [], distro):
++         fail("repos_index_overlays needs to be a list of *.repos files")
++     _configure_ros2(name = name, distro_src = distro_src, repos_index_overlays = repos_index_overlays)
++ 
++-def configure_repos(*, name = "ros2_config", repos_index, repos_index_overlays = [], setup_file):
+++def configure_repos(*, name, repos_index, setup_file, repos_index_overlays = []):
++     """Configure ROS 2 repositories based on the custom *.repos file."""
++ 
++     if not type(repos_index_overlays) == type([]):
++         fail("repos_index_overlays needs to be a list of *.repos files")
+++
++     ros2_config(
++         name = name,
++         repos_index = repos_index,
++diff --git a/repos/config/detail/generate_repos_lock.bzl b/repos/config/detail/generate_repos_lock.bzl
++new file mode 100644
++index 0000000..0d9bdf5
++--- /dev/null
+++++ b/repos/config/detail/generate_repos_lock.bzl
++@@ -0,0 +1,24 @@
+++load("@python_deps//:requirements.bzl", "requirement")
+++load("@rules_python//python:defs.bzl", "py_binary")
+++
+++def generate_repos_lock(name, repos_file, setup_file, overlay_files):
+++    """Macro to create a py_binary for generating repos_lock.update"""
+++
+++    py_binary(
+++        name = name,
+++        srcs = [
+++            Label("generate_ros2_config.py"),
+++            Label("lock_repos.py"),
+++        ],
+++        args = [
+++            "$(execpath {})".format(repos_file),
+++            "$(execpath {})".format(setup_file),
+++        ] + ["$(execpath {})".format(f) for f in overlay_files],
+++        data = [
+++            repos_file,
+++            setup_file,
+++        ] + overlay_files,
+++        main = Label("lock_repos.py"),
+++        visibility = ["//visibility:public"],
+++        deps = [requirement("pyyaml")],
+++    )
++\ No newline at end of file
++diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
++index 0e9102c..7fa83e3 100644
++--- a/repos/config/detail/ros2_config.bzl
+++++ b/repos/config/detail/ros2_config.bzl
++@@ -30,13 +30,29 @@ _archive_attrs = {
++     ),
++ }
++ 
+++BUILD_FILE_CONTENT = """\
+++load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "generate_repos_lock")
+++
+++generate_repos_lock(
+++    name = "repos_lock.update",
+++    repos_file = ":repos_index_file.repos",  # Custom repos file
+++    setup_file = ":repos_setup_file.bzl",  # Custom setup file
+++    overlay_files = [
+++        ":repos_overlay_files.repos",
+++    ],
+++)
+++
+++exports_files(glob(["**/*"]))
+++"""
+++
+++
++ def _ros2_config_impl(ctx):
++     ctx.file("repos_index_file.bzl", content = "REPOS_INDEX_FILE = '{}'".format(ctx.attr.repos_index))
++-    ctx.file("repos_overlay_files.bzl", content = "REPOS_OVERLAY_FILES = {}".format(["{}".format(l) for l in ctx.attr.repos_index_overlays]))
+++    ctx.file("repos_overlay_files.bzl", content = "REPOS_OVERLAY_FILES = {}".format(["{}".format(i) for i in ctx.attr.repos_index_overlays]))
++     ctx.file("repos_setup_file.bzl", content = "REPOS_SETUP_FILE = '{}'".format(ctx.attr.setup_file))
++     ctx.symlink(ctx.attr.setup_file, "setup.bzl")
++     ctx.file("WORKSPACE", content = "workspace(name = {})".format(ctx.name), executable = False)
++-    ctx.file("BUILD.bazel", content = "exports_files(glob(['**/*']))", executable = False)
+++    ctx.file("BUILD.bazel", content = BUILD_FILE_CONTENT, executable = False)
++ 
++     return update_attrs(ctx.attr, _archive_attrs.keys(), {})
++ 
++-- 
++2.34.1
++
+diff --git a/0002-Fix-the-generation-fo-repos-lock-file.patch b/0002-Fix-the-generation-fo-repos-lock-file.patch
+new file mode 100644
+index 0000000..770e0d9
+--- /dev/null
++++ b/0002-Fix-the-generation-fo-repos-lock-file.patch
+@@ -0,0 +1,70 @@
++From 208e21581dc16a9fb20841d230a0c5577bb61e41 Mon Sep 17 00:00:00 2001
++From: Revati Naik <revati.naik@apex.ai>
++Date: Tue, 11 Feb 2025 13:46:31 -0800
++Subject: [PATCH 2/2] Fix the generation fo repos lock file
++
++---
++ repos/config/detail/generate_repos_lock.bzl | 23 +++++++++------------
++ repos/config/detail/ros2_config.bzl         |  4 ++--
++ 2 files changed, 12 insertions(+), 15 deletions(-)
++
++diff --git a/repos/config/detail/generate_repos_lock.bzl b/repos/config/detail/generate_repos_lock.bzl
++index 0d9bdf5..f1d7d80 100644
++--- a/repos/config/detail/generate_repos_lock.bzl
+++++ b/repos/config/detail/generate_repos_lock.bzl
++@@ -1,4 +1,7 @@
++ load("@python_deps//:requirements.bzl", "requirement")
+++load("@ros2_config//:repos_index_file.bzl", "REPOS_INDEX_FILE")
+++load("@ros2_config//:repos_overlay_files.bzl", "REPOS_OVERLAY_FILES")
+++load("@ros2_config//:repos_setup_file.bzl", "REPOS_SETUP_FILE")
++ load("@rules_python//python:defs.bzl", "py_binary")
++ 
++ def generate_repos_lock(name, repos_file, setup_file, overlay_files):
++@@ -6,19 +9,13 @@ def generate_repos_lock(name, repos_file, setup_file, overlay_files):
++ 
++     py_binary(
++         name = name,
++-        srcs = [
++-            Label("generate_ros2_config.py"),
++-            Label("lock_repos.py"),
++-        ],
+++        srcs = ["lock_repos.py", "generate_ros2_config.py"],
+++        main = "lock_repos.py",
+++        data = [REPOS_INDEX_FILE, REPOS_SETUP_FILE] + REPOS_OVERLAY_FILES,
++         args = [
++-            "$(execpath {})".format(repos_file),
++-            "$(execpath {})".format(setup_file),
++-        ] + ["$(execpath {})".format(f) for f in overlay_files],
++-        data = [
++-            repos_file,
++-            setup_file,
++-        ] + overlay_files,
++-        main = Label("lock_repos.py"),
++-        visibility = ["//visibility:public"],
+++            "$(execpath {})".format(REPOS_INDEX_FILE),
+++            "$(execpath {})".format(REPOS_SETUP_FILE),
+++        ] + ["$(execpath {})".format(f) for f in REPOS_OVERLAY_FILES],
++         deps = [requirement("pyyaml")],
+++        visibility = ["//visibility:public"],
++     )
++\ No newline at end of file
++diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
++index 7fa83e3..f067301 100644
++--- a/repos/config/detail/ros2_config.bzl
+++++ b/repos/config/detail/ros2_config.bzl
++@@ -35,10 +35,10 @@ load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "generate_repos_
++ 
++ generate_repos_lock(
++     name = "repos_lock.update",
++-    repos_file = ":repos_index_file.repos",  # Custom repos file
+++    repos_file = ":repos_index_file.bzl",  # Custom repos file
++     setup_file = ":repos_setup_file.bzl",  # Custom setup file
++     overlay_files = [
++-        ":repos_overlay_files.repos",
+++        ":repos_overlay_files.bzl",
++     ],
++ )
++ 
++-- 
++2.34.1
++
+diff --git a/repos/config/BUILD.bazel b/repos/config/BUILD.bazel
+index c716378..98e6e39 100644
+--- a/repos/config/BUILD.bazel
++++ b/repos/config/BUILD.bazel
+@@ -16,5 +16,5 @@ exports_files(["bazel.repos"] + glob(["*.lock.bzl"]))
+ 
+ alias(
+     name = "repos_lock.update",
+-    actual = "//repos/config/detail:repos_lock.update",
++    actual = "@ros2_config//:repos_lock.update",
+ )
+diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
+index ed10d70..ef35ef9 100644
+--- a/repos/config/defs.bzl
++++ b/repos/config/defs.bzl
+@@ -46,11 +46,12 @@ def configure_ros2(*, name = "ros2_config", repos_index_overlays = [], distro):
+         fail("repos_index_overlays needs to be a list of *.repos files")
+     _configure_ros2(name = name, distro_src = distro_src, repos_index_overlays = repos_index_overlays)
+ 
+-def configure_repos(*, name = "ros2_config", repos_index, repos_index_overlays = [], setup_file):
++def configure_repos(*, name, repos_index, setup_file, repos_index_overlays = []):
+     """Configure ROS 2 repositories based on the custom *.repos file."""
+ 
+     if not type(repos_index_overlays) == type([]):
+         fail("repos_index_overlays needs to be a list of *.repos files")
++
+     ros2_config(
+         name = name,
+         repos_index = repos_index,
+diff --git a/repos/config/detail/BUILD.bazel b/repos/config/detail/BUILD.bazel
+index 498ad90..f9f633d 100644
+--- a/repos/config/detail/BUILD.bazel
++++ b/repos/config/detail/BUILD.bazel
+@@ -12,21 +12,5 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-load("@python_deps//:requirements.bzl", "requirement")
+-load("@ros2_config//:repos_index_file.bzl", "REPOS_INDEX_FILE")
+-load("@ros2_config//:repos_overlay_files.bzl", "REPOS_OVERLAY_FILES")
+-load("@ros2_config//:repos_setup_file.bzl", "REPOS_SETUP_FILE")
+-load("@rules_python//python:defs.bzl", "py_binary")
+ 
+-py_binary(
+-    name = "repos_lock.update",
+-    srcs = ["lock_repos.py", "generate_ros2_config.py"],
+-    main = "lock_repos.py",
+-    data = [REPOS_INDEX_FILE, REPOS_SETUP_FILE] + REPOS_OVERLAY_FILES,
+-    args = [
+-        "$(execpath {})".format(REPOS_INDEX_FILE),
+-        "$(execpath {})".format(REPOS_SETUP_FILE),
+-    ] + ["$(execpath {})".format(f) for f in REPOS_OVERLAY_FILES],
+-    deps = [requirement("pyyaml")],
+-    visibility = ["//visibility:public"],
+-)
++exports_files(["generate_ros2_config.py", "lock_repos.py"])
+\ No newline at end of file
+diff --git a/repos/config/detail/generate_repos_lock.bzl b/repos/config/detail/generate_repos_lock.bzl
+new file mode 100644
+index 0000000..859623b
+--- /dev/null
++++ b/repos/config/detail/generate_repos_lock.bzl
+@@ -0,0 +1,18 @@
++load("@python_deps//:requirements.bzl", "requirement")
++load("@rules_python//python:defs.bzl", "py_binary")
++
++def generate_repos_lock(*, name, repos_file, setup_file, overlay_files):
++    """Macro to create a py_binary for generating repos_lock.update"""
++
++    py_binary(
++        name = name,
++        srcs = [Label("lock_repos.py"), Label("generate_ros2_config.py")],
++        main = Label("lock_repos.py"),
++        data = [repos_file, setup_file] + overlay_files,
++        args = [
++            "$(execpath {})".format(repos_file),
++            "$(execpath {})".format(setup_file),
++        ] + ["$(execpath {})".format(f) for f in overlay_files],
++        deps = [requirement("pyyaml")],
++        visibility = ["//visibility:public"],
++    )
+diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
+index 0e9102c..f554e43 100644
+--- a/repos/config/detail/ros2_config.bzl
++++ b/repos/config/detail/ros2_config.bzl
+@@ -30,13 +30,33 @@ _archive_attrs = {
+     ),
+ }
+ 
++BUILD_FILE_CONTENT = """\
++load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "generate_repos_lock")
++
++generate_repos_lock(
++    name = "repos_lock.update",
++    repos_file = "ros.repos",  # Custom repos file
++    setup_file = "setup.bzl",  # Custom setup file
++    overlay_files = [
++{overlays}
++    ],
++)
++
++exports_files(glob(["**/*"]))
++"""
++
+ def _ros2_config_impl(ctx):
+-    ctx.file("repos_index_file.bzl", content = "REPOS_INDEX_FILE = '{}'".format(ctx.attr.repos_index))
+-    ctx.file("repos_overlay_files.bzl", content = "REPOS_OVERLAY_FILES = {}".format(["{}".format(l) for l in ctx.attr.repos_index_overlays]))
+-    ctx.file("repos_setup_file.bzl", content = "REPOS_SETUP_FILE = '{}'".format(ctx.attr.setup_file))
++    ctx.symlink(ctx.attr.repos_index, "ros.repos")
+     ctx.symlink(ctx.attr.setup_file, "setup.bzl")
++    i = 0
++    overlay_files = []
++    for file in ctx.attr.repos_index_overlays:
++        filname = "overlay_{}.bzl".format(i)
++        ctx.symlink(file, filname)
++        i += 1
++        overlay_files.append(filname)
+     ctx.file("WORKSPACE", content = "workspace(name = {})".format(ctx.name), executable = False)
+-    ctx.file("BUILD.bazel", content = "exports_files(glob(['**/*']))", executable = False)
++    ctx.file("BUILD.bazel", content = BUILD_FILE_CONTENT.format(overlays="\n".join(['        "{}",'.format(filename) for filename in overlay_files])), executable = False)
+ 
+     return update_attrs(ctx.attr, _archive_attrs.keys(), {})
+ 
+diff --git a/repos/config/detail/test/test_repos_index_sha256.sh b/repos/config/detail/test/test_repos_index_sha256.sh
+new file mode 100755
+index 0000000..64e013e
+--- /dev/null
++++ b/repos/config/detail/test/test_repos_index_sha256.sh
+@@ -0,0 +1,23 @@
++#!/bin/bash
++
++REPOS_INDEX_FILE="$1"
++REPOS_SETUP_FILE="$2"
++
++REPOS_SETUP_FILE_SHA256=$(grep "SHA256" "${REPOS_SETUP_FILE}" | cut -f 5 -d ' ')
++
++if [[ -z "${REPOS_SETUP_FILE_SHA256}" ]]; then
++  echo "${REPOS_SETUP_FILE} DOES NOT HAVE A SHA256 COMMENT. TERMINATING"
++  exit -1
++elif [[ "${REPOS_SETUP_FILE_SHA256}" =~ ^[a-f0-9]{65}$ ]]; then
++  echo "${REPOS_SETUP_FILE} INVALID SHA256 COMMENT of ${REPOS_SETUP_FILE_SHA256}. TERMINATING"
++  exit -1
++fi
++
++REPOS_INDEX_FILE_SHA256=$(sha256sum "${REPOS_INDEX_FILE}" |  cut -f 1 -d ' ')
++
++if [ "${REPOS_INDEX_FILE_SHA256}" != "${REPOS_SETUP_FILE_SHA256}" ]; then
++  echo "SHA256 MISMATCH. RUN 'bazel run @rules_ros//repos/config:repos_lock.update' THEN TRY AGAIN"
++  exit -1
++fi
++
++exit 0
+\ No newline at end of file
+diff --git a/rules_ros.patch b/rules_ros.patch
+new file mode 100644
+index 0000000..f1c0006
+--- /dev/null
++++ b/rules_ros.patch
+@@ -0,0 +1,18692 @@
++From 310c9680b58d24a3a5012d80c3e089776fbc94fa Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Thu, 13 Oct 2022 14:11:58 +0200
++Subject: [PATCH 01/27] Initial bazel support
++
++---
++ .bazelrc                                      |  12 ++
++ .bazelversion                                 |   1 +
++ README.md                                     | 139 +++++++++++++-----
++ WORKSPACE                                     |  14 ++
++ examples/BUILD.bazel                          |  27 ++++
++ examples/bazel_simple_example/BUILD           |  47 ++++++
++ examples/bazel_simple_example/publisher.cpp   |  58 ++++++++
++ examples/bazel_simple_example/subscriber.cpp  |  40 +++++
++ examples/hello_world/BUILD.bazel              |  32 ++++
++ .../main.cpp                                  |   0
++ examples/simple_pkg_example/BUILD.bazel       |  17 ---
++ pkg/defs.bzl                                  |  14 ++
++ pkg/detail/BUILD                              |  14 ++
++ pkg/detail/executable_wrapper_generator.py    |  14 ++
++ pkg/detail/package_xml_generator.py           |  14 ++
++ pkg/detail/ros_archive.bzl                    |  14 ++
++ pkg/detail/ros_pkg.bzl                        |  14 ++
++ pkg/detail/setup_bash_generator.py            |  14 ++
++ pkg/detail/templates/install.template         |  26 +++-
++ pkg/detail/utils.bzl                          |  14 ++
++ pkg/providers.bzl                             |  14 ++
++ .../ament_index_cpp.BUILD.bazel               |  23 +++
++ .../ament_index_python.BUILD.bazel            |  81 ++++++++++
++ repos/config/BUILD.bazel                      |  14 ++
++ repos/config/bazel.repos                      |  65 +++++---
++ repos/config/defs.bzl                         |  14 ++
++ repos/config/detail/BUILD.bazel               |  14 ++
++ repos/config/detail/generate_ros2_config.py   |  38 +++++
++ repos/config/detail/git_repository.bzl        |  14 ++
++ repos/config/detail/lock_repos.py             |  14 ++
++ repos/config/detail/new_local_repository.bzl  |  77 ++++++++++
++ repos/config/detail/ros2_config.bzl           |  14 ++
++ .../root.BUILD.bazel                          |  34 +++++
++ .../std_msgs.BUILD.bazel                      |  29 ++++
++ repos/ros2.rcl.BUILD/rcl.BUILD.bazel          |  14 ++
++ .../rcl_yaml_param_parser.BUILD.bazel         |  14 ++
++ .../builtin_interfaces.BUILD.bazel            |  20 ++-
++ .../rcl_interfaces.BUILD.bazel                |  15 ++
++ .../rosgraph_msgs.BUILD.bazel                 |  28 ++++
++ .../statistics_msgs.BUILD.bazel               |  28 ++++
++ .../rcl_logging_interface.BUILD.bazel         |  14 ++
++ repos/ros2.rclcpp.BUILD/build_interfaces.py   |  37 +++++
++ repos/ros2.rclcpp.BUILD/rclcpp.BUILD.bazel    |  75 +++++++++-
++ .../rcpputils.BUILD.bazel                     |  14 ++
++ .../build_logging_macros.py                   |  15 +-
++ repos/ros2.rcutils.BUILD/root.BUILD.bazel     |  14 ++
++ repos/ros2.rmw.BUILD/rmw.BUILD.bazel          |  19 ++-
++ .../tracetools.BUILD.bazel                    |  14 ++
++ repos/ros2.ros2cli.BUILD/ros2cli.BUILD.bazel  |  90 ++++++++++++
++ repos/ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel  |  80 ++++++++++
++ repos/ros2.ros2cli.BUILD/ros2run.BUILD.bazel  |  71 +++++++++
++ .../rosidl_adapter.BUILD.bazel                |  58 ++++++++
++ .../ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel  |  28 ++++
++ .../rosidl_cmake.BUILD.bazel                  |  28 ++++
++ .../rosidl_generator_c.BUILD.bazel            | 108 ++++++++++++++
++ .../rosidl_generator_cpp.BUILD.bazel          |  71 +++++++++
++ .../rosidl_parser.BUILD.bazel                 |  28 ++++
++ .../rosidl_runtime_c.BUILD.bazel              |  14 ++
++ .../rosidl_runtime_cpp.BUILD.bazel            |  27 ++++
++ .../rosidl_typesupport_interface.BUILD.bazel  |  14 ++
++ .../rosidl_generator_dds_idl.BUILD.bazel      |  54 +++++++
++ .../rosidl_typesupport_c.BUILD.bazel          |  82 +++++++++++
++ rosidl/defs.bzl                               | 104 ++++++++++++-
++ ..._library_with_hdrs_extracted_from_srcs.bzl |  45 ++++++
++ .../detail/cc_library_with_msgs_provider.bzl  |  36 +++++
++ rosidl/detail/common_config.bzl               |  80 ++++++++++
++ rosidl/detail/misc_support.bzl                |  91 ++++++++++++
++ rosidl/detail/rosidl_adapter.bzl              | 131 +++++++++++++++++
++ rosidl/detail/rosidl_generator_c.bzl          | 131 +++++++++++++++++
++ rosidl/detail/rosidl_generator_cpp.bzl        |  98 ++++++++++++
++ rosidl/detail/rosidl_generator_dds_idl.bzl    | 118 +++++++++++++++
++ rosidl/detail/rosidl_typesupport_c.bzl        | 109 ++++++++++++++
++ rosidl/detail/visiability_control.bzl         |  26 ++++
++ rosidl/providers.bzl                          |  14 ++
++ thirdparty/bazel_skylib/repositories.bzl      |  14 ++
++ thirdparty/bazel_skylib/setup.bzl             |  14 ++
++ thirdparty/libyaml/libyaml.BUILD              |  16 --
++ thirdparty/libyaml/libyaml.BUILD.bazel        |  30 ++++
++ thirdparty/libyaml/repositories.bzl           |  16 +-
++ thirdparty/python/repositories.bzl            |  14 ++
++ thirdparty/python/requirements_lock.in        |   6 +-
++ thirdparty/python/requirements_lock.txt       |  54 +++++++
++ thirdparty/setup_01.bzl                       |  14 ++
++ thirdparty/setup_02.bzl                       |  14 ++
++ thirdparty/setup_03.bzl                       |  14 ++
++ thirdparty/setup_04.bzl                       |  14 ++
++ utils/template_expansion.bzl                  |  68 +++++++--
++ 87 files changed, 3184 insertions(+), 131 deletions(-)
++ create mode 100644 .bazelrc
++ create mode 100644 .bazelversion
++ create mode 100644 examples/BUILD.bazel
++ create mode 100644 examples/bazel_simple_example/BUILD
++ create mode 100644 examples/bazel_simple_example/publisher.cpp
++ create mode 100644 examples/bazel_simple_example/subscriber.cpp
++ create mode 100644 examples/hello_world/BUILD.bazel
++ rename examples/{simple_pkg_example => hello_world}/main.cpp (100%)
++ delete mode 100644 examples/simple_pkg_example/BUILD.bazel
++ create mode 100644 repos/ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel
++ create mode 100644 repos/ament.ament_index.BUILD/ament_index_python.BUILD.bazel
++ create mode 100644 repos/config/detail/new_local_repository.bzl
++ create mode 100644 repos/ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel
++ create mode 100644 repos/ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel
++ create mode 100644 repos/ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel
++ create mode 100644 repos/ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel
++ create mode 100644 repos/ros2.rclcpp.BUILD/build_interfaces.py
++ create mode 100644 repos/ros2.ros2cli.BUILD/ros2cli.BUILD.bazel
++ create mode 100644 repos/ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel
++ create mode 100644 repos/ros2.ros2cli.BUILD/ros2run.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel
++ create mode 100644 repos/ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel
++ create mode 100644 rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl
++ create mode 100644 rosidl/detail/cc_library_with_msgs_provider.bzl
++ create mode 100644 rosidl/detail/common_config.bzl
++ create mode 100644 rosidl/detail/misc_support.bzl
++ create mode 100644 rosidl/detail/rosidl_adapter.bzl
++ create mode 100644 rosidl/detail/rosidl_generator_c.bzl
++ create mode 100644 rosidl/detail/rosidl_generator_cpp.bzl
++ create mode 100644 rosidl/detail/rosidl_generator_dds_idl.bzl
++ create mode 100644 rosidl/detail/rosidl_typesupport_c.bzl
++ create mode 100644 rosidl/detail/visiability_control.bzl
++ delete mode 100644 thirdparty/libyaml/libyaml.BUILD
++ create mode 100644 thirdparty/libyaml/libyaml.BUILD.bazel
++
++diff --git a/.bazelrc b/.bazelrc
++new file mode 100644
++index 0000000..e6717c0
++--- /dev/null
+++++ b/.bazelrc
++@@ -0,0 +1,12 @@
+++# enable incompatible python init mode
+++build --incompatible_default_to_explicit_init_py
+++
+++# enable implementation_deps on cc_library targets
+++build --experimental_cc_implementation_deps
+++
+++# set c++14 for all builds
+++build --cxxopt="-std=c++17"
+++build --host_cxxopt="-std=c++17"
+++
+++# try to import a user-specific bazelrc (gitignored)
+++try-import %workspace%/user.bazelrc
++diff --git a/.bazelversion b/.bazelversion
++new file mode 100644
++index 0000000..7d3cdbf
++--- /dev/null
+++++ b/.bazelversion
++@@ -0,0 +1 @@
+++5.3.1
++\ No newline at end of file
++diff --git a/README.md b/README.md
++index 55bd0dc..01ef700 100644
++--- a/README.md
+++++ b/README.md
++@@ -5,11 +5,11 @@
++ This repository contains all the setup, rules and build configuration to use
++ [Bazel](http://bazel.build) with ROS2. As reccomended by Bazel, all ROS2 packages
++ are built from source. They are loaded as needed, so no a priori loading or manual version
++-management of ROS2 repos is required.
+++management of ROS2 repos (e.g. via vcs tool) is required.
++ 
++ The neccessary BUILD files for ROS2 repos are injected while loading. In case bazel will
++-gain some traction within the ROS community, Bazel BUILD files can also be provided directly
++-by the ROS2 repositories.
+++gain some traction within the ROS community, Bazel BUILD files should ideally be provided
+++directly by the ROS2 repositories.
++ 
++ Specific rules for message generation and packaging are provided in this repository (see 
++ [rosidl/defs.bzl](rosidl/defs.bzl) and [pkg/defs.bzl](pkg/defs.bzl)).
++@@ -22,51 +22,110 @@ Here is a short list of major restrictions:
++   will not be supported in the foreseeable future.
++ * Only ROS2 humble supported. Other distros may work after extending
++   `@rules_ros//repos/config/defs.bzl` accordingly.
++-* Message generation is still incomplete. Therefore even the simples examples will not compile
++-  fully yet.
+++* Message generation is still incomplete. Therefore even the simplest examples will not run
+++  due to not yet bazelized middleware.
++ * Not all packages have been bazelized yet. Main focus currently lies on generating an
++-  install space and providing message generation support.
++-* The addition of custom packages into the repo setup is not yet available. Same applies to
++-  adding additional python packages. This will be added soon.
+++  install space and providing message generation support. From the `ros2cli` only the `run`
+++  command is currently bazelized.
+++* The streamlined integration of custom packages into the repo setup is not yet available.
+++  Same applies to adding additional python packages. 
+++  This will be added soon.
++ 
++ ## Getting started
++ 
++-### Workspace setup
++-
++-To import rules_ros in your project, add the following code snippet to your WORKSPACE file:
++-
++-```python
++-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++-
++-RULES_ROS_VERSION = "xxx" # TODO: where to find the right version
++-RUIES_ROS_SHA = "xxx"
++-
++-https_archive(
++-    name = "rules_ros",
++-    sha256 = RUIES_ROS_SHA,
++-    strip_prefix = "xxx",
++-    url = "https://github.com/ApexAI/rules_ros/archive/{}.zip".format(RULES_ROS_VERSION),
++-)
++-
++-load("@rules_ros//repos/config:defs.bzl", "configure_ros2")
++-configure_ros2(distro = "humble") # currently only humble is supported
++-
++-load("@ros2_config//:setup.bzl", "setup")
++-setup()
+++### Prerequisits
+++Bazel needs to be available. We reccomend using [bazelisk](https://github.com/bazelbuild/bazelisk)
+++as a launch tool for bazel.
++ 
++-load("@rules_ros//thirdparty:setup_01.bzl", "setup_01")
++-setup_01()
++-
++-load("@rules_ros//thirdparty:setup_02.bzl", "setup_02")
++-setup_02()
+++### Workspace setup
+++Create an empty folder and add the following files to it:
+++* `WORKSPACE` file:
+++  ```python
+++  workspace(name = "my_first_bazel_ros_workspace") # choose your workspace name here
+++  # load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+++  load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+++
+++  RULES_ROS_VERSION = "xxx" # TODO: where to find the right version
+++  RUIES_ROS_SHA = "xxx"
+++
+++  # until we have a first release, please use this:
+++  git_repository(
+++      name = "rules_ros",
+++      remote = "https://github.com/ApexAI/rules_ros.git",
+++      branch = "main",
+++  )
+++
+++  # after the first release, switch to this dependency 
+++  #https_archive(
+++  #    name = "rules_ros",
+++  #    sha256 = RULES_ROS_SHA,
+++  #    strip_prefix = "xxx",
+++  #    url = "https://github.com/ApexAI/rules_ros/archive/{}.zip".format(RULES_ROS_VERSION),
+++  #)
+++
+++  load("@rules_ros//repos/config:defs.bzl", "configure_ros2")
+++  configure_ros2(distro = "humble") # currently only humble is supported
+++
+++  load("@ros2_config//:setup.bzl", "setup")
+++  setup()
+++
+++  load("@rules_ros//thirdparty:setup_01.bzl", "setup_01")
+++  setup_01()
+++
+++  load("@rules_ros//thirdparty:setup_02.bzl", "setup_02")
+++  setup_02()
+++
+++  load("@rules_ros//thirdparty:setup_03.bzl", "setup_03")
+++  setup_03()
+++
+++  load("@rules_ros//thirdparty:setup_04.bzl", "setup_04")
+++  setup_04()
+++  ```
+++* `.bazelrc` file:
+++  ```bash
+++  # enable incompatible python init mode
+++  build --incompatible_default_to_explicit_init_py
+++
+++  # enable implementation_deps on cc_library targets
+++  build --experimental_cc_implementation_deps
+++
+++  # set c++14 for all builds
+++  build --cxxopt="-std=c++17"
+++  build --host_cxxopt="-std=c++17"
+++  ```
+++  
+++* `.bazelversion` file (in case you are using bazelisk):
+++  ```text
+++  5.3.1
+++  ```
+++
+++### Run bazel example
+++To **build** an example delivered in the `rules_ros` repository run e.g.
+++```bash
+++bazel build @rules_ros//examples/hello_world
+++```
+++from anywhere within your workspace.
++ 
++-load("@rules_ros//thirdparty:setup_03.bzl", "setup_03")
++-setup_03()
+++**Executing** the example can be done by calling
+++```bash
+++bazel run @rules_ros//examples/hello_world
+++```
+++Note that no sourcing is necessary. Bazel will take care of all the dependencies. 
++ 
++-load("@rules_ros//thirdparty:setup_04.bzl", "setup_04")
++-setup_04()
+++**Deploying** a package archive to an install folder can be done by
+++```bash
+++bazel run @rules_ros//examples:rules_ros_examples.install <install_folder>
+++```
+++Now we are back to working with ROS as usual. Source the package as usual:
+++```bash
+++source <install_folder>/setup.bash
+++```
+++and run an executable with
+++```bash
+++ros2 run hello_world hello_world
++ ```
++ 
+++## Features
++ ### Python Interpreter
++ 
++ In this setup a hermetic python interpreter is included. The version is specified in 
++@@ -77,7 +136,7 @@ you must run
++ bazel run @rules_ros//thirdparty/python:requirements_lock.update
++ ```
++ to pin specific versions of the dependencies. In the future there will be a possibility to
++-inject any customization in the WORKSPACE file.
+++inject a customization in the WORKSPACE file.
++ 
++ ### ROS2 Repositories
++ 
++diff --git a/WORKSPACE b/WORKSPACE
++index 6a5bbcf..a9159b5 100644
++--- a/WORKSPACE
+++++ b/WORKSPACE
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ workspace(name = "rules_ros")
++ 
++ load("//repos/config:defs.bzl", "configure_ros2")
++diff --git a/examples/BUILD.bazel b/examples/BUILD.bazel
++new file mode 100644
++index 0000000..d633e88
++--- /dev/null
+++++ b/examples/BUILD.bazel
++@@ -0,0 +1,27 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++load("@rules_ros//pkg:defs.bzl", "ros_archive", "ros_pkg_set")
+++
+++ros_pkg_set(
+++    name = "rules_ros_examples_pkgs",
+++    deps = [
+++        "//examples/hello_world:hello_world_pkg",
+++        "@ros2.ros2cli//ros2cli",
+++    ],
+++)
+++
+++ros_archive(
+++    name = "rules_ros_examples",
+++    ros_pkgs = [":rules_ros_examples_pkgs"],
+++)
++diff --git a/examples/bazel_simple_example/BUILD b/examples/bazel_simple_example/BUILD
++new file mode 100644
++index 0000000..ddf0dd1
++--- /dev/null
+++++ b/examples/bazel_simple_example/BUILD
++@@ -0,0 +1,47 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++load("@rules_ros//pkg:defs.bzl", "ros_pkg")
+++
+++cc_binary(
+++    name = "publisher",
+++    srcs = ["publisher.cpp"],
+++    deps = [
+++        "@ros2.common_interfaces//std_msgs",
+++        "@ros2.rclcpp//rclcpp",
+++    ],
+++)
+++
+++cc_binary(
+++    name = "subscriber",
+++    srcs = ["subscriber.cpp"],
+++    deps = [
+++        "@ros2.common_interfaces//std_msgs",
+++        "@ros2.rclcpp//rclcpp",
+++    ],
+++)
+++
+++ros_pkg(
+++    name = "bazel_simple_example_pkg",
+++    description = "Simple pub/sub example",
+++    lib_executables = [
+++        "publisher",
+++        "subscriber",
+++    ],
+++    license = "Apex.AI License",
+++    maintainer_email = "kilian.funk@apex.ai",
+++    maintainer_name = "Kilian Funk",
+++    pkg_name = "bazel_simple_example",
+++    version = "1.0.0",
+++    visibility = ["//visibility:public"],
+++)
++diff --git a/examples/bazel_simple_example/publisher.cpp b/examples/bazel_simple_example/publisher.cpp
++new file mode 100644
++index 0000000..5973bcf
++--- /dev/null
+++++ b/examples/bazel_simple_example/publisher.cpp
++@@ -0,0 +1,58 @@
+++// Copyright 2022 Apex.AI, Inc.
+++//
+++// Licensed under the Apache License, Version 2.0 (the "License");
+++// you may not use this file except in compliance with the License.
+++// You may obtain a copy of the License at
+++//
+++//     http://www.apache.org/licenses/LICENSE-2.0
+++//
+++// Unless required by applicable law or agreed to in writing, software
+++// distributed under the License is distributed on an "AS IS" BASIS,
+++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++// See the License for the specific language governing permissions and
+++// limitations under the License.
+++
+++#include <rclcpp/duration.hpp>
+++#include <rclcpp/node.hpp>
+++
+++#include <iostream>
+++
+++#include <chrono>
+++#include <functional>
+++#include <memory>
+++#include <string>
+++
+++#include "rclcpp/rclcpp.hpp"
+++#include "std_msgs/msg/string.hpp"
+++
+++using namespace std::chrono_literals;
+++
+++/* This example creates a subclass of Node and uses std::bind() to register a
+++ * member function as a callback from the timer. */
+++
+++class MinimalPublisher : public rclcpp::Node {
+++public:
+++  MinimalPublisher() : Node("minimal_publisher"), count_(0) {
+++    publisher_ = this->create_publisher<std_msgs::msg::String>("topic", 10);
+++    timer_ = this->create_wall_timer(
+++        500ms, std::bind(&MinimalPublisher::timer_callback, this));
+++  }
+++
+++private:
+++  void timer_callback() {
+++    auto message = std_msgs::msg::String();
+++    message.data = "Hello, world! " + std::to_string(count_++);
+++    RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", message.data.c_str());
+++    publisher_->publish(message);
+++  }
+++  rclcpp::TimerBase::SharedPtr timer_;
+++  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_;
+++  size_t count_;
+++};
+++
+++int main(int argc, char *argv[]) {
+++  rclcpp::init(argc, argv);
+++  rclcpp::spin(std::make_shared<MinimalPublisher>());
+++  rclcpp::shutdown();
+++  return 0;
+++}
++diff --git a/examples/bazel_simple_example/subscriber.cpp b/examples/bazel_simple_example/subscriber.cpp
++new file mode 100644
++index 0000000..916725e
++--- /dev/null
+++++ b/examples/bazel_simple_example/subscriber.cpp
++@@ -0,0 +1,40 @@
+++// Copyright 2022 Apex.AI, Inc.
+++//
+++// Licensed under the Apache License, Version 2.0 (the "License");
+++// you may not use this file except in compliance with the License.
+++// You may obtain a copy of the License at
+++//
+++//     http://www.apache.org/licenses/LICENSE-2.0
+++//
+++// Unless required by applicable law or agreed to in writing, software
+++// distributed under the License is distributed on an "AS IS" BASIS,
+++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++// See the License for the specific language governing permissions and
+++// limitations under the License.
+++
+++#include <memory>
+++
+++#include "rclcpp/rclcpp.hpp"
+++#include "std_msgs/msg/string.hpp"
+++using std::placeholders::_1;
+++
+++class MinimalSubscriber : public rclcpp::Node {
+++public:
+++  MinimalSubscriber() : Node("minimal_subscriber") {
+++    subscription_ = this->create_subscription<std_msgs::msg::String>(
+++        "topic", 10, std::bind(&MinimalSubscriber::topic_callback, this, _1));
+++  }
+++
+++private:
+++  void topic_callback(const std_msgs::msg::String::SharedPtr msg) const {
+++    RCLCPP_INFO(this->get_logger(), "I heard: '%s'", msg->data.c_str());
+++  }
+++  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_;
+++};
+++
+++int main(int argc, char *argv[]) {
+++  rclcpp::init(argc, argv);
+++  rclcpp::spin(std::make_shared<MinimalSubscriber>());
+++  rclcpp::shutdown();
+++  return 0;
+++}
++diff --git a/examples/hello_world/BUILD.bazel b/examples/hello_world/BUILD.bazel
++new file mode 100644
++index 0000000..7e57ee6
++--- /dev/null
+++++ b/examples/hello_world/BUILD.bazel
++@@ -0,0 +1,32 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_ros//pkg:defs.bzl", "ros_pkg")
+++
+++cc_binary(
+++    name = "hello_world",
+++    srcs = ["main.cpp"],
+++)
+++
+++ros_pkg(
+++    name = "hello_world_pkg",
+++    description = "A simple hello world application.",
+++    lib_executables = [":hello_world"],
+++    license = "Apache 2.0",
+++    maintainer_email = "kilian.funk@apex.ai",
+++    maintainer_name = "Kilian Funk",
+++    pkg_name = "hello_world",
+++    version = "1.0.0",
+++    visibility = ["//visibility:public"],
+++)
++\ No newline at end of file
++diff --git a/examples/simple_pkg_example/main.cpp b/examples/hello_world/main.cpp
++similarity index 100%
++rename from examples/simple_pkg_example/main.cpp
++rename to examples/hello_world/main.cpp
++diff --git a/examples/simple_pkg_example/BUILD.bazel b/examples/simple_pkg_example/BUILD.bazel
++deleted file mode 100644
++index a76b4fd..0000000
++--- a/examples/simple_pkg_example/BUILD.bazel
+++++ /dev/null
++@@ -1,17 +0,0 @@
++-load("@rules_ros//pkg:defs.bzl", "ros_pkg")
++-
++-cc_binary(
++-    name = "hello_world",
++-    srcs = ["main.cpp"],
++-)
++-
++-ros_pkg(
++-    name = "simple_pkg_example",
++-    pkg_name = "simple_pkg_example",
++-    description = "A simple hello word application.",
++-    version = "1.0.0",
++-    maintainer_name = "Kilian Funk",
++-    maintainer_email = "kilian.funk@apex.ai",
++-    license = "Apache 2.0",
++-    lib_executables = [":hello_world"],
++-)
++diff --git a/pkg/defs.bzl b/pkg/defs.bzl
++index 3e9895c..3cdf278 100644
++--- a/pkg/defs.bzl
+++++ b/pkg/defs.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_pkg//pkg:tar.bzl", _pkg_tar = "pkg_tar")
++ load(
++     "@rules_ros//pkg/detail:ros_pkg.bzl",
++diff --git a/pkg/detail/BUILD b/pkg/detail/BUILD
++index 729eda7..6eae5f9 100644
++--- a/pkg/detail/BUILD
+++++ b/pkg/detail/BUILD
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_python//python:defs.bzl", "py_binary")
++ load("@python_deps//:requirements.bzl", "requirement")
++ 
++diff --git a/pkg/detail/executable_wrapper_generator.py b/pkg/detail/executable_wrapper_generator.py
++index 7ad4f44..fb8da57 100644
++--- a/pkg/detail/executable_wrapper_generator.py
+++++ b/pkg/detail/executable_wrapper_generator.py
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ import argparse
++ 
++ TEMPLATE = """#!/bin/bash
++diff --git a/pkg/detail/package_xml_generator.py b/pkg/detail/package_xml_generator.py
++index ecbc379..582811a 100644
++--- a/pkg/detail/package_xml_generator.py
+++++ b/pkg/detail/package_xml_generator.py
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ import argparse
++ from jinja2 import Environment
++ 
++diff --git a/pkg/detail/ros_archive.bzl b/pkg/detail/ros_archive.bzl
++index 1adcffc..a233b61 100644
++--- a/pkg/detail/ros_archive.bzl
+++++ b/pkg/detail/ros_archive.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_pkg//:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
++ load(
++     ":utils.bzl",
++diff --git a/pkg/detail/ros_pkg.bzl b/pkg/detail/ros_pkg.bzl
++index 18e21b7..b9fd094 100644
++--- a/pkg/detail/ros_pkg.bzl
+++++ b/pkg/detail/ros_pkg.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_pkg//:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
++ load("@rules_python//python:packaging.bzl", "PyWheelInfo")
++ load(
++diff --git a/pkg/detail/setup_bash_generator.py b/pkg/detail/setup_bash_generator.py
++index 9cfdc49..c307426 100644
++--- a/pkg/detail/setup_bash_generator.py
+++++ b/pkg/detail/setup_bash_generator.py
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ import argparse
++ 
++ TEMPLATE = """# !/usr/bash
++diff --git a/pkg/detail/templates/install.template b/pkg/detail/templates/install.template
++index 2c8ee10..e221047 100644
++--- a/pkg/detail/templates/install.template
+++++ b/pkg/detail/templates/install.template
++@@ -1,6 +1,20 @@
++ #! /bin/bash
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
++ 
++ ARCHIVE={{file}}
+++PREFIX=$1/{{name}}
++ 
++ if [ $# -ne 1 ]; then
++     echo "Please specify an install folder" && exit 1
++@@ -8,14 +22,18 @@ fi
++ echo "Install dir: $1"
++ mkdir -p $1
++ 
++-pwd
+++if ls $PREFIX 2> /dev/null >/dev/null; then
+++  echo "Removing old installation."
+++  rm -rf $PREFIX
+++fi
++ 
++ echo "Installing $ARCHIVE"
++ tar -xf $ARCHIVE --directory=$1
++ 
++-PREFIX=$1/{{name}}
++ 
++ if command -v pip > /dev/null; then
++-    echo "Installing Python wheels to $PREFIX"
++-    pip install --prefix $PREFIX $PREFIX/share/*/*.whl
+++    if ls $PREFIX/share/*/*.whl 2> /dev/null >/dev/null; then
+++        echo "Installing Python wheels to $PREFIX"
+++        pip install --prefix $PREFIX --no-warn-script-location $PREFIX/share/*/*.whl
+++    fi
++ fi
++diff --git a/pkg/detail/utils.bzl b/pkg/detail/utils.bzl
++index 353decb..6b91573 100644
++--- a/pkg/detail/utils.bzl
+++++ b/pkg/detail/utils.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_pkg//:providers.bzl", _PackageFilegroupInfo = "PackageFilegroupInfo")
++ load("@rules_ros//pkg:providers.bzl", _RosPkgInfo = "RosPkgInfo")
++ 
++diff --git a/pkg/providers.bzl b/pkg/providers.bzl
++index 33fba0a..63b54e7 100644
++--- a/pkg/providers.bzl
+++++ b/pkg/providers.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ RosPkgInfo = provider(
++     fields = [
++         "name",
++diff --git a/repos/ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel b/repos/ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel
++new file mode 100644
++index 0000000..ac752eb
++--- /dev/null
+++++ b/repos/ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel
++@@ -0,0 +1,23 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++cc_library(
+++    name = "ament_index_cpp",
+++    srcs = glob(["src/*"]),
+++    hdrs = glob(["include/**/*"]),
+++    strip_include_prefix = "include",
+++    visibility = ["//visibility:public"],
+++    deps = [
+++    ],
+++)
++diff --git a/repos/ament.ament_index.BUILD/ament_index_python.BUILD.bazel b/repos/ament.ament_index.BUILD/ament_index_python.BUILD.bazel
++new file mode 100644
++index 0000000..e0f23cf
++--- /dev/null
+++++ b/repos/ament.ament_index.BUILD/ament_index_python.BUILD.bazel
++@@ -0,0 +1,81 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_python//python:packaging.bzl", "py_wheel")
+++load("@rules_python//python:python.bzl", "py_test")
+++load("@rules_ros//pkg:defs.bzl", "ros_pkg")
+++
+++py_library(
+++    name = "ament_index_python_py",
+++    srcs = glob(["ament_index_python/**/*.py"]),
+++)
+++
+++py_test(
+++    name = "ament_index_python_py_test",
+++    srcs = ["test/test_ament_index_python.py"],
+++    imports = ["."],
+++    main = "test/test_ament_index_python.py",
+++    deps = [
+++        ":ament_index_python_py",
+++    ],
+++)
+++
+++py_wheel(
+++    name = "ament_index_python_whl",
+++    # packages=find_packages(exclude=['test']),
+++    # data_files=[
+++    #     ('share/' + package_name, ['package.xml']),
+++    #     ('share/ament_index/resource_index/packages',
+++    #         ['resource/' + package_name]),
+++    # ],
+++    # install_requires=['ros2cli'],
+++    # zip_safe=True,
+++    author = "Dirk Thomas",
+++    author_email = "dthomas@osrfoundation.org",
+++    # maintainer='Dirk Thomas',
+++    # maintainer_email='dthomas@osrfoundation.org',
+++    # url='https://github.com/ros2/ros2cli/tree/master/ros2run',
+++    # download_url='https://github.com/ros2/ros2cli/releases',
+++    # keywords=[],
+++    classifiers = [
+++        'Intended Audience :: Developers',
+++        'License :: OSI Approved :: Apache Software License',
+++        'Programming Language :: Python',
+++        'Topic :: Software Development',
+++    ],
+++    #description_file = "README.md",
+++    distribution = "ament_index_python",
+++    #tests_require=['pytest'],
+++    license = "Apache License, Version 2.0",
+++    strip_path_prefixes = ["ament_index_python"],
+++    version = '0.8.6',
+++    deps = [":ament_index_python_py"],
+++    entry_points = {
+++        'console_scripts': [
+++            'ament_index = ament_index_python.cli:main',
+++        ],
+++    },
+++)
+++
+++ros_pkg(
+++    name = "ament_index_python",
+++    description = "Python API to access the ament resource index.",
+++    license = "Apex.AI License",
+++    maintainer_name = "Dirk Thomas",
+++    maintainer_email = "dthomas@osrfoundation.org",
+++    pkg_name = "ament_index_python",
+++    py_packages = ["ament_index_python_whl"],
+++    version = "0.7.2",
+++    visibility = ["//visibility:public"],
+++)
++diff --git a/repos/config/BUILD.bazel b/repos/config/BUILD.bazel
++index ed83d14..bb45bbf 100644
++--- a/repos/config/BUILD.bazel
+++++ b/repos/config/BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ exports_files(["ros2_humble.lock"])
++ 
++ alias(
++diff --git a/repos/config/bazel.repos b/repos/config/bazel.repos
++index e6f7dec..07350c3 100644
++--- a/repos/config/bazel.repos
+++++ b/repos/config/bazel.repos
++@@ -1,8 +1,10 @@
++ repositories:
++ #  ament/ament_cmake:
++ #    bazel: {}
++-#  ament/ament_index:
++-#    bazel: {}
+++  ament/ament_index:
+++    bazel:
+++      "@rules_ros//repos:ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel": "ament_index_cpp/BUILD.bazel"
+++      "@rules_ros//repos:ament.ament_index.BUILD/ament_index_python.BUILD.bazel": "ament_index_python/BUILD.bazel"
++ #  ament/ament_lint:
++ #    bazel: {}
++ #  ament/ament_package:
++@@ -13,16 +15,16 @@ repositories:
++ #    bazel: {}
++ #  ament/uncrustify_vendor:
++ #    bazel: {}
++-#  eProsima/Fast-CDR:
++-#    bazel: {}
++-#  eProsima/Fast-DDS:
++-#    bazel: {}
++-#  eProsima/foonathan_memory_vendor:
++-#    bazel: {}
++-#  eclipse-cyclonedds/cyclonedds:
++-#    bazel: {}
++-#  eclipse-iceoryx/iceoryx:
++-#    bazel: {}
+++  eProsima/Fast-CDR:
+++    bazel: {}
+++  eProsima/Fast-DDS:
+++    bazel: {}
+++  eProsima/foonathan_memory_vendor:
+++    bazel: {}
+++  eclipse-cyclonedds/cyclonedds:
+++    bazel: {}
+++  eclipse-iceoryx/iceoryx:
+++    bazel: {}
++ #  ignition/ignition_cmake2_vendor:
++ #    bazel: {}
++ #  ignition/ignition_math6_vendor:
++@@ -39,8 +41,9 @@ repositories:
++ #    bazel: {}
++ #  ros-tooling/keyboard_handler:
++ #    bazel: {}
++-#  ros-tooling/libstatistics_collector:
++-#    bazel: {}
+++  ros-tooling/libstatistics_collector:
+++    bazel:
+++      "@rules_ros//repos:ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel": "BUILD.bazel"
++ #  ros-visualization/interactive_markers:
++ #    bazel: {}
++ #  ros-visualization/python_qt_binding:
++@@ -97,8 +100,9 @@ repositories:
++ #    bazel: {}
++ #  ros2/ament_cmake_ros:
++ #    bazel: {}
++-#  ros2/common_interfaces:
++-#    bazel: {}
+++  ros2/common_interfaces:
+++    bazel:
+++      "@rules_ros//repos:ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel": "std_msgs/BUILD.bazel"
++ #  ros2/console_bridge_vendor:
++ #    bazel: {}
++ #  ros2/demos:
++@@ -136,18 +140,21 @@ repositories:
++   ros2/rcl_interfaces:
++     bazel:
++       "@rules_ros//repos:ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel": "rcl_interfaces/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel": "rosgraph_msgs/BUILD.bazel"
++       "@rules_ros//repos:ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel": "builtin_interfaces/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel": "statistics_msgs/BUILD.bazel"
++   ros2/rcl_logging:
++     bazel:
++       "@rules_ros//repos:ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel": "rcl_logging_interface/BUILD.bazel"
++   ros2/rclcpp:
++     bazel:
+++      "@rules_ros//repos:ros2.rclcpp.BUILD/build_interfaces.py": "rclcpp/build_interfaces.py"
++       "@rules_ros//repos:ros2.rclcpp.BUILD/rclcpp.BUILD.bazel": "rclcpp/BUILD.bazel"
++ #  ros2/rclpy:
++ #    bazel: {}
++   ros2/rcpputils:
++     bazel:
++-      "@rules_ros//repos:ros2.rcpputils.BUILD/rcpputils.BUILD.bazel": "rcpputils/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcpputils.BUILD/rcpputils.BUILD.bazel": "BUILD.bazel"
++   ros2/rcutils:
++     bazel:
++       "@rules_ros//repos:ros2.rcutils.BUILD/root.BUILD.bazel": "BUILD.bazel"
++@@ -170,8 +177,11 @@ repositories:
++   ros2/ros2_tracing:
++     bazel:
++         "@rules_ros//repos:ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel": "tracetools/BUILD.bazel"
++-#  ros2/ros2cli:
++-#    bazel: {}
+++  ros2/ros2cli:
+++    bazel:
+++        "@rules_ros//repos:ros2.ros2cli.BUILD/ros2cli.BUILD.bazel": "ros2cli/BUILD.bazel"
+++        "@rules_ros//repos:ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel": "ros2pkg/BUILD.bazel"
+++        "@rules_ros//repos:ros2.ros2cli.BUILD/ros2run.BUILD.bazel": "ros2run/BUILD.bazel"
++ #  ros2/ros2cli_common_extensions:
++ #    bazel: {}
++ #  ros2/ros_testing:
++@@ -181,17 +191,26 @@ repositories:
++   ros2/rosidl:
++     bazel:
++       "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel": "rosidl_runtime_c/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel": "rosidl_runtime_cpp/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel": "rosidl_adapter/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel": "rosidl_cli/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel": "rosidl_parser/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel": "rosidl_cmake/BUILD.bazel"
++       "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel": "rosidl_typesupport_interface/BUILD.bazel"
++-#  ros2/rosidl_dds:
++-#    bazel: {}
+++      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel": "rosidl_generator_c/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel": "rosidl_generator_cpp/BUILD.bazel"
+++  ros2/rosidl_dds:
+++    bazel:
+++      "@rules_ros//repos:ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel": "rosidl_generator_dds_idl/BUILD.bazel"
++ #  ros2/rosidl_defaults:
++ #    bazel: {}
++ #  ros2/rosidl_python:
++ #    bazel: {}
++ #  ros2/rosidl_runtime_py:
++ #    bazel: {}
++-#  ros2/rosidl_typesupport:
++-#    bazel: {}
+++  ros2/rosidl_typesupport:
+++    bazel:
+++      "@rules_ros//repos:ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel": "rosidl_typesupport_c/BUILD.bazel"
++ #  ros2/rosidl_typesupport_fastrtps:
++ #    bazel: {}
++ #  ros2/rpyutils:
++diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
++index 90d3706..3767bd5 100644
++--- a/repos/config/defs.bzl
+++++ b/repos/config/defs.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//repos/config/detail:ros2_config.bzl", _ros2_config = "ros2_config")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++ load("@bazel_tools//tools/build_defs/repo:git.bzl", _new_git_repository = "new_git_repository")
++diff --git a/repos/config/detail/BUILD.bazel b/repos/config/detail/BUILD.bazel
++index c008dab..9519eaf 100644
++--- a/repos/config/detail/BUILD.bazel
+++++ b/repos/config/detail/BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@ros2_config//:repos_lock_file.bzl", "REPOS_LOCK_FILE")
++ 
++ py_binary(
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index d3cee97..234de73 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -1,10 +1,25 @@
++ #! /usr/bin/env python3
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ import sys
++ import yaml
++ 
++ 
++ HEADER = """
++ load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++ 
++ def setup():
++@@ -20,6 +35,29 @@ def print_setup(repos):
++ 
++ 
++ def build_load_command(repo, spec):
+++    if spec['type'] == "git":
+++        return build_remote_load_command(repo, spec)
+++    if spec['type'] == "local":
+++        return build_local_load_command(repo, spec)
+++    else:
+++        raise ValueError(f"Unknown repo type {spec['type']}")
+++
+++
+++def build_local_load_command(repo, spec):
+++    build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
+++    return f"""
+++    print("Loading: @{repo.replace('/','.')}")
+++    _maybe(
+++        name = "{repo.replace('/','.')}",
+++        build_files = {{
+++{build_files}
+++        }},
+++        path = "{spec['path']}",
+++        repo_rule = _new_local_repository,
+++    )
+++"""
+++
+++def build_remote_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""
++     print("Loading: @{repo.replace('/','.')}")
++diff --git a/repos/config/detail/git_repository.bzl b/repos/config/detail/git_repository.bzl
++index 93a0686..2eb1e84 100644
++--- a/repos/config/detail/git_repository.bzl
+++++ b/repos/config/detail/git_repository.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "update_attrs")
++ 
++ _archive_attrs = {
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index 1e776cf..1feaf77 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -1,4 +1,18 @@
++ #! /usr/bin/env python3
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ 
++ import argparse
++ import tempfile
++diff --git a/repos/config/detail/new_local_repository.bzl b/repos/config/detail/new_local_repository.bzl
++new file mode 100644
++index 0000000..3ccb254
++--- /dev/null
+++++ b/repos/config/detail/new_local_repository.bzl
++@@ -0,0 +1,77 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", "update_attrs")
+++
+++_archive_attrs = {
+++    "path": attr.string(
+++        doc = "Path to the repository.",
+++    ),
+++    "build_files": attr.label_keyed_string_dict(
+++        doc =
+++            "Same as in native rule.",
+++    ),
+++}
+++
+++def _execute_or_fail(ctx, args, **kwargs):
+++    result = ctx.execute(args, **kwargs)
+++    if result.return_code != 0:
+++        fail(result.stderr)
+++    return result
+++
+++def _file_exists(ctx, file_name):
+++    exec_result = ctx.execute(["ls", file_name])
+++    if exec_result.return_code != 0:
+++        return False
+++    return True
+++
+++def _workspace_and_buildfiles(ctx):
+++    if not _file_exists(ctx, "WORKSPACE") and not _file_exists(ctx, "WORKSPACE.bazel"):
+++        ctx.file("WORKSPACE", content = 'workspace(name = "{}")'.format(ctx.name))
+++
+++    if not _file_exists(ctx, "WORKSPACE"):
+++        ctx.symlink("WORKSPACE", "WORKSPACE.bazel")
+++
+++    for label, destinations in ctx.attr.build_files.items():
+++        if type(destinations) != type([]):
+++            destinations = [destinations]
+++            for destination in destinations:
+++                ctx.symlink(label, destination)
+++
+++def _files_in_directory(ctx, directory_path):
+++    exec_result = ctx.execute(["find", directory_path, "-maxdepth", "1", "-mindepth", "1"])
+++    if exec_result.return_code != 0:
+++        fail(exec_result.stderr)
+++
+++    return exec_result.stdout.splitlines()
+++
+++def _new_local_repository_impl(ctx):
+++    """Implementation of the git_repository rule."""
+++
+++    for f in _files_in_directory(ctx, ctx.attr.path):
+++        _execute_or_fail(ctx, ["cp", "-r", f, f.rpartition("/")[2]])
+++
+++    _workspace_and_buildfiles(ctx)
+++
+++    return update_attrs(ctx.attr, _archive_attrs.keys(), {})
+++
+++new_local_repository = repository_rule(
+++    implementation = _new_local_repository_impl,
+++    attrs = _archive_attrs,
+++    doc =
+++        """Custom rule to clone a git repo as external dependency.
+++        It allows to inject multiple BUILD files.
+++        """,
+++)
+++
++diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
++index 72b0ed0..aff3153 100644
++--- a/repos/config/detail/ros2_config.bzl
+++++ b/repos/config/detail/ros2_config.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "update_attrs")
++ 
++ BUILD_FILE_CONTENT = """
++diff --git a/repos/ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel b/repos/ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel
++new file mode 100644
++index 0000000..f0fded9
++--- /dev/null
+++++ b/repos/ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel
++@@ -0,0 +1,34 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@bazel_skylib//rules:expand_template.bzl","expand_template")
+++
+++cc_library(
+++    name = "libstatistics_collector",
+++    srcs = glob([
+++        "src/**/*.c",
+++        "src/**/*.cpp",
+++    ]),
+++    hdrs = glob([
+++        "include/**/*.h",
+++        "include/**/*.hpp",
+++    ]),
+++    strip_include_prefix = "include",
+++    deps = [
+++        "@ros2.rcl_interfaces//builtin_interfaces",
+++        "@ros2.rcpputils//:rcpputils",
+++        "@ros2.rcl_interfaces//statistics_msgs",
+++    ],
+++    visibility = ["//visibility:public"],
+++)
++diff --git a/repos/ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel b/repos/ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel
++new file mode 100644
++index 0000000..ad53120
++--- /dev/null
+++++ b/repos/ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel
++@@ -0,0 +1,29 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_ros//rosidl:defs.bzl", "msgs_library")
+++
+++msgs_library(
+++    name = "std_msgs",
+++    srcs = glob([
+++        "msg/*.idl",
+++        "msg/*.msg",
+++        "srv/*.srv",
+++    ]),
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        "@ros2.rcl_interfaces//builtin_interfaces",
+++    ],
+++)
+++
++diff --git a/repos/ros2.rcl.BUILD/rcl.BUILD.bazel b/repos/ros2.rcl.BUILD/rcl.BUILD.bazel
++index 9497916..1f26109 100644
++--- a/repos/ros2.rcl.BUILD/rcl.BUILD.bazel
+++++ b/repos/ros2.rcl.BUILD/rcl.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ cc_library(
++     name = "rcl",
++     srcs = glob([
++diff --git a/repos/ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel b/repos/ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel
++index d208ed8..9af8973 100644
++--- a/repos/ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel
+++++ b/repos/ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ cc_library(
++     name = "rcl_yaml_param_parser",
++     srcs = glob(["src/**/*.c"]),
++diff --git a/repos/ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel b/repos/ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel
++index d24f5ef..262cf35 100644
++--- a/repos/ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel
+++++ b/repos/ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel
++@@ -1,13 +1,25 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//rosidl:defs.bzl", "msgs_library")
++ 
++ msgs_library(
++-    name = "rcl_interfaces",
+++    name = "builtin_interfaces",
++     srcs = glob([
+++        "msg/*.msg",
++         "msg/*.idl",
++         "srv/*.srv",
++     ]),
++     visibility = ["//visibility:public"],
++-    deps = [
++-        "//builtin_interfaces",
++-    ],
++ )
++diff --git a/repos/ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel b/repos/ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel
++index d24f5ef..f50a7fd 100644
++--- a/repos/ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel
+++++ b/repos/ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel
++@@ -1,8 +1,23 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//rosidl:defs.bzl", "msgs_library")
++ 
++ msgs_library(
++     name = "rcl_interfaces",
++     srcs = glob([
+++        "msg/*.msg",
++         "msg/*.idl",
++         "srv/*.srv",
++     ]),
++diff --git a/repos/ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel b/repos/ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel
++new file mode 100644
++index 0000000..45dfb89
++--- /dev/null
+++++ b/repos/ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel
++@@ -0,0 +1,28 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_ros//rosidl:defs.bzl", "msgs_library")
+++
+++msgs_library(
+++    name = "rosgraph_msgs",
+++    srcs = glob([
+++        "msg/*.msg",
+++        "msg/*.idl",
+++        "srv/*.srv",
+++    ]),
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        "//builtin_interfaces",
+++    ],
+++)
++diff --git a/repos/ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel b/repos/ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel
++new file mode 100644
++index 0000000..ac4a660
++--- /dev/null
+++++ b/repos/ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel
++@@ -0,0 +1,28 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_ros//rosidl:defs.bzl", "msgs_library")
+++
+++msgs_library(
+++    name = "statistics_msgs",
+++    srcs = glob([
+++        "msg/*.msg",
+++        "msg/*.idl",
+++        "srv/*.srv",
+++    ]),
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        "//builtin_interfaces",
+++    ],
+++)
++diff --git a/repos/ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel b/repos/ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel
++index 2c307f5..598fcbc 100644
++--- a/repos/ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel
+++++ b/repos/ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ cc_library(
++     name = "rcl_logging_interface",
++     srcs = glob(["src/**/*.c"]),
++diff --git a/repos/ros2.rclcpp.BUILD/build_interfaces.py b/repos/ros2.rclcpp.BUILD/build_interfaces.py
++new file mode 100644
++index 0000000..f84ec87
++--- /dev/null
+++++ b/repos/ros2.rclcpp.BUILD/build_interfaces.py
++@@ -0,0 +1,37 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++import em
+++import argparse
+++
+++if __name__ == "__main__":
+++    # execute only if run as a script
+++    parser = argparse.ArgumentParser()
+++    parser.add_argument("file_out", help="File to be generated")
+++    parser.add_argument("file_template", help="Template for the file to be filled")
+++    parser.add_argument("-D", help="Define")
+++    args = parser.parse_args()
+++    defines = ['-D', 'rcutils_module_path = \"\"']
+++    if "D" in vars(args):
+++        defines.extend(['-D', args.D])
+++    em.invoke((
+++        [
+++            '-o', args.file_out,
+++            # We don't need to populate rcutils_module_path as we already have rcutils imported, so
+++            # it will be found within the .em script. This parameter we pass (as empty) for legacy
+++            # reasons only to avoid changing the .em file.
+++            *defines,
+++            args.file_template
+++        ]
+++    ))
++diff --git a/repos/ros2.rclcpp.BUILD/rclcpp.BUILD.bazel b/repos/ros2.rclcpp.BUILD/rclcpp.BUILD.bazel
++index 1c43f3d..3ff99d2 100644
++--- a/repos/ros2.rclcpp.BUILD/rclcpp.BUILD.bazel
+++++ b/repos/ros2.rclcpp.BUILD/rclcpp.BUILD.bazel
++@@ -1,11 +1,82 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_ros//utils:template_expansion.bzl", "cc_library_from_template")
+++load("@python_deps//:requirements.bzl", "requirement")
+++
++ cc_library(
++     name = "rclcpp",
++     srcs = glob(["src/**/*.cpp", "src/**/*.hpp"]),
++     hdrs = glob(["include/**/*.hpp"]),
++     strip_include_prefix = "include",
++     deps = [
+++        "@ament.ament_index//ament_index_cpp",
++         "@ros2.rcl//rcl",
++-        "@ros2.rcpputils//rcpputils",
+++        "@ros2.rmw//rmw",
+++        "@ros2.rcpputils//:rcpputils",
+++        "@ros2.rcl_interfaces//rosgraph_msgs",
+++        "@ros-tooling.libstatistics_collector//:libstatistics_collector",
+++        ":logging",
+++        ":get_interfaces",
+++        ":interface_traits",
++     ],
++     visibility = ["//visibility:public"],
++-)
++\ No newline at end of file
+++)
+++
+++cc_library_from_template(
+++    name = "logging",
+++    generator_script = "@ros2.rcutils//:build_logging_macros",
+++    template = "resource/logging.hpp.em",
+++    package_name = "rclcpp"
+++)
+++
+++NODE_INTERFACES = [
+++    "node_base",
+++    "node_clock",
+++    "node_graph",
+++    "node_logging",
+++    "node_parameters",
+++    "node_services",
+++    "node_time_source",
+++    "node_timers",
+++    "node_topics",
+++    "node_waitables",
+++]
+++
+++cc_library_from_template(
+++    name = "get_interfaces",
+++    generator_script = ":build_interfaces",
+++    template = "resource/get_interface.hpp.em",
+++    output_pattern = "node_interfaces/get_{interface_name}.hpp",
+++    package_name = "rclcpp",
+++    variables = {"interface_name": [interface + "_interface" for interface in NODE_INTERFACES]},
+++)
+++
+++cc_library_from_template(
+++    name = "interface_traits",
+++    generator_script = ":build_interfaces",
+++    template = "resource/interface_traits.hpp.em",
+++    output_pattern = "node_interfaces/{interface_name}_traits.hpp",
+++    package_name = "rclcpp",
+++    variables = {"interface_name": [interface + "_interface" for interface in NODE_INTERFACES]},
+++)
+++
+++
+++py_binary(
+++    name = "build_interfaces",
+++    srcs = ["build_interfaces.py"],
+++    deps = [
+++        requirement("empy"),
+++    ],
+++)
++diff --git a/repos/ros2.rcpputils.BUILD/rcpputils.BUILD.bazel b/repos/ros2.rcpputils.BUILD/rcpputils.BUILD.bazel
++index dedfb99..6f5d3fe 100644
++--- a/repos/ros2.rcpputils.BUILD/rcpputils.BUILD.bazel
+++++ b/repos/ros2.rcpputils.BUILD/rcpputils.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ cc_library(
++     name = "rcpputils",
++     srcs = glob(["src/**/*.c"]),
++diff --git a/repos/ros2.rcutils.BUILD/build_logging_macros.py b/repos/ros2.rcutils.BUILD/build_logging_macros.py
++index 88cfa6d..76e3e1b 100644
++--- a/repos/ros2.rcutils.BUILD/build_logging_macros.py
+++++ b/repos/ros2.rcutils.BUILD/build_logging_macros.py
++@@ -1,5 +1,16 @@
++-# Copyright 2021 Apex.AI, Inc.
++-# All rights reserved.
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
++ 
++ import em
++ import argparse
++diff --git a/repos/ros2.rcutils.BUILD/root.BUILD.bazel b/repos/ros2.rcutils.BUILD/root.BUILD.bazel
++index 122a0a2..02122b2 100644
++--- a/repos/ros2.rcutils.BUILD/root.BUILD.bazel
+++++ b/repos/ros2.rcutils.BUILD/root.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//utils:template_expansion.bzl", "cc_library_from_template")
++ load("@python_deps//:requirements.bzl", "requirement")
++ 
++diff --git a/repos/ros2.rmw.BUILD/rmw.BUILD.bazel b/repos/ros2.rmw.BUILD/rmw.BUILD.bazel
++index e10e3f5..07bf9c2 100644
++--- a/repos/ros2.rmw.BUILD/rmw.BUILD.bazel
+++++ b/repos/ros2.rmw.BUILD/rmw.BUILD.bazel
++@@ -1,7 +1,24 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ cc_library(
++     name = "rmw",
++     srcs = glob(["src/**/*.c"]),
++-    hdrs = glob(["include/**/*.h"]),
+++    hdrs = glob([
+++        "include/**/*.h",
+++        "include/**/*.hpp",
+++    ]),
++     strip_include_prefix = "include",
++     deps = ["@ros2.rcutils//:rcutils"],
++     visibility = ["//visibility:public"],
++diff --git a/repos/ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel b/repos/ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel
++index 2128a34..ea240e4 100644
++--- a/repos/ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel
+++++ b/repos/ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@bazel_skylib//rules:expand_template.bzl","expand_template")
++ 
++ cc_library(
++diff --git a/repos/ros2.ros2cli.BUILD/ros2cli.BUILD.bazel b/repos/ros2.ros2cli.BUILD/ros2cli.BUILD.bazel
++new file mode 100644
++index 0000000..19a537c
++--- /dev/null
+++++ b/repos/ros2.ros2cli.BUILD/ros2cli.BUILD.bazel
++@@ -0,0 +1,90 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_python//python:packaging.bzl", "py_wheel")
+++load("@rules_ros//pkg:defs.bzl", "ros_pkg")
+++
+++py_library(
+++    name = "ros2cli_py",
+++    srcs = glob(["ros2cli/**/*.py"]),
+++)
+++
+++py_wheel(
+++    name = "ros2cli_whl",
+++    # packages=find_packages(exclude=['test']),
+++    # data_files=[
+++    #     ('share/' + package_name, ['package.xml']),
+++    #     ('share/ament_index/resource_index/packages',
+++    #         ['resource/' + package_name]),
+++    # ],
+++    # install_requires=['ros2cli'],
+++    # zip_safe=True,
+++    author = "Dirk Thomas",
+++    author_email = "dthomas@osrfoundation.org",
+++    # maintainer='Dirk Thomas',
+++    # maintainer_email='dthomas@osrfoundation.org',
+++    # url='https://github.com/ros2/ros2cli/tree/master/ros2run',
+++    # download_url='https://github.com/ros2/ros2cli/releases',
+++    # keywords=[],
+++    classifiers = [
+++        "Environment :: Console",
+++        "Intended Audience :: Developers",
+++        "License :: OSI Approved :: Apache Software License",
+++        "Programming Language :: Python",
+++    ],
+++    #description_file = "README.md",
+++    distribution = "ros2cli",
+++    #tests_require=['pytest'],
+++    entry_points = {
+++        "ros2cli.command": [
+++            "daemon = ros2cli.command.daemon:DaemonCommand",
+++            "extension_points = ros2cli.command.extension_points:ExtensionPointsCommand",
+++            "extensions = ros2cli.command.extensions:ExtensionsCommand",
+++        ],
+++        "ros2cli.extension_point": [
+++            "ros2cli.command = ros2cli.command:CommandExtension",
+++            "ros2cli.daemon.verb = ros2cli.verb.daemon:VerbExtension",
+++        ],
+++        "ros2cli.daemon.verb": [
+++            "start = ros2cli.verb.daemon.start:StartVerb",
+++            "status = ros2cli.verb.daemon.status:StatusVerb",
+++            "stop = ros2cli.verb.daemon.stop:StopVerb",
+++        ],
+++        "console_scripts": [
+++            "ros2 = ros2cli.cli:main",
+++            "_ros2_daemon = ros2cli.daemon:main",
+++        ],
+++    },
+++    license = "Apache License, Version 2.0",
+++    strip_path_prefixes = ["ros2cli"],
+++    version = "0.8.6",
+++    deps = [":ros2cli_py"],
+++)
+++
+++ros_pkg(
+++    name = "ros2cli",
+++    description = "Framework for ROS 2 command line tools.",
+++    license = "Apex.AI License",
+++    maintainer_email = "dthomas@osrfoundation.org",
+++    maintainer_name = "Dirk Thomas",
+++    pkg_name = "ros2cli",
+++    py_packages = ["ros2cli_whl"],
+++    deps = [
+++        "//ros2pkg",
+++        "//ros2run",
+++        "@ament.ament_index//ament_index_python",
+++    ],
+++    version = "0.8.6",
+++    visibility = ["//visibility:public"],
+++)
++diff --git a/repos/ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel b/repos/ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel
++new file mode 100644
++index 0000000..c88b5dc
++--- /dev/null
+++++ b/repos/ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel
++@@ -0,0 +1,80 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_python//python:packaging.bzl", "py_wheel")
+++load("@rules_ros//pkg:defs.bzl", "ros_pkg")
+++
+++py_library(
+++    name = "ros2pkg_py",
+++    srcs = glob(["ros2pkg/**/*.py"]),
+++)
+++
+++py_wheel(
+++    name = "ros2pkg_whl",
+++    # packages=find_packages(exclude=['test']),
+++    # data_files=[
+++    #     ('share/' + package_name, ['package.xml']),
+++    #     ('share/ament_index/resource_index/packages',
+++    #         ['resource/' + package_name]),
+++    # ],
+++    # install_requires=['ros2cli'],
+++    # zip_safe=True,
+++    author = "Dirk Thomas",
+++    author_email = "dthomas@osrfoundation.org",
+++    # maintainer='Dirk Thomas',
+++    # maintainer_email='dthomas@osrfoundation.org',
+++    # url='https://github.com/ros2/ros2cli/tree/master/ros2run',
+++    # download_url='https://github.com/ros2/ros2cli/releases',
+++    # keywords=[],
+++    classifiers = [
+++        "Environment :: Console",
+++        "Intended Audience :: Developers",
+++        "License :: OSI Approved :: Apache Software License",
+++        "Programming Language :: Python",
+++    ],
+++    #description_file = "README.md",
+++    distribution = "ros2pkg",
+++    #tests_require=['pytest'],
+++    entry_points = {
+++        "ros2cli.command": [
+++            "pkg = ros2pkg.command.pkg:PkgCommand",
+++        ],
+++        "ros2cli.extension_point": [
+++            "ros2pkg.verb = ros2pkg.verb:VerbExtension",
+++        ],
+++        "ros2pkg.verb": [
+++            "create = ros2pkg.verb.create:CreateVerb",
+++            "executables = ros2pkg.verb.executables:ExecutablesVerb",
+++            "list = ros2pkg.verb.list:ListVerb",
+++            "prefix = ros2pkg.verb.prefix:PrefixVerb",
+++            "xml = ros2pkg.verb.xml:XmlVerb",
+++        ],
+++    },
+++    license = "Apache License, Version 2.0",
+++    strip_path_prefixes = ["ros2pkg"],
+++    version = "0.8.6",
+++    deps = [":ros2pkg_py"],
+++)
+++
+++ros_pkg(
+++    name = "ros2pkg",
+++    description = "The pkg command for ROS 2 command line tools.",
+++    license = "Apex.AI License",
+++    maintainer_email = "dthomas@osrfoundation.org",
+++    maintainer_name = "Dirk Thomas",
+++    pkg_name = "ros2pkg",
+++    py_packages = ["ros2pkg_whl"],
+++    version = "0.8.6",
+++    visibility = ["//visibility:public"],
+++)
++diff --git a/repos/ros2.ros2cli.BUILD/ros2run.BUILD.bazel b/repos/ros2.ros2cli.BUILD/ros2run.BUILD.bazel
++new file mode 100644
++index 0000000..3ce461c
++--- /dev/null
+++++ b/repos/ros2.ros2cli.BUILD/ros2run.BUILD.bazel
++@@ -0,0 +1,71 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@rules_python//python:packaging.bzl", "py_wheel")
+++load("@rules_ros//pkg:defs.bzl", "ros_pkg")
+++
+++py_library(
+++    name = "ros2run_py",
+++    srcs = glob(["ros2run/**/*.py"]),
+++)
+++
+++py_wheel(
+++    name = "ros2run_whl",
+++    # packages=find_packages(exclude=['test']),
+++    # data_files=[
+++    #     ('share/' + package_name, ['package.xml']),
+++    #     ('share/ament_index/resource_index/packages',
+++    #         ['resource/' + package_name]),
+++    # ],
+++    # install_requires=['ros2cli'],
+++    # zip_safe=True,
+++    author = "Dirk Thomas",
+++    author_email = "dthomas@osrfoundation.org",
+++    # maintainer='Dirk Thomas',
+++    # maintainer_email='dthomas@osrfoundation.org',
+++    # url='https://github.com/ros2/ros2cli/tree/master/ros2run',
+++    # download_url='https://github.com/ros2/ros2cli/releases',
+++    # keywords=[],
+++    classifiers = [
+++        "Environment :: Console",
+++        "Intended Audience :: Developers",
+++        "License :: OSI Approved :: Apache Software License",
+++        "Programming Language :: Python",
+++    ],
+++    # description_file = "README.md",
+++    distribution = "ros2run",
+++    #tests_require=['pytest'],
+++    entry_points = {
+++        "ros2cli.command": [
+++            "run = ros2run.command.run:RunCommand",
+++        ],
+++    },
+++    license = "Apache License, Version 2.0",
+++    strip_path_prefixes = ["ros2run"],
+++    version = "0.8.6",
+++    visibility = ["//visibility:public"],
+++    deps = [":ros2run_py"],
+++)
+++
+++ros_pkg(
+++    name = "ros2run",
+++    description = "The run command for ROS 2 command line tools.",
+++    license = "Apex.AI License",
+++    maintainer_email = "dthomas@osrfoundation.org",
+++    maintainer_name = "Dirk Thomas",
+++    pkg_name = "ros2run",
+++    py_packages = ["ros2run_whl"],
+++    version = "0.8.6",
+++    visibility = ["//visibility:public"],
+++)
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel
++new file mode 100644
++index 0000000..08be8d2
++--- /dev/null
+++++ b/repos/ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel
++@@ -0,0 +1,58 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@python_deps//:requirements.bzl", "requirement")
+++
+++py_library(
+++    name = "rosidl_adapter",
+++    srcs = glob([
+++        "rosidl_adapter/**/*.py",
+++        "rosidl_adapter/*.py",
+++    ]),
+++    data = glob(["rosidl_adapter/resource/*.idl.em"]),
+++    imports = ["."],
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        "//rosidl_cli",
+++        requirement("catkin_pkg"),
+++        requirement("empy"),
+++    ],
+++)
+++
+++py_binary(
+++    name = "msg2idl",
+++    srcs = ["scripts/msg2idl.py"],
+++    legacy_create_init = 0,  # required for py_binaries used on execution platform
+++    visibility = ["//visibility:public"],
+++    deps = [":rosidl_adapter"],
+++)
+++
+++py_binary(
+++    name = "srv2idl",
+++    srcs = ["scripts/srv2idl.py"],
+++    legacy_create_init = 0,  # required for py_binaries used on execution platform
+++    visibility = ["//visibility:public"],
+++    deps = [":rosidl_adapter"],
+++)
+++
+++py_test(
+++    name = "test_base_type",
+++    srcs = [
+++        "test/test_base_type.py",
+++    ],
+++    deps = [
+++        ":rosidl_adapter",
+++        requirement("pytest"),
+++    ],
+++)
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel
++new file mode 100644
++index 0000000..bc5e176
++--- /dev/null
+++++ b/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel
++@@ -0,0 +1,28 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@python_deps//:requirements.bzl", "requirement")
+++
+++py_library(
+++    name = "rosidl_cli",
+++    srcs = glob([
+++        "rosidl_cli/**/*.py",
+++        "rosidl_cli/*.py",
+++    ]),
+++    imports = ["."],
+++    visibility = ["//visibility:public"],
+++    deps = [
+++    ],
+++)
+++
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel
++new file mode 100644
++index 0000000..91550dc
++--- /dev/null
+++++ b/repos/ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel
++@@ -0,0 +1,28 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@python_deps//:requirements.bzl", "requirement")
+++
+++py_library(
+++    name = "rosidl_cmake_python",
+++    srcs = [
+++        "rosidl_cmake/__init__.py",
+++    ],
+++    imports = ["."],
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        "//rosidl_parser:rosidl_parser_python",
+++        requirement("empy"),
+++    ],
+++)
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel
++new file mode 100644
++index 0000000..61e9c7c
++--- /dev/null
+++++ b/repos/ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel
++@@ -0,0 +1,108 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+++
+++py_library(
+++    name = "rosidl_generator_c_python",
+++    srcs = [
+++        "rosidl_generator_c/__init__.py",
+++    ],
+++    imports = ["."],
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        "@ros2.rosidl//rosidl_cmake:rosidl_cmake_python",
+++        "@ros2.rosidl//rosidl_parser:rosidl_parser_python",
+++    ],
+++)
+++
+++copy_file(
+++    name = "rosidl_generator_c_with_py_extension",
+++    src = "bin/rosidl_generator_c",
+++    out = "generator.py",
+++    allow_symlink = True,
+++)
+++
+++py_binary(
+++    name = "generator",
+++    srcs = [
+++        "generator.py",
+++    ],
+++    legacy_create_init = 0,  # required for py_binaries used on execution platform
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        ":rosidl_generator_c_python",
+++    ],
+++)
+++
+++filegroup(
+++    name = "resource",
+++    srcs = glob(["resource/*.em"]),
+++    visibility = ["//visibility:public"],
+++)
+++
+++exports_files([
+++    "resource/rosidl_generator_c__visibility_control.h.in",
+++])
+++
+++# Test run (In cmake only enabled if APEX_CERT is not set)
+++# cc_msgs_library(
+++#     name = "messages",
+++#     srcs = glob(
+++#         [
+++#             "msg/*.idl",
+++#             "srv/*.srv",
+++#         ],
+++#         exclude = [
+++#             "msg/WStrings.idl",  # Exclude as cyclonedds does not support wstrings
+++#         ],
+++#     ),
+++#     visibility = ["//visibility:private"],
+++# )
+++#
+++# cc_test(
+++#     name = "test_compilation_c",
+++#     srcs = [
+++#         "test/separate_compilation.c",
+++#         "test/separate_compilation.h",
+++#         "test/test_compilation.c",
+++#     ],
+++#     linkopts = ["-ldl"],
+++#     visibility = ["//visibility:private"],
+++#     deps = [":messages"],
+++# )
+++#
+++# # Does not compile as it relies on wstring
+++# #cc_test(
+++# #    name = "test_interfaces_c",
+++# #    srcs = ["test/test_interfaces.c"],
+++# #    deps = [ ":messages" ],
+++# #    visibility = ["//visibility:private"],
+++# #)
+++#
+++# cc_test(
+++#     name = "test_invalid_initialization_c",
+++#     srcs = ["test/test_invalid_initialization.c"],
+++#     linkopts = ["-ldl"],
+++#     visibility = ["//visibility:private"],
+++#     deps = [":messages"],
+++# )
+++
+++cc_test(
+++    name = "test_strict_aliasing_c",
+++    srcs = ["test/test_strict_aliasing.c"],
+++    linkopts = ["-ldl"],
+++    visibility = ["//visibility:private"],
+++    deps = [":messages"],
+++)
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel
++new file mode 100644
++index 0000000..3e227dd
++--- /dev/null
+++++ b/repos/ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel
++@@ -0,0 +1,71 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+++# load("//apex_os/core/rosidl/rules_rosidl:defs.bzl", "cc_msgs_library")
+++
+++py_library(
+++    name = "rosidl_generator_cpp_python",
+++    srcs = [
+++        "rosidl_generator_cpp/__init__.py",
+++    ],
+++    imports = ["."],
+++    deps = [
+++        "@ros2.rosidl//rosidl_cmake:rosidl_cmake_python",
+++        "@ros2.rosidl//rosidl_parser:rosidl_parser_python",
+++    ],
+++)
+++
+++copy_file(
+++    name = "rosidl_generator_cpp_with_py_extension",
+++    src = "bin/rosidl_generator_cpp",
+++    out = "generator.py",
+++    allow_symlink = True,
+++)
+++
+++py_binary(
+++    name = "generator",
+++    srcs = [
+++        "generator.py",
+++    ],
+++    legacy_create_init = 0,  # required for py_binaries used on execution platform
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        ":rosidl_generator_cpp_python",
+++    ],
+++)
+++
+++filegroup(
+++    name = "resource",
+++    srcs = glob(["resource/*.em"]),
+++    visibility = ["//visibility:public"],
+++)
+++
+++# Test run
+++# cc_msgs_library(
+++#     name = "messages",
+++#     srcs = glob(
+++#         [
+++#             "msg/*.idl",
+++#             "srv/*.srv",
+++#         ],
+++#         exclude = [
+++#             "msg/Malformatted.idl",
+++#             "msg/UnknownTypes.idl",
+++#             "msg/WStrings.idl",  # Exclude as cyclonedds does not support wstrings
+++#             "msg/WChar.idl",  # Exclude as cyclonedds does not support wchar
+++#         ],
+++#     ),
+++#     visibility = ["//visibility:public"],
+++# )
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel
++new file mode 100644
++index 0000000..4be3ab8
++--- /dev/null
+++++ b/repos/ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel
++@@ -0,0 +1,28 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@python_deps//:requirements.bzl", "requirement")
+++
+++py_library(
+++    name = "rosidl_parser_python",
+++    srcs = glob([
+++        "rosidl_parser/*.py",
+++    ]),
+++    data = ["rosidl_parser/grammar.lark"],
+++    imports = ["."],
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        requirement("lark"),
+++    ],
+++)
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel
++index 4f1ef43..976b574 100644
++--- a/repos/ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel
+++++ b/repos/ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ cc_library(
++     name = "rosidl_runtime_c",
++     srcs = glob(["src/*.c"]),
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel
++new file mode 100644
++index 0000000..f233bfb
++--- /dev/null
+++++ b/repos/ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel
++@@ -0,0 +1,27 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++cc_library(
+++    name = "rosidl_runtime_cpp",
+++    srcs = [],
+++    hdrs = glob([
+++        "include/rosidl_runtime_cpp/*.hpp",
+++        "include/rosidl_typesupport_cpp/*.hpp",
+++    ]),
+++    strip_include_prefix = "include",
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        # "//apex_os/core/dds_typesupport",
+++    ],
+++)
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel
++index f327741..ebd7e75 100644
++--- a/repos/ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel
+++++ b/repos/ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ cc_library(
++     name = "rosidl_typesupport_interface",
++     hdrs = glob(["include/**/*.h"]),
++diff --git a/repos/ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel b/repos/ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel
++new file mode 100644
++index 0000000..2bccd36
++--- /dev/null
+++++ b/repos/ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel
++@@ -0,0 +1,54 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+++
+++py_library(
+++    name = "rosidl_generator_dds_idl_python",
+++    srcs = [
+++        "rosidl_generator_dds_idl/__init__.py",
+++    ],
+++    imports = ["."],
+++)
+++
+++copy_file(
+++    name = "rosidl_generator_dds_idl_with_py_extension",
+++    src = "bin/rosidl_generator_dds_idl",
+++    out = "generator.py",
+++    allow_symlink = True,
+++)
+++
+++filegroup(
+++    name = "resource",
+++    srcs = glob(["resource/*.em"]),
+++    visibility = ["//visibility:public"],
+++)
+++
+++py_binary(
+++    name = "generator",
+++    srcs = [
+++        "rosidl_generator_dds_idl_with_py_extension",
+++    ],
+++    data = [
+++        ":resource",
+++    ],
+++    legacy_create_init = 0,  # required for py_binaries used on execution platform
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        ":rosidl_generator_dds_idl_python",
+++        # "//apex_os/core/apex_dds/apex_middleware/apex_middleware_typefiles_generator",
+++        "@ros2.rosidl//rosidl_cmake:rosidl_cmake_python",
+++        # "//apex_os/core/rosidl/rosidl_parser:rosidl_parser_python",
+++    ],
+++)
++diff --git a/repos/ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel b/repos/ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel
++new file mode 100644
++index 0000000..064b80c
++--- /dev/null
+++++ b/repos/ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel
++@@ -0,0 +1,82 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+++
+++py_library(
+++    name = "rosidl_typesupport_c_python",
+++    srcs = [
+++        "rosidl_typesupport_c/__init__.py",
+++    ],
+++    imports = ["."],
+++    deps = [
+++        "@ros2.rosidl//rosidl_cmake:rosidl_cmake_python",
+++    ],
+++)
+++
+++copy_file(
+++    name = "rosidl_typesupport_c_with_py_extension",
+++    src = "bin/rosidl_typesupport_c",
+++    out = "generator.py",
+++    allow_symlink = True,
+++)
+++
+++py_binary(
+++    name = "generator",
+++    srcs = [
+++        ":generator.py",
+++    ],
+++    legacy_create_init = 0,  # required for py_binaries used on execution platform
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        ":rosidl_typesupport_c_python",
+++        "@ros2.rosidl//rosidl_cmake:rosidl_cmake_python",
+++        "@ros2.rosidl//rosidl_parser:rosidl_parser_python",
+++    ],
+++)
+++
+++cc_library(
+++    name = "rosidl_typesupport_c",
+++    srcs = glob([
+++        "src/*.c",
+++        "src/*.cpp",
+++        "src/*.hpp",
+++    ]),
+++    hdrs = glob([
+++        "include/rosidl_typesupport_c/*.h",
+++    ]),
+++    strip_include_prefix = "include",
+++    visibility = ["//visibility:public"],
+++    deps = [
+++        #"//apex_os/core/dds_typesupport",
+++        "@ros2.rosidl//rosidl_runtime_c",
+++        "@ros2.rcpputils//:rcpputils",
+++    ],
+++)
+++
+++filegroup(
+++    name = "config_files",
+++    srcs = glob(["resource/*.in"]),
+++    visibility = ["//visibility:public"],
+++)
+++
+++filegroup(
+++    name = "resource",
+++    srcs = glob(["resource/*.em"]),
+++    visibility = ["//visibility:public"],
+++)
+++
+++exports_files([
+++    "resource/rosidl_typesupport_c__visibility_control.h.in",
+++])
++diff --git a/rosidl/defs.bzl b/rosidl/defs.bzl
++index 94d6955..e5645f4 100644
++--- a/rosidl/defs.bzl
+++++ b/rosidl/defs.bzl
++@@ -1,2 +1,102 @@
++-def msgs_library(*, name, **kwargs):
++-    pass
++\ No newline at end of file
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":detail/rosidl_adapter.bzl", _rosidl_adapter = "rosidl_adapter")
+++load(":detail/rosidl_generator_c.bzl", _cc_rosidl_generator_c_library = "cc_rosidl_generator_c_library")
+++load(":detail/rosidl_generator_cpp.bzl", _cc_rosidl_generator_cpp_library = "cc_rosidl_generator_cpp_library")
+++load(":detail/rosidl_typesupport_c.bzl", _cc_rosidl_typesupport_c_library = "cc_rosidl_typesupport_c_library")
+++load(":detail/cc_library_with_msgs_provider.bzl", _msgs_library_with_cc ="msgs_library_with_cc")
+++
+++raw_msgs_library = _rosidl_adapter
+++
+++def msgs_library(
+++        *,
+++        name,
+++        srcs = [],
+++        deps = [],
+++        visibility = None):
+++    """ Create a library for msg/srv/idl files with all default bindings (currently C++)
+++
+++    Provides:
+++        This rule provides a `MsgsInfo` provider to be used as a dependency for other msgs_library.
+++        It also provides a `CcInfo` provider to be used as a dependency for C/C++ library with the cc toolchain.
+++
+++        This macro provides an auxilary target `{name}__raw__` which only contains the `MsgsInfo`
+++        provider without any bindings.
+++
+++    Args:
+++        name: [String] The target name
+++        srcs: [List of Labels] Idl files (of all kinds msg, srv, idl)
+++        deps: [List of Labels] Dependencies to `cc_library` or other `msgs_library`
+++        visibility: Visability label
+++    """
+++
+++    # Convert: *.msg, *.srv -> *.idl (ROS), Copy: *.idl -> *.idl (ROS)
+++    name_raw = "{}_raw".format(name)
+++    _rosidl_adapter(
+++        name = name_raw,
+++        srcs = srcs,
+++        deps = deps,
+++        visibility = visibility,
+++    )
+++
+++    # Collect generated cc_libraries
+++    cc_libs = []
+++
+++    # Library with rosidl_generator_c
+++    name_rosidl_generator_c = "{}__rosidl_generator_c".format(name)
+++    cc_libs.append(":" + name_rosidl_generator_c)
+++    _cc_rosidl_generator_c_library(
+++        name = name_rosidl_generator_c,
+++        srcs = [":" + name_raw],
+++        deps = [
+++            "@ros2.rosidl//rosidl_runtime_c",
+++        ] + deps,
+++    )
+++
+++    # Library with rosidl_generator_cpp
+++    name_rosidl_generator_cpp = "{}__rosidl_generator_cpp".format(name)
+++    cc_libs.append(":" + name_rosidl_generator_cpp)
+++    _cc_rosidl_generator_cpp_library(
+++        name = name_rosidl_generator_cpp,
+++        srcs = [":" + name_raw],
+++        deps = [
+++            "@ros2.rosidl//rosidl_runtime_cpp",
+++        ] + deps,
+++        linkstatic = True,  # No object files
+++    )
+++
+++    # Library with rosidl_typesupport_c
+++    name_rosidl_typesupport_c = "{}__rosidl_typesupport_c".format(name)
+++    cc_libs.append(":" + name_rosidl_typesupport_c)
+++    _cc_rosidl_typesupport_c_library(
+++        name = name_rosidl_typesupport_c,
+++        srcs = [":" + name_raw],
+++        typesupports = ["rmw_cyclonedds_cpp"],
+++        deps = [
+++            ":" + name_rosidl_generator_c,
+++            "@ros2.rosidl_typesupport//rosidl_typesupport_c",
+++        ] + deps,
+++    )
+++
+++
+++    _msgs_library_with_cc(
+++        name = name,
+++        deps = cc_libs + deps,
+++        msgs = ":" + name_raw,
+++        visibility = visibility,
+++    )
+++
+++
+++
++diff --git a/rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl b/rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl
++new file mode 100644
++index 0000000..163ff39
++--- /dev/null
+++++ b/rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl
++@@ -0,0 +1,45 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++def _filtered_filegroup_impl(ctx):
+++    return [DefaultInfo(
+++        files = depset([f for f in ctx.files.files_to_filter if f.extension in ctx.attr.suffixes]),
+++    )]
+++
+++_filtered_filegroup = rule(
+++    implementation = _filtered_filegroup_impl,
+++    attrs = {
+++        "files_to_filter": attr.label_list(
+++            mandatory = True,
+++            allow_files = True,
+++        ),
+++        "suffixes": attr.string_list(
+++            mandatory = True,
+++        ),
+++    },
+++)
+++
+++def cc_library_with_hdrs_extracted_from_srcs(*, name, srcs, **kwargs):
+++    _filtered_filegroup(
+++        name = "_%s_hdrs" % name,
+++        visibility = ["//visibility:private"],
+++        files_to_filter = srcs,
+++        suffixes = ["h", "hh", "hpp", "hxx", "inc", "inl", "H"],
+++    )
+++    native.cc_library(
+++        name = name,
+++        srcs = srcs,
+++        hdrs = [":_%s_hdrs" % name],
+++        **kwargs
+++    )
++diff --git a/rosidl/detail/cc_library_with_msgs_provider.bzl b/rosidl/detail/cc_library_with_msgs_provider.bzl
++new file mode 100644
++index 0000000..b59873c
++--- /dev/null
+++++ b/rosidl/detail/cc_library_with_msgs_provider.bzl
++@@ -0,0 +1,36 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":providers.bzl", "MsgsInfo")
+++
+++def _msgs_library_with_cc_impl(ctx):
+++    cc_info = cc_common.merge_cc_infos(cc_infos = [dep[CcInfo] for dep in ctx.attr.deps])
+++    msgs_info = ctx.attr.msgs[MsgsInfo]
+++    return [cc_info, msgs_info]
+++
+++msgs_library_with_cc = rule(
+++    implementation = _msgs_library_with_cc_impl,
+++    attrs = {
+++        "deps": attr.label_list(providers = [CcInfo]),
+++        "msgs": attr.label(providers = [MsgsInfo]),
+++    },
+++    fragments = ["cpp"],
+++    toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
+++    doc = """
+++       Rule that provides two providers:
+++           * a MsgsInfo provider containing all idl_srcs and transitive
+++             dependencies
+++           * a CcInfo provider including all transitive dependencies
+++    """,
+++)
++diff --git a/rosidl/detail/common_config.bzl b/rosidl/detail/common_config.bzl
++new file mode 100644
++index 0000000..e665917
++--- /dev/null
+++++ b/rosidl/detail/common_config.bzl
++@@ -0,0 +1,80 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":detail/misc_support.bzl", "get_package_name")
+++
+++def _create_common_config_internal(ctx, *, srcs, output_directory, split_position, output_file_create_func, skip_first_filepath_element = False, append_extra_package_name = False):
+++    # Step 0: Config
+++    package_name = get_package_name(ctx)
+++
+++    # Step 1: Prepare output list
+++    _outputs = []
+++    _idl_tuples = []
+++    _subdir = None
+++    for src in srcs:
+++        _src_split = src.path.split("/")
+++        _subdir = "/".join(_src_split[:-split_position])
+++        _filepath = "/".join(_src_split[-split_position + (1 if skip_first_filepath_element else 0):-1])
+++        _filename = _src_split[-1]
+++        _idl_tuples.append(_subdir + ":" + _filepath + "/" + _filename)
+++        for output_file_name in output_file_create_func(_filename):
+++            _output_temp = output_directory + "/" if output_directory else ""
+++            _outputs.append(ctx.actions.declare_file(_output_temp + _filepath + "/" + output_file_name))
+++
+++    # Step 2: Fixed set of dirnames for msg, srv
+++    _dirnames = ["msg", "srv"]
+++
+++    # Step 3: Check if any output available ... no output is an error!
+++    if not _subdir:
+++        fail("Nothing to generate.")
+++
+++    # Return result
+++    return struct(
+++        package_name = package_name,
+++        output_dir = _subdir + "/" + (package_name + "/" if append_extra_package_name else "") + output_directory if output_directory else _subdir,
+++        output_dir_relative = output_directory,
+++        output_dir_subdir = _subdir,
+++        outputs = _outputs,
+++        idl_tuples = _idl_tuples,
+++        dirnames = _dirnames,
+++    )
+++
+++def create_common_config(ctx, *, srcs, output_file_create_func):
+++    return _create_common_config_internal(
+++        ctx,
+++        srcs = srcs,
+++        output_directory = get_package_name(ctx),
+++        split_position = 2,
+++        output_file_create_func = output_file_create_func,
+++    )
+++
+++def create_common_config_for_dds_idl_generator(ctx, *, srcs, output_file_create_func):
+++    return _create_common_config_internal(
+++        ctx,
+++        srcs = srcs,
+++        output_directory = None,
+++        split_position = 2,
+++        output_file_create_func = output_file_create_func,
+++    )
+++
+++def create_common_config_for_apex_middleware_typefiles_generator(ctx, *, output_file_create_func):
+++    return _create_common_config_internal(
+++        ctx,
+++        srcs = ctx.files.srcs,
+++        output_directory = get_package_name(ctx),
+++        split_position = 4,
+++        output_file_create_func = output_file_create_func,
+++        skip_first_filepath_element = True,
+++        append_extra_package_name = True,
+++    )
++diff --git a/rosidl/detail/misc_support.bzl b/rosidl/detail/misc_support.bzl
++new file mode 100644
++index 0000000..6c93ec3
++--- /dev/null
+++++ b/rosidl/detail/misc_support.bzl
++@@ -0,0 +1,91 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++_POSSIBLE_TYPES = ["msg", "srv", "idl"]
+++
+++def get_package_name(ctx):
+++    """Get the name of the package form its rule context label."""
+++    return ctx.label.package.split("/")[-1]
+++
+++def tokenize_message(msg_path):
+++    """
+++    Split a message into its folder path, type, message name and extension.
+++
+++    Example: "blah/msg/String.idl" -> ["blah", "msg", "String", "idl"]
+++
+++    :param      msg_path:  Path to a message
+++
+++    :returns:   A tuple of path, name, extension: "blah/msg/String.idl" -> ["blah", "String", "idl"]
+++    """
+++    for type_name in _POSSIBLE_TYPES:
+++        type_with_slashes = "/{}/".format(type_name)
+++        if type_with_slashes in msg_path:
+++            local_folder_path, msg_with_extension = msg_path.split(type_with_slashes)
+++            msg_name, extension = msg_with_extension.split(".")
+++            return local_folder_path, type_name, msg_name, extension
+++    fail("Message source {} must have one of {} prefixes.".format(msg_path, _POSSIBLE_TYPES))
+++
+++def to_snake_case(name):
+++    """ Translate a name to snake case.
+++        Will translate
+++        'AbcDef' to 'abc_def'
+++        'ABCDef' to 'a_b_c_def'
+++    """
+++    words = []
+++    current_word = ""
+++    for char in name.elems():
+++        if char == ".":
+++            break
+++        if char.isupper() and current_word:
+++            words.append(current_word)
+++            current_word = ""
+++        current_word += char.lower()
+++    words.append(current_word)
+++    return "_".join(words)
+++
+++def to_snake_case_with_exceptions(name):
+++    """ Translate a name to snake case with the execption of multiple upper case
+++        characters in a row.
+++        Will translate
+++        'AbcDef' to 'abc_def'
+++        'ABCDef' to 'abc_def'
+++        'ColorRBGA' to 'color_rgba'
+++    """
+++    isupper = [c.isupper() or (c == ".") for c in name.elems()]
+++    isupper.append(True)
+++    result = name[0].lower()
+++    for i in range(1, len(name)):
+++        if name[i] == ".":
+++            break
+++        if ((not isupper[i - 1] and isupper[i]) or
+++            (isupper[i - 1] and isupper[i] and not isupper[i + 1])):
+++            result += "_"
+++        result += name[i].lower()
+++    return result
+++
+++def to_identifier(name):
+++    res = ""
+++    for char in name.elems():
+++        if char.isalnum() or char == "_":
+++            res += char
+++    return res
+++
+++def extract_single_dirname(files):
+++    if len(files) == 0:
+++        fail("Empty list of files not allowed.")
+++    dirname = files[0].dirname
+++    for f in files[1:]:
+++        if f.dirname != dirname:
+++            fail("Directory names unequal.")
+++    return dirname
++diff --git a/rosidl/detail/rosidl_adapter.bzl b/rosidl/detail/rosidl_adapter.bzl
++new file mode 100644
++index 0000000..da98275
++--- /dev/null
+++++ b/rosidl/detail/rosidl_adapter.bzl
++@@ -0,0 +1,131 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":detail/misc_support.bzl", "get_package_name", "tokenize_message")
+++load(":providers.bzl", "MsgsInfo", "create_msgs_info_provider")
+++
+++_DUMMY_PACKAGE_XML = """\
+++<?xml version="1.0"?>
+++<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+++<package format="2">
+++  <name>{package_name}</name>
+++  <version>0.0.1</version>
+++  <description>This is a generated xml</description>
+++  <maintainer email="generated@apex.ai">Generated</maintainer>
+++  <license>Apache License 2.0</license>
+++  <export>
+++  </export>
+++</package>
+++"""
+++
+++def _convert_to_idl_file(ctx, message_file):
+++    """Convert a non-idl file to idl one."""
+++
+++    _, type_name, msg_name, extension = tokenize_message(message_file.path)
+++    msg_local_path = "{type_name}/{name}.{extension}".format(
+++        type_name = type_name,
+++        name = msg_name,
+++        extension = extension,
+++    )
+++    local_idl_file_path = "{name}.{extension}".format(name = msg_name, extension = "idl")
+++
+++    if extension == "idl":
+++        out_idl_file = ctx.actions.declare_file(msg_local_path)
+++        args = ctx.actions.args()
+++        args.add(message_file)
+++        args.add(out_idl_file)
+++        ctx.actions.run(
+++            inputs = [message_file],
+++            outputs = [out_idl_file],
+++            progress_message = "Copying {} to idl".format(message_file.path),
+++            executable = "/bin/cp",
+++            arguments = [args],
+++        )
+++        return out_idl_file
+++    elif extension == "srv" or extension == "msg":
+++        # We symlink the input file to the output folder as the python script for the idl adapter
+++        # generates the output file in the same folder as the input file. This is the only way I found
+++        # to make sure the output file is actually populated.
+++        in_file_symlink = ctx.actions.declare_file(msg_local_path)
+++        ctx.actions.symlink(
+++            output = in_file_symlink,
+++            target_file = message_file,
+++            progress_message = "Symlink file: {}".format(msg_local_path),
+++        )
+++
+++        # We need a dummy xml to trick the idl adapter script into thinking that we are running it from
+++        # a colcon package for whatever reason. We are not using any dependencies in that script, so
+++        # this should be safe. An alternative would be to give this function the actual xml file, but
+++        # for that it would need to be part of the attrs provided to this rule (specified by the user).
+++        dummy_package_xml = ctx.actions.declare_file("package.xml", sibling = in_file_symlink)
+++        ctx.actions.write(
+++            output = dummy_package_xml,
+++            content = _DUMMY_PACKAGE_XML.format(package_name = get_package_name(ctx)),
+++        )
+++
+++        out_idl_file = ctx.actions.declare_file(local_idl_file_path, sibling = in_file_symlink)
+++        args = ctx.actions.args()
+++        args.add(in_file_symlink)
+++        ctx.actions.run(
+++            inputs = [in_file_symlink, dummy_package_xml],
+++            outputs = [out_idl_file],
+++            progress_message = "Convert {} to idl".format(in_file_symlink.path),
+++            executable = {
+++                "msg": ctx.executable._msg2idl_idl_adapter,
+++                "srv": ctx.executable._srv2idl_idl_adapter,
+++            }[extension],
+++            arguments = [args],
+++        )
+++        return out_idl_file
+++    else:
+++        fail(
+++            "Unable to handle \"" + message_file.path + "\". Message extension is not supported.",
+++        )
+++
+++def _rosidl_adapter_impl(ctx):
+++    idl_files = []
+++    for src in ctx.files.srcs:
+++        idl_files.append(_convert_to_idl_file(ctx, src))
+++    return [
+++        create_msgs_info_provider(srcs = idl_files, deps = ctx.attr.deps),
+++        DefaultInfo(
+++            files = depset(direct = idl_files),
+++        ),
+++    ]
+++
+++rosidl_adapter = rule(
+++    implementation = _rosidl_adapter_impl,
+++    provides = [MsgsInfo],
+++    attrs = {
+++        "srcs": attr.label_list(
+++            allow_files = [".idl", ".msg", ".srv"],
+++            mandatory = True,
+++        ),
+++        "deps": attr.label_list(
+++            providers = [MsgsInfo],
+++        ),
+++        "_msg2idl_idl_adapter": attr.label(
+++            executable = True,
+++            default = "@ros2.rosidl//rosidl_adapter:msg2idl",
+++            cfg = "exec",
+++            doc = "A converter from msg to idl files.",
+++        ),
+++        "_srv2idl_idl_adapter": attr.label(
+++            executable = True,
+++            default = "@ros2.rosidl//rosidl_adapter:srv2idl",
+++            cfg = "exec",
+++            doc = "A converter from srv to idl files.",
+++        ),
+++    },
+++)
++diff --git a/rosidl/detail/rosidl_generator_c.bzl b/rosidl/detail/rosidl_generator_c.bzl
++new file mode 100644
++index 0000000..b2c0e73
++--- /dev/null
+++++ b/rosidl/detail/rosidl_generator_c.bzl
++@@ -0,0 +1,131 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":detail/misc_support.bzl", "extract_single_dirname", "to_snake_case_with_exceptions")
+++load(":detail/common_config.bzl", "create_common_config")
+++load(":detail/visiability_control.bzl", "create_visibility_control_h")
+++load(":detail/cc_library_with_hdrs_extracted_from_srcs.bzl", "cc_library_with_hdrs_extracted_from_srcs")
+++load(":providers.bzl", "MsgsInfo")
+++
+++_default_attrs = {
+++    "_generator": attr.label(
+++        default = "@ros2.rosidl//rosidl_generator_c:generator",
+++        executable = True,
+++        cfg = "exec",
+++        doc = "A generator used to actually generate",
+++    ),
+++    "_generator_resources": attr.label_list(
+++        default = [
+++            "@ros2.rosidl//rosidl_generator_c:resource",
+++        ],
+++        cfg = "exec",
+++    ),
+++   "_visibility_control_h_in": attr.label(
+++       default = "@ros2.rosidl//rosidl_generator_c:resource/rosidl_generator_c__visibility_control.h.in",
+++       allow_single_file = True,
+++   ),
+++}
+++
+++def _dict_union(x, y):
+++    z = {}
+++    z.update(x)
+++    z.update(y)
+++    return z
+++
+++def _output_files_create(name):
+++    snake_case_name = to_snake_case_with_exceptions(name)
+++    return [
+++        snake_case_name + "" + ".h",
+++        "detail/" + snake_case_name + "__struct" + ".h",
+++        "detail/" + snake_case_name + "__type_support" + ".h",
+++        "detail/" + snake_case_name + "__functions" + ".h",
+++        "detail/" + snake_case_name + "__functions" + ".c",
+++    ]
+++
+++def _build_generator_c_files(ctx, srcs):
+++    # Step 1: Configure
+++    cfg = create_common_config(
+++        ctx,
+++        srcs = srcs,
+++        output_file_create_func = _output_files_create,
+++    )
+++
+++    # Step 2: Write config file
+++    _config = {
+++        "package_name": cfg.package_name,
+++        "output_dir": cfg.output_dir,
+++        "template_dir": extract_single_dirname(ctx.files._generator_resources),
+++        "idl_tuples": cfg.idl_tuples,
+++        "target_dependencies": [],
+++    }
+++    arguments_json_file = ctx.actions.declare_file("rosidl_generator_c__arguments.json")
+++    ctx.actions.write(
+++        output = arguments_json_file,
+++        content = json.encode_indent(_config, indent = "  "),
+++    )
+++
+++    # Step 3: Run rosidl_generator_c
+++    args = ctx.actions.args()
+++    args.add("--generator-arguments-file", arguments_json_file.path)
+++    ctx.actions.run(
+++        executable = ctx.executable._generator,
+++        arguments = [args],
+++        inputs = srcs + [arguments_json_file],
+++        tools = ctx.files._generator_resources,
+++        outputs = cfg.outputs,
+++    )
+++
+++    # Step 4: Add visibility control file
+++    create_visibility_control_h(
+++        ctx,
+++        cfg,
+++        output_filename = "rosidl_generator_c__visibility_control.h",
+++    )
+++    return cfg.outputs
+++
+++def _rosidl_generator_c_impl(ctx):
+++    outputs = _build_generator_c_files(ctx, ctx.files.srcs)
+++    return [
+++        DefaultInfo(files = depset(direct = outputs)),
+++    ]
+++
+++_rosidl_generator_c = rule(
+++    implementation = _rosidl_generator_c_impl,
+++    attrs = _dict_union(_default_attrs, {"srcs": attr.label_list(allow_files = [".idl"])}),
+++)
+++
+++def _rosidl_generator_c_aspect_impl(target, ctx):
+++    outputs = _build_generator_c_files(ctx, target[OutputGroupInfo].rosidl_generator_dds_idl.to_list())
+++    return [
+++        DefaultInfo(files = depset(direct = outputs)),
+++    ]
+++
+++rosidl_generator_c_aspect = aspect(
+++    implementation = _rosidl_generator_c_aspect_impl,
+++    attrs = _default_attrs,
+++    required_providers = [MsgsInfo],
+++    attr_aspects = ["deps"],
+++)
+++
+++def cc_rosidl_generator_c_library(*, name, srcs, **kwargs):
+++    _rosidl_generator_c(
+++        name = "_%s_files" % name,
+++        srcs = srcs,
+++    )
+++    cc_library_with_hdrs_extracted_from_srcs(
+++        name = name,
+++        srcs = [":_%s_files" % name],
+++        strip_include_prefix = ".",
+++        **kwargs
+++    )
++diff --git a/rosidl/detail/rosidl_generator_cpp.bzl b/rosidl/detail/rosidl_generator_cpp.bzl
++new file mode 100644
++index 0000000..de68fe9
++--- /dev/null
+++++ b/rosidl/detail/rosidl_generator_cpp.bzl
++@@ -0,0 +1,98 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":detail/misc_support.bzl", "extract_single_dirname", "to_snake_case_with_exceptions")
+++load(":detail/common_config.bzl", "create_common_config")
+++load(":detail/cc_library_with_hdrs_extracted_from_srcs.bzl", "cc_library_with_hdrs_extracted_from_srcs")
+++load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+++
+++def output_files_create(name):
+++    snake_case_name = to_snake_case_with_exceptions(name)
+++    return [
+++        snake_case_name + ".hpp",
+++        "detail/" + snake_case_name + "__builder" + ".hpp",
+++        "detail/" + snake_case_name + "__struct" + ".hpp",
+++        "detail/" + snake_case_name + "__traits" + ".hpp",
+++    ]
+++
+++def _rosidl_generator_cpp_impl(ctx):
+++    # Step 1: Configure
+++    cfg = create_common_config(
+++        ctx,
+++        srcs = ctx.files.srcs,
+++        output_file_create_func = lambda name: output_files_create(name),
+++    )
+++
+++    # Step 2: Write config file
+++    _config = {
+++        "package_name": cfg.package_name,
+++        "output_dir": cfg.output_dir,
+++        "template_dir": extract_single_dirname(ctx.files._generator_resources),
+++        "idl_tuples": cfg.idl_tuples,
+++        "target_dependencies": [],
+++    }
+++    arguments_json_file = ctx.actions.declare_file("rosidl_generator_cpp__arguments.json")
+++    ctx.actions.write(
+++        output = arguments_json_file,
+++        content = json.encode_indent(_config, indent = "  "),
+++    )
+++
+++    # Step 3: Run rosidl_generator_cpp
+++    args = ctx.actions.args()
+++    args.add("--generator-arguments-file", arguments_json_file.path)
+++    ctx.actions.run(
+++        executable = ctx.executable._generator,
+++        arguments = [args],
+++        inputs = ctx.files.srcs + [arguments_json_file],
+++        tools = ctx.files._generator_resources,
+++        outputs = cfg.outputs,
+++    )
+++
+++    # Final: Return results
+++    return [
+++        DefaultInfo(
+++            files = depset(direct = cfg.outputs),
+++        ),
+++    ]
+++
+++_rosidl_generator_cpp = rule(
+++    implementation = _rosidl_generator_cpp_impl,
+++    attrs = {
+++        "srcs": attr.label_list(allow_files = [".idl"]),
+++        "_generator": attr.label(
+++            default = "@ros2.rosidl//rosidl_generator_cpp:generator",
+++            executable = True,
+++            cfg = "exec",
+++            doc = "A generator used to actually generate",
+++        ),
+++        "_generator_resources": attr.label_list(
+++            default = [
+++                "@ros2.rosidl//rosidl_generator_cpp:resource",
+++            ],
+++            cfg = "exec",
+++        ),
+++    },
+++)
+++
+++def cc_rosidl_generator_cpp_library(*, name, srcs, **kwargs):
+++    _rosidl_generator_cpp(
+++        name = "_%s_files" % name,
+++        srcs = srcs,
+++    )
+++    cc_library_with_hdrs_extracted_from_srcs(
+++        name = name,
+++        srcs = [":_%s_files" % name],
+++        strip_include_prefix = ".",
+++        **kwargs
+++    )
++diff --git a/rosidl/detail/rosidl_generator_dds_idl.bzl b/rosidl/detail/rosidl_generator_dds_idl.bzl
++new file mode 100644
++index 0000000..c0ec998
++--- /dev/null
+++++ b/rosidl/detail/rosidl_generator_dds_idl.bzl
++@@ -0,0 +1,118 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":detail/misc_support.bzl", "extract_single_dirname")
+++load(":detail/common_config.bzl", "create_common_config_for_dds_idl_generator")
+++load(":providers.bzl", "MsgsInfo")
+++
+++_default_attrs = {
+++    "_generator": attr.label(
+++        default = "@ros2.rosidl_dds//rosidl_generator_dds_idl:generator",
+++        executable = True,
+++        cfg = "exec",
+++        doc = "A generator used to actually generate the messages.",
+++    ),
+++    "_generator_resources": attr.label_list(
+++        default = [
+++            "@ros2.rosidl_dds//rosidl_generator_dds_idl:resource",
+++        ],
+++        cfg = "exec",
+++    ),
+++    "_additional_service_templates": attr.label_list(
+++        default = [],
+++        allow_files = [".em"],
+++        doc = "Sometimes due to how python scripts work they need this additional input.",
+++    ),
+++}
+++
+++def _dict_union(x, y):
+++    z = {}
+++    z.update(x)
+++    z.update(y)
+++    return z
+++
+++def _output_files_create(name):
+++    return [
+++        "apex_middleware_typefiles" + "/" + name.replace(".idl", "_.idl"),
+++    ]
+++
+++def _build_dds_idl_files(ctx, srcs):
+++    # Step 1: Configure
+++    cfg = create_common_config_for_dds_idl_generator(
+++        ctx,
+++        srcs = srcs,
+++        output_file_create_func = _output_files_create,
+++    )
+++
+++    # Step 2: Write config file
+++    _config = {
+++        "package_name": cfg.package_name,
+++        "output_dir": cfg.output_dir,
+++        "template_dir": extract_single_dirname(ctx.files._generator_resources),
+++        "idl_tuples": cfg.idl_tuples,
+++        "target_dependencies": [],
+++    }
+++    arguments_json_file = ctx.actions.declare_file("rosidl_generator_dds_idl__apex_middleware_typefiles__arguments.json")
+++    ctx.actions.write(
+++        output = arguments_json_file,
+++        content = json.encode_indent(_config, indent = "  "),
+++    )
+++
+++    # Step 3: Run rosidl_generator_c
+++    args = ctx.actions.args()
+++
+++    args.add("--generator-arguments-file", arguments_json_file.path)
+++    # args.add("--subfolders", "apex_middleware_typefiles")
+++    # args.add("--extension", "apex_middleware_typefiles_generator.rosidl_generator_dds_idl_extension")
+++    if ctx.attr._additional_service_templates:
+++        args.add("--additional-service-templates")
+++        for p in ctx.files._additional_service_templates:
+++            args.add(p.path)
+++    ctx.actions.run(
+++        executable = ctx.executable._generator,
+++        arguments = [args],
+++        inputs = srcs + ctx.files._additional_service_templates + [arguments_json_file],
+++        tools = ctx.files._generator_resources,
+++        outputs = cfg.outputs,
+++    )
+++
+++    # Final: Return output files
+++    return cfg.outputs
+++
+++def _rosidl_generator_dds_idl_impl(ctx):
+++    outputs = _build_dds_idl_files(ctx, ctx.files.srcs)
+++    return [
+++        DefaultInfo(files = depset(direct = outputs)),
+++    ]
+++
+++rosidl_generator_dds_idl = rule(
+++    implementation = _rosidl_generator_dds_idl_impl,
+++    attrs = _dict_union(
+++        _default_attrs,
+++        {"srcs": attr.label_list(allow_files = [".idl"])},
+++    ),
+++)
+++
+++def _rosidl_generator_dds_idl_aspect_impl(target, ctx):
+++    outputs = _build_dds_idl_files(ctx, target[MsgsInfo].srcs)
+++    return [
+++        OutputGroupInfo(rosidl_generator_dds_idl = outputs),
+++    ]
+++
+++rosidl_generator_dds_idl_aspect = aspect(
+++    implementation = _rosidl_generator_dds_idl_aspect_impl,
+++    attrs = _default_attrs,
+++    required_providers = [MsgsInfo],
+++    attr_aspects = ["deps"],
+++)
++diff --git a/rosidl/detail/rosidl_typesupport_c.bzl b/rosidl/detail/rosidl_typesupport_c.bzl
++new file mode 100644
++index 0000000..2954991
++--- /dev/null
+++++ b/rosidl/detail/rosidl_typesupport_c.bzl
++@@ -0,0 +1,109 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load(":detail/misc_support.bzl", "extract_single_dirname", "to_snake_case_with_exceptions")
+++load(":detail/common_config.bzl", "create_common_config")
+++load(":detail/visiability_control.bzl", "create_visibility_control_h")
+++load(":detail/cc_library_with_hdrs_extracted_from_srcs.bzl", "cc_library_with_hdrs_extracted_from_srcs")
+++
+++def output_files_create(name):
+++    snake_case_name = to_snake_case_with_exceptions(name)
+++    return [
+++        snake_case_name + "__type_support" + ".cpp",
+++    ]
+++
+++def _rosidl_typesupport_c_impl(ctx):
+++    # Step 1: Configure
+++    cfg = create_common_config(
+++        ctx,
+++        srcs = ctx.files.srcs,
+++        output_file_create_func = output_files_create,
+++    )
+++
+++    # Step 2: Write config file
+++    _config = {
+++        "package_name": cfg.package_name,
+++        "output_dir": cfg.output_dir,
+++        "template_dir": extract_single_dirname(ctx.files._generator_resources),
+++        "idl_tuples": cfg.idl_tuples,
+++        "target_dependencies": [],
+++    }
+++    arguments_json_file = ctx.actions.declare_file("rosidl_typesupport_c__arguments.json")
+++    ctx.actions.write(
+++        output = arguments_json_file,
+++        content = json.encode_indent(_config, indent = "  "),
+++    )
+++
+++    # Step 3: Run rosidl_generator_c
+++    args = ctx.actions.args()
+++    args.add("--generator-arguments-file", arguments_json_file.path)
+++    if len(ctx.attr.typesupports) < 1:
+++        fail("Typesupports may not be an empty list")
+++    args.add("--typesupports")
+++    for rmw in ctx.attr.typesupports:
+++        args.add(rmw)
+++    ctx.actions.run(
+++        executable = ctx.executable._generator,
+++        arguments = [args],
+++        inputs = ctx.files.srcs + [arguments_json_file],
+++        tools = ctx.files._generator_resources,
+++        outputs = cfg.outputs,
+++    )
+++
+++    # Final: Return results
+++    return [
+++        DefaultInfo(
+++            files = depset(direct = cfg.outputs),
+++        ),
+++    ]
+++
+++_rosidl_typesupport_c = rule(
+++    implementation = _rosidl_typesupport_c_impl,
+++    attrs = {
+++        "srcs": attr.label_list(allow_files = [".idl"]),
+++        "_generator": attr.label(
+++            default = "@ros2.rosidl_typesupport//rosidl_typesupport_c:generator",
+++            executable = True,
+++            cfg = "exec",
+++            doc = "A generator used to actually generate",
+++        ),
+++        "_generator_resources": attr.label_list(
+++            default = [
+++                "@ros2.rosidl_typesupport//rosidl_typesupport_c:resource",
+++            ],
+++            cfg = "exec",
+++        ),
+++        "_visibility_control_h_in": attr.label(
+++            default = "@ros2.rosidl_typesupport//rosidl_typesupport_c:resource/rosidl_typesupport_c__visibility_control.h.in",
+++            allow_single_file = True,
+++        ),
+++        "typesupports": attr.string_list(
+++            mandatory = True,
+++            doc = "Typesupports that are required to generate the messages.",
+++        ),
+++    },
+++)
+++
+++def cc_rosidl_typesupport_c_library(*, name, srcs, typesupports, **kwargs):
+++    _rosidl_typesupport_c(
+++        name = "_%s_files" % name,
+++        srcs = srcs,
+++        typesupports = typesupports,
+++    )
+++    cc_library_with_hdrs_extracted_from_srcs(
+++        name = name,
+++        srcs = [":_%s_files" % name],
+++        strip_include_prefix = ".",
+++        **kwargs
+++    )
++diff --git a/rosidl/detail/visiability_control.bzl b/rosidl/detail/visiability_control.bzl
++new file mode 100644
++index 0000000..e7faf4b
++--- /dev/null
+++++ b/rosidl/detail/visiability_control.bzl
++@@ -0,0 +1,26 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++def create_visibility_control_h(ctx, cfg, *, output_filename):
+++    for _dirname in cfg.dirnames:
+++        visibility_control_h = ctx.actions.declare_file(cfg.output_dir_relative + "/" + _dirname + "/" + output_filename)
+++        cfg.outputs.append(visibility_control_h)
+++        ctx.actions.expand_template(
+++            template = ctx.file._visibility_control_h_in,
+++            output = visibility_control_h,
+++            substitutions = {
+++                "@PROJECT_NAME_UPPER@": cfg.package_name.upper(),
+++                "@PROJECT_NAME@": cfg.package_name,
+++            },
+++        )
++diff --git a/rosidl/providers.bzl b/rosidl/providers.bzl
++index 71bcb66..fc27a73 100644
++--- a/rosidl/providers.bzl
+++++ b/rosidl/providers.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ MsgsInfo = provider(
++     doc = """
++     Provider for a set of idl files containing message definitions.
++diff --git a/thirdparty/bazel_skylib/repositories.bzl b/thirdparty/bazel_skylib/repositories.bzl
++index 755ee8d..39f7b81 100644
++--- a/thirdparty/bazel_skylib/repositories.bzl
+++++ b/thirdparty/bazel_skylib/repositories.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
++ 
++diff --git a/thirdparty/bazel_skylib/setup.bzl b/thirdparty/bazel_skylib/setup.bzl
++index ddb95eb..25e35e5 100644
++--- a/thirdparty/bazel_skylib/setup.bzl
+++++ b/thirdparty/bazel_skylib/setup.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
++ 
++ def setup_bazel_skylib_repositories():
++diff --git a/thirdparty/libyaml/libyaml.BUILD b/thirdparty/libyaml/libyaml.BUILD
++deleted file mode 100644
++index 2da5dc4..0000000
++--- a/thirdparty/libyaml/libyaml.BUILD
+++++ /dev/null
++@@ -1,16 +0,0 @@
++-cc_library(
++-    name = "libyaml",
++-    srcs = glob([
++-        "src/*.c",
++-        "src/*.h",
++-    ]),
++-    hdrs = glob(["include/*.h"]),
++-    defines = [
++-        'YAML_VERSION_STRING=\\\"0.2.5\\\"',
++-        "YAML_VERSION_MAJOR=0",
++-        "YAML_VERSION_MINOR=2",
++-        "YAML_VERSION_PATCH=5",
++-    ],
++-    includes = ["include"],
++-    visibility = ["//visibility:public"],
++-)
++diff --git a/thirdparty/libyaml/libyaml.BUILD.bazel b/thirdparty/libyaml/libyaml.BUILD.bazel
++new file mode 100644
++index 0000000..bde944a
++--- /dev/null
+++++ b/thirdparty/libyaml/libyaml.BUILD.bazel
++@@ -0,0 +1,30 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++cc_library(
+++    name = "libyaml",
+++    srcs = glob([
+++        "src/*.c",
+++        "src/*.h",
+++    ]),
+++    hdrs = glob(["include/*.h"]),
+++    defines = [
+++        'YAML_VERSION_STRING=\\\"0.2.5\\\"',
+++        "YAML_VERSION_MAJOR=0",
+++        "YAML_VERSION_MINOR=2",
+++        "YAML_VERSION_PATCH=5",
+++    ],
+++    includes = ["include"],
+++    visibility = ["//visibility:public"],
+++)
++diff --git a/thirdparty/libyaml/repositories.bzl b/thirdparty/libyaml/repositories.bzl
++index c032545..de6efd8 100644
++--- a/thirdparty/libyaml/repositories.bzl
+++++ b/thirdparty/libyaml/repositories.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
++ 
++@@ -11,5 +25,5 @@ def load_libyaml_repositories():
++         urls = ["https://github.com/yaml/libyaml/releases/download/{version}/yaml-{version}.zip".format(version = LIBYAML_VERSION)],
++         sha256 = LIBYAML_SHA,
++         strip_prefix = "yaml-{version}".format(version = LIBYAML_VERSION),
++-        build_file = "@rules_ros//thirdparty/libyaml:libyaml.BUILD",
+++        build_file = "@rules_ros//thirdparty/libyaml:libyaml.BUILD.bazel",
++     )
++diff --git a/thirdparty/python/repositories.bzl b/thirdparty/python/repositories.bzl
++index ab15db2..4c90aa9 100644
++--- a/thirdparty/python/repositories.bzl
+++++ b/thirdparty/python/repositories.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
++ 
++diff --git a/thirdparty/python/requirements_lock.in b/thirdparty/python/requirements_lock.in
++index 57e8dbf..c25f06f 100644
++--- a/thirdparty/python/requirements_lock.in
+++++ b/thirdparty/python/requirements_lock.in
++@@ -1,5 +1,5 @@
++ empy==3.3.2
++ jinja2==3.1.2
++-#catkin_pkg==0.4.14
++-#lark==0.10.1
++-#pytest==6.2.4
+++catkin_pkg==0.4.14
+++lark==0.10.1
+++pytest==6.2.4
++diff --git a/thirdparty/python/requirements_lock.txt b/thirdparty/python/requirements_lock.txt
++index 68ec093..86394ae 100644
++--- a/thirdparty/python/requirements_lock.txt
+++++ b/thirdparty/python/requirements_lock.txt
++@@ -4,13 +4,33 @@
++ #
++ #    bazel run //thirdparty/python:requirements_lock.update
++ #
+++attrs==22.1.0 \
+++    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+++    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
+++    # via pytest
+++catkin-pkg==0.4.14 \
+++    --hash=sha256:67bffdd93dd1b5b80caccc046d6bdde91b7e8a2ca3c5d472d1673c97d4469e98 \
+++    --hash=sha256:fc2e5ae2dcfc288739dbf9758b67b94e138506dca4f06f81cfc8bcdd3164b234
+++    # via -r thirdparty/python/requirements_lock.in
+++docutils==0.19 \
+++    --hash=sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6 \
+++    --hash=sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc
+++    # via catkin-pkg
++ empy==3.3.2 \
++     --hash=sha256:99f016af2770c48ab57a65df7aae251360dc69a1514c15851458a71d4ddfea9c
++     # via -r thirdparty/python/requirements_lock.in
+++iniconfig==1.1.1 \
+++    --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
+++    --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
+++    # via pytest
++ jinja2==3.1.2 \
++     --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
++     --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
++     # via -r thirdparty/python/requirements_lock.in
+++lark==0.10.1 \
+++    --hash=sha256:98f2c6f8e41fe601fd103476eb759ac1ad4d3dc8094633133a16cef5a32b0f65 \
+++    --hash=sha256:eb919a7326a76af36e2e2cb5ac6c1be6723bba83945a0a33e6d533070cbaccc7
+++    # via -r thirdparty/python/requirements_lock.in
++ markupsafe==2.1.1 \
++     --hash=sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003 \
++     --hash=sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88 \
++@@ -53,3 +73,37 @@ markupsafe==2.1.1 \
++     --hash=sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a \
++     --hash=sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7
++     # via jinja2
+++packaging==21.3 \
+++    --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
+++    --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+++    # via pytest
+++pluggy==0.13.1 \
+++    --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
+++    --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d
+++    # via pytest
+++py==1.11.0 \
+++    --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
+++    --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
+++    # via pytest
+++pyparsing==3.0.9 \
+++    --hash=sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb \
+++    --hash=sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
+++    # via
+++    #   catkin-pkg
+++    #   packaging
+++pytest==6.2.4 \
+++    --hash=sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b \
+++    --hash=sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890
+++    # via -r thirdparty/python/requirements_lock.in
+++python-dateutil==2.8.2 \
+++    --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
+++    --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
+++    # via catkin-pkg
+++six==1.16.0 \
+++    --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
+++    --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
+++    # via python-dateutil
+++toml==0.10.2 \
+++    --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
+++    --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
+++    # via pytest
++diff --git a/thirdparty/setup_01.bzl b/thirdparty/setup_01.bzl
++index 3ca71a6..458e160 100644
++--- a/thirdparty/setup_01.bzl
+++++ b/thirdparty/setup_01.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//thirdparty/python:repositories.bzl", "load_rules_python_repositories")
++ load("@rules_ros//thirdparty/libyaml:repositories.bzl", "load_libyaml_repositories")
++ load("@rules_ros//thirdparty/bazel_skylib:repositories.bzl", "load_bazel_skylib_repositories")
++diff --git a/thirdparty/setup_02.bzl b/thirdparty/setup_02.bzl
++index e4ae752..9fb358f 100644
++--- a/thirdparty/setup_02.bzl
+++++ b/thirdparty/setup_02.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//thirdparty/python:setup_toolchain.bzl", "register_python_toolchain")
++ load("@rules_ros//thirdparty/bazel_skylib:setup.bzl", "setup_bazel_skylib_repositories")
++ load("@rules_ros//thirdparty/rules_pkg:setup.bzl", "setup_rules_pkg_repositories")
++diff --git a/thirdparty/setup_03.bzl b/thirdparty/setup_03.bzl
++index 15cb742..bec5e62 100644
++--- a/thirdparty/setup_03.bzl
+++++ b/thirdparty/setup_03.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//thirdparty/python:pip_parse.bzl", "pip_parse")
++ 
++ def setup_03():
++diff --git a/thirdparty/setup_04.bzl b/thirdparty/setup_04.bzl
++index 92c5cde..2134bc6 100644
++--- a/thirdparty/setup_04.bzl
+++++ b/thirdparty/setup_04.bzl
++@@ -1,3 +1,17 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ load("@rules_ros//thirdparty/python:install_deps.bzl", "install_deps")
++ 
++ def setup_04():
++diff --git a/utils/template_expansion.bzl b/utils/template_expansion.bzl
++index 45369fa..bc37374 100644
++--- a/utils/template_expansion.bzl
+++++ b/utils/template_expansion.bzl
++@@ -1,29 +1,56 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
++ def _expand_template_impl(ctx):
++     """Get am .em template and produce a header-only library from the generated file."""
++     package_name = ctx.attr.package_name
++     template_file = ctx.file.template
++     if not template_file.basename.endswith(".em"):
++         fail("The template file must end with '.em'")
++-    out_file_basename = template_file.basename.rsplit(".", 1)[0]
++-    output_file = ctx.actions.declare_file(
++-        "include/{package_name}/{file_name}".format(
++-            package_name = package_name,
++-            file_name = out_file_basename,
++-        ),
++-    )
++-    args = [output_file.path] + [template_file.path]
++-    ctx.actions.run(
++-        inputs = [template_file],
++-        outputs = [output_file],
++-        progress_message = "Generating a header from template {}".format(template_file.path),
++-        executable = ctx.executable.generator_script,
++-        arguments = args,
++-    )
+++    if len(ctx.attr.variables)>1:
+++        fail("More than one variable definition not implemented.")
+++    variable = ctx.attr.variables.keys()[0] if len(ctx.attr.variables) != 0 else None
+++    values = ctx.attr.variables[variable] if variable != None else [None]
+++    outputs = []
+++
+++    for value in values:
+++        out_file_basename = ctx.attr.output_pattern.format(**{variable:value}) \
+++            if ctx.attr.output_pattern != "" \
+++            else template_file.basename.rsplit(".", 1)[0]
+++        output_file = ctx.actions.declare_file(
+++            "include/{package_name}/{file_name}".format(
+++                package_name = package_name,
+++                file_name = out_file_basename,
+++            ),
+++        )
+++        args = [output_file.path] + [template_file.path]
+++        if value != None:
+++            args.extend(["-D", variable + ' = "' + value + '"'])
+++        ctx.actions.run(
+++            inputs = [template_file],
+++            outputs = [output_file],
+++            progress_message = "Generating a header from template {}".format(template_file.path),
+++            executable = ctx.executable.generator_script,
+++            arguments = args,
+++        )
+++        outputs.append(output_file)
+++
++     includes_folder = output_file.path.rsplit(package_name, 1)[0]
++     return [CcInfo(
++         compilation_context = cc_common.create_compilation_context(
++             includes = depset([includes_folder]),
++-            headers = depset([output_file]),
+++            headers = depset(outputs),
++         ),
++     )]
++ 
++@@ -39,6 +66,15 @@ cc_library_from_template = rule(
++             allow_single_file = [".em"],
++             doc = "Input file that will be used to generate the output file.",
++         ),
+++        "output_pattern": attr.string(
+++            mandatory = False,
+++            default = "",
+++        ),
+++        "variables": attr.string_list_dict(
+++            mandatory = False,
+++            doc = "Variables, that will be used for looping through the template expansion.",
+++            default = {},
+++        ),
++         "generator_script": attr.label(
++             mandatory = True,
++             executable = True,
++-- 
++2.34.1
++
++
++From f610ed1c39440488dacbc8236d3d3bc7c4ceafb8 Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Fri, 21 Oct 2022 08:48:34 +0900
++Subject: [PATCH 02/27] Add license file
++
++---
++ LICENSE | 201 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
++ 1 file changed, 201 insertions(+)
++ create mode 100644 LICENSE
++
++diff --git a/LICENSE b/LICENSE
++new file mode 100644
++index 0000000..8dada3e
++--- /dev/null
+++++ b/LICENSE
++@@ -0,0 +1,201 @@
+++                                 Apache License
+++                           Version 2.0, January 2004
+++                        http://www.apache.org/licenses/
+++
+++   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+++
+++   1. Definitions.
+++
+++      "License" shall mean the terms and conditions for use, reproduction,
+++      and distribution as defined by Sections 1 through 9 of this document.
+++
+++      "Licensor" shall mean the copyright owner or entity authorized by
+++      the copyright owner that is granting the License.
+++
+++      "Legal Entity" shall mean the union of the acting entity and all
+++      other entities that control, are controlled by, or are under common
+++      control with that entity. For the purposes of this definition,
+++      "control" means (i) the power, direct or indirect, to cause the
+++      direction or management of such entity, whether by contract or
+++      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+++      outstanding shares, or (iii) beneficial ownership of such entity.
+++
+++      "You" (or "Your") shall mean an individual or Legal Entity
+++      exercising permissions granted by this License.
+++
+++      "Source" form shall mean the preferred form for making modifications,
+++      including but not limited to software source code, documentation
+++      source, and configuration files.
+++
+++      "Object" form shall mean any form resulting from mechanical
+++      transformation or translation of a Source form, including but
+++      not limited to compiled object code, generated documentation,
+++      and conversions to other media types.
+++
+++      "Work" shall mean the work of authorship, whether in Source or
+++      Object form, made available under the License, as indicated by a
+++      copyright notice that is included in or attached to the work
+++      (an example is provided in the Appendix below).
+++
+++      "Derivative Works" shall mean any work, whether in Source or Object
+++      form, that is based on (or derived from) the Work and for which the
+++      editorial revisions, annotations, elaborations, or other modifications
+++      represent, as a whole, an original work of authorship. For the purposes
+++      of this License, Derivative Works shall not include works that remain
+++      separable from, or merely link (or bind by name) to the interfaces of,
+++      the Work and Derivative Works thereof.
+++
+++      "Contribution" shall mean any work of authorship, including
+++      the original version of the Work and any modifications or additions
+++      to that Work or Derivative Works thereof, that is intentionally
+++      submitted to Licensor for inclusion in the Work by the copyright owner
+++      or by an individual or Legal Entity authorized to submit on behalf of
+++      the copyright owner. For the purposes of this definition, "submitted"
+++      means any form of electronic, verbal, or written communication sent
+++      to the Licensor or its representatives, including but not limited to
+++      communication on electronic mailing lists, source code control systems,
+++      and issue tracking systems that are managed by, or on behalf of, the
+++      Licensor for the purpose of discussing and improving the Work, but
+++      excluding communication that is conspicuously marked or otherwise
+++      designated in writing by the copyright owner as "Not a Contribution."
+++
+++      "Contributor" shall mean Licensor and any individual or Legal Entity
+++      on behalf of whom a Contribution has been received by Licensor and
+++      subsequently incorporated within the Work.
+++
+++   2. Grant of Copyright License. Subject to the terms and conditions of
+++      this License, each Contributor hereby grants to You a perpetual,
+++      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+++      copyright license to reproduce, prepare Derivative Works of,
+++      publicly display, publicly perform, sublicense, and distribute the
+++      Work and such Derivative Works in Source or Object form.
+++
+++   3. Grant of Patent License. Subject to the terms and conditions of
+++      this License, each Contributor hereby grants to You a perpetual,
+++      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+++      (except as stated in this section) patent license to make, have made,
+++      use, offer to sell, sell, import, and otherwise transfer the Work,
+++      where such license applies only to those patent claims licensable
+++      by such Contributor that are necessarily infringed by their
+++      Contribution(s) alone or by combination of their Contribution(s)
+++      with the Work to which such Contribution(s) was submitted. If You
+++      institute patent litigation against any entity (including a
+++      cross-claim or counterclaim in a lawsuit) alleging that the Work
+++      or a Contribution incorporated within the Work constitutes direct
+++      or contributory patent infringement, then any patent licenses
+++      granted to You under this License for that Work shall terminate
+++      as of the date such litigation is filed.
+++
+++   4. Redistribution. You may reproduce and distribute copies of the
+++      Work or Derivative Works thereof in any medium, with or without
+++      modifications, and in Source or Object form, provided that You
+++      meet the following conditions:
+++
+++      (a) You must give any other recipients of the Work or
+++          Derivative Works a copy of this License; and
+++
+++      (b) You must cause any modified files to carry prominent notices
+++          stating that You changed the files; and
+++
+++      (c) You must retain, in the Source form of any Derivative Works
+++          that You distribute, all copyright, patent, trademark, and
+++          attribution notices from the Source form of the Work,
+++          excluding those notices that do not pertain to any part of
+++          the Derivative Works; and
+++
+++      (d) If the Work includes a "NOTICE" text file as part of its
+++          distribution, then any Derivative Works that You distribute must
+++          include a readable copy of the attribution notices contained
+++          within such NOTICE file, excluding those notices that do not
+++          pertain to any part of the Derivative Works, in at least one
+++          of the following places: within a NOTICE text file distributed
+++          as part of the Derivative Works; within the Source form or
+++          documentation, if provided along with the Derivative Works; or,
+++          within a display generated by the Derivative Works, if and
+++          wherever such third-party notices normally appear. The contents
+++          of the NOTICE file are for informational purposes only and
+++          do not modify the License. You may add Your own attribution
+++          notices within Derivative Works that You distribute, alongside
+++          or as an addendum to the NOTICE text from the Work, provided
+++          that such additional attribution notices cannot be construed
+++          as modifying the License.
+++
+++      You may add Your own copyright statement to Your modifications and
+++      may provide additional or different license terms and conditions
+++      for use, reproduction, or distribution of Your modifications, or
+++      for any such Derivative Works as a whole, provided Your use,
+++      reproduction, and distribution of the Work otherwise complies with
+++      the conditions stated in this License.
+++
+++   5. Submission of Contributions. Unless You explicitly state otherwise,
+++      any Contribution intentionally submitted for inclusion in the Work
+++      by You to the Licensor shall be under the terms and conditions of
+++      this License, without any additional terms or conditions.
+++      Notwithstanding the above, nothing herein shall supersede or modify
+++      the terms of any separate license agreement you may have executed
+++      with Licensor regarding such Contributions.
+++
+++   6. Trademarks. This License does not grant permission to use the trade
+++      names, trademarks, service marks, or product names of the Licensor,
+++      except as required for reasonable and customary use in describing the
+++      origin of the Work and reproducing the content of the NOTICE file.
+++
+++   7. Disclaimer of Warranty. Unless required by applicable law or
+++      agreed to in writing, Licensor provides the Work (and each
+++      Contributor provides its Contributions) on an "AS IS" BASIS,
+++      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+++      implied, including, without limitation, any warranties or conditions
+++      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+++      PARTICULAR PURPOSE. You are solely responsible for determining the
+++      appropriateness of using or redistributing the Work and assume any
+++      risks associated with Your exercise of permissions under this License.
+++
+++   8. Limitation of Liability. In no event and under no legal theory,
+++      whether in tort (including negligence), contract, or otherwise,
+++      unless required by applicable law (such as deliberate and grossly
+++      negligent acts) or agreed to in writing, shall any Contributor be
+++      liable to You for damages, including any direct, indirect, special,
+++      incidental, or consequential damages of any character arising as a
+++      result of this License or out of the use or inability to use the
+++      Work (including but not limited to damages for loss of goodwill,
+++      work stoppage, computer failure or malfunction, or any and all
+++      other commercial damages or losses), even if such Contributor
+++      has been advised of the possibility of such damages.
+++
+++   9. Accepting Warranty or Additional Liability. While redistributing
+++      the Work or Derivative Works thereof, You may choose to offer,
+++      and charge a fee for, acceptance of support, warranty, indemnity,
+++      or other liability obligations and/or rights consistent with this
+++      License. However, in accepting such obligations, You may act only
+++      on Your own behalf and on Your sole responsibility, not on behalf
+++      of any other Contributor, and only if You agree to indemnify,
+++      defend, and hold each Contributor harmless for any liability
+++      incurred by, or claims asserted against, such Contributor by reason
+++      of your accepting any such warranty or additional liability.
+++
+++   END OF TERMS AND CONDITIONS
+++
+++   APPENDIX: How to apply the Apache License to your work.
+++
+++      To apply the Apache License to your work, attach the following
+++      boilerplate notice, with the fields enclosed by brackets "{}"
+++      replaced with your own identifying information. (Don't include
+++      the brackets!)  The text should be enclosed in the appropriate
+++      comment syntax for the file format. We also recommend that a
+++      file or class name and description of purpose be included on the
+++      same "printed page" as the copyright notice for easier
+++      identification within third-party archives.
+++
+++   Copyright {yyyy} {name of copyright owner}
+++
+++   Licensed under the Apache License, Version 2.0 (the "License");
+++   you may not use this file except in compliance with the License.
+++   You may obtain a copy of the License at
+++
+++       http://www.apache.org/licenses/LICENSE-2.0
+++
+++   Unless required by applicable law or agreed to in writing, software
+++   distributed under the License is distributed on an "AS IS" BASIS,
+++   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++   See the License for the specific language governing permissions and
+++   limitations under the License.
++-- 
++2.34.1
++
++
++From 6d5e4b6acff20b2a2d7a8a20df672e1117e66fba Mon Sep 17 00:00:00 2001
++From: Christophe Bedard <christophe.bedard@apex.ai>
++Date: Fri, 4 Nov 2022 15:44:41 -0700
++Subject: [PATCH 03/27] Clean up README
++
++---
++ README.md | 62 +++++++++++++++++++++++++++----------------------------
++ 1 file changed, 31 insertions(+), 31 deletions(-)
++
++diff --git a/README.md b/README.md
++index 01ef700..dd5cd8f 100644
++--- a/README.md
+++++ b/README.md
++@@ -1,43 +1,45 @@
++-# ROS2 Rules for Bazel
+++# ROS 2 Rules for Bazel
++ 
++ ## Overview
++ 
++ This repository contains all the setup, rules and build configuration to use
++-[Bazel](http://bazel.build) with ROS2. As reccomended by Bazel, all ROS2 packages
+++[Bazel](http://bazel.build) with ROS 2. As recommended by Bazel, all ROS 2 packages
++ are built from source. They are loaded as needed, so no a priori loading or manual version
++-management of ROS2 repos (e.g. via vcs tool) is required.
+++management of ROS 2 repos (e.g., via vcs tool) is required.
++ 
++-The neccessary BUILD files for ROS2 repos are injected while loading. In case bazel will
++-gain some traction within the ROS community, Bazel BUILD files should ideally be provided
++-directly by the ROS2 repositories.
+++The neccessary BUILD files for ROS 2 repos are injected while loading. In case Bazel gains
+++some traction within the ROS community, Bazel BUILD files should ideally be provided
+++directly by the ROS 2 repositories.
++ 
++ Specific rules for message generation and packaging are provided in this repository (see 
++ [rosidl/defs.bzl](rosidl/defs.bzl) and [pkg/defs.bzl](pkg/defs.bzl)).
++ 
++ ## ! Current Restrictions !
++ 
++-This is still work in progress. Some essential parts are not complete yet. 
+++This is still work in progress. Some essential parts are not complete yet.
++ Here is a short list of major restrictions:
++-* Only tested on Ubunut 20.04 linux (x86_64). Other linux distributions may work. Windows
+++* Only tested on Ubunut 20.04 Linux (x86_64). Other Linux distributions may work. Windows
++   will not be supported in the foreseeable future.
++-* Only ROS2 humble supported. Other distros may work after extending
+++* Only ROS 2 Humble is supported. Other distros may work after extending
++   `@rules_ros//repos/config/defs.bzl` accordingly.
++ * Message generation is still incomplete. Therefore even the simplest examples will not run
++   due to not yet bazelized middleware.
++ * Not all packages have been bazelized yet. Main focus currently lies on generating an
++-  install space and providing message generation support. From the `ros2cli` only the `run`
++-  command is currently bazelized.
+++  install space and providing message generation support. Out of all the ROS 2 CLI commands,
+++  (`ros2cli`), only the `run` command is currently bazelized.
++ * The streamlined integration of custom packages into the repo setup is not yet available.
++-  Same applies to adding additional python packages. 
+++  Same applies to adding additional Python packages. 
++   This will be added soon.
++ 
++ ## Getting started
++ 
++ ### Prerequisits
+++
++ Bazel needs to be available. We reccomend using [bazelisk](https://github.com/bazelbuild/bazelisk)
++-as a launch tool for bazel.
+++as a launch tool for Bazel.
++ 
++ ### Workspace setup
+++
++ Create an empty folder and add the following files to it:
++ * `WORKSPACE` file:
++   ```python
++@@ -64,7 +66,7 @@ Create an empty folder and add the following files to it:
++   #)
++ 
++   load("@rules_ros//repos/config:defs.bzl", "configure_ros2")
++-  configure_ros2(distro = "humble") # currently only humble is supported
+++  configure_ros2(distro = "humble") # currently only Humble is supported
++ 
++   load("@ros2_config//:setup.bzl", "setup")
++   setup()
++@@ -83,13 +85,13 @@ Create an empty folder and add the following files to it:
++   ```
++ * `.bazelrc` file:
++   ```bash
++-  # enable incompatible python init mode
+++  # enable incompatible Python init mode
++   build --incompatible_default_to_explicit_init_py
++ 
++   # enable implementation_deps on cc_library targets
++   build --experimental_cc_implementation_deps
++ 
++-  # set c++14 for all builds
+++  # set C++14 for all builds
++   build --cxxopt="-std=c++17"
++   build --host_cxxopt="-std=c++17"
++   ```
++@@ -99,8 +101,9 @@ Create an empty folder and add the following files to it:
++   5.3.1
++   ```
++ 
++-### Run bazel example
++-To **build** an example delivered in the `rules_ros` repository run e.g.
+++### Run Bazel example
+++
+++To **build** an example delivered in the `rules_ros` repository run, e.g.
++ ```bash
++ bazel build @rules_ros//examples/hello_world
++ ```
++@@ -126,36 +129,33 @@ ros2 run hello_world hello_world
++ ```
++ 
++ ## Features
+++
++ ### Python Interpreter
++ 
++-In this setup a hermetic python interpreter is included. The version is specified in 
+++In this setup, a hermetic Python interpreter is included. The version is specified in
++ `thirdparty/python/repositories.bzl`. Python packages specified in
++ `thirdparty/python/requirements_lock.in` are available for use. If you need to add a package,
++-you must run 
+++you must run
++ ```console
++ bazel run @rules_ros//thirdparty/python:requirements_lock.update
++ ```
++ to pin specific versions of the dependencies. In the future there will be a possibility to
++ inject a customization in the WORKSPACE file.
++ 
++-### ROS2 Repositories
+++### ROS 2 Repositories
++ 
++-ROS2 repositories are made available as external dependencies with the name specified in
++-the `ros2.repos` file known from the original ros2 repository. E. g. the repo `ros2/rclcpp`
+++ROS 2 repositories are made available as external dependencies with the name specified in
+++the `ros2.repos` file known from the original ROS 2 repository, e.g., the `ros2/rclcpp` repo
++ will be available as `@ros2.rclcpp` with all targets specified in the BUILD files in
++ `repos/config/ros2.rclcpp.BUILD`. The precise location where the build files will be injected
++-into the rclcpp repo is specified in the index file `repos/config/bazel.repos`.
+++into the `rclcpp` repo is specified in the index file `repos/config/bazel.repos`.
++ 
++-So, if you need to depend on `rclcpp` in you code, you would add `"@ros2.rclcpp//rclcpp"`
+++Therefore, if you need to depend on `rclcpp` in you code, you need to add `"@ros2.rclcpp//rclcpp"`
++ as a dependency in your `cc_binary` or `cc_library` target.
++ 
++-The exact version of a ros2 repository is pinned in the file `repos/config/ros2_<distro>.lock`.
+++The exact version of a ROS 2 repository is pinned in the file `repos/config/ros2_<distro>.lock`.
++ This file can be updated for the configured distro by running:
++ ```console
++ bazel run @rules_ros//repos/config:repos_lock.update
++ ```
++- In the future there will be a possibility to inject any customization in the WORKSPACE file.
++-
++-
++-
++-
+++In the future there will be a possibility to inject any customization in the WORKSPACE file.
++-- 
++2.34.1
++
++
++From 179d1443ea3c95f30813fe95859ee6521f57fe6f Mon Sep 17 00:00:00 2001
++From: Alexander Hans <ahans@users.noreply.github.com>
++Date: Fri, 21 Oct 2022 10:49:05 +0200
++Subject: [PATCH 04/27] Add pyyaml requirement to rosidl_cli target
++
++---
++ .../ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel  |  1 +
++ thirdparty/python/requirements_lock.in        |  1 +
++ thirdparty/python/requirements_lock.txt       | 42 +++++++++++++++++++
++ 3 files changed, 44 insertions(+)
++
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel b/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel
++index bc5e176..1106f03 100644
++--- a/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel
+++++ b/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel
++@@ -23,6 +23,7 @@ py_library(
++     imports = ["."],
++     visibility = ["//visibility:public"],
++     deps = [
+++        requirement("pyyaml"),
++     ],
++ )
++ 
++diff --git a/thirdparty/python/requirements_lock.in b/thirdparty/python/requirements_lock.in
++index c25f06f..1355111 100644
++--- a/thirdparty/python/requirements_lock.in
+++++ b/thirdparty/python/requirements_lock.in
++@@ -3,3 +3,4 @@ jinja2==3.1.2
++ catkin_pkg==0.4.14
++ lark==0.10.1
++ pytest==6.2.4
+++pyyaml==6.0.0
++\ No newline at end of file
++diff --git a/thirdparty/python/requirements_lock.txt b/thirdparty/python/requirements_lock.txt
++index 86394ae..f14cd07 100644
++--- a/thirdparty/python/requirements_lock.txt
+++++ b/thirdparty/python/requirements_lock.txt
++@@ -99,6 +99,48 @@ python-dateutil==2.8.2 \
++     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
++     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
++     # via catkin-pkg
+++pyyaml==6.0.0 \
+++    --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf \
+++    --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \
+++    --hash=sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b \
+++    --hash=sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57 \
+++    --hash=sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b \
+++    --hash=sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4 \
+++    --hash=sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07 \
+++    --hash=sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba \
+++    --hash=sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9 \
+++    --hash=sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287 \
+++    --hash=sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513 \
+++    --hash=sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0 \
+++    --hash=sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782 \
+++    --hash=sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0 \
+++    --hash=sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92 \
+++    --hash=sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f \
+++    --hash=sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2 \
+++    --hash=sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc \
+++    --hash=sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1 \
+++    --hash=sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c \
+++    --hash=sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86 \
+++    --hash=sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4 \
+++    --hash=sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c \
+++    --hash=sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34 \
+++    --hash=sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b \
+++    --hash=sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d \
+++    --hash=sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c \
+++    --hash=sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb \
+++    --hash=sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7 \
+++    --hash=sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737 \
+++    --hash=sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3 \
+++    --hash=sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d \
+++    --hash=sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358 \
+++    --hash=sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53 \
+++    --hash=sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78 \
+++    --hash=sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803 \
+++    --hash=sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a \
+++    --hash=sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f \
+++    --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
+++    --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
+++    # via -r thirdparty/python/requirements_lock.in
++ six==1.16.0 \
++     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
++     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
++-- 
++2.34.1
++
++
++From dd4e1c675dbcc2f64ae42779765c54c1523b99b2 Mon Sep 17 00:00:00 2001
++From: Andre Nguyen <andre-nguyen@users.noreply.github.com>
++Date: Fri, 25 Nov 2022 14:33:41 -0500
++Subject: [PATCH 05/27] Fix typos in readme
++
++---
++ README.md | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/README.md b/README.md
++index dd5cd8f..be183a2 100644
++--- a/README.md
+++++ b/README.md
++@@ -33,9 +33,9 @@ Here is a short list of major restrictions:
++ 
++ ## Getting started
++ 
++-### Prerequisits
+++### Prerequisites
++ 
++-Bazel needs to be available. We reccomend using [bazelisk](https://github.com/bazelbuild/bazelisk)
+++Bazel needs to be available. We recommend using [bazelisk](https://github.com/bazelbuild/bazelisk)
++ as a launch tool for Bazel.
++ 
++ ### Workspace setup
++-- 
++2.34.1
++
++
++From 1f369dd909884b7ae520f455b5d376d4a3e93d70 Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Wed, 27 Sep 2023 15:34:40 -0700
++Subject: [PATCH 06/27] Bump Bazel version to 6.3.1
++
++---
++ .bazelversion | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/.bazelversion b/.bazelversion
++index 7d3cdbf..f9da12e 100644
++--- a/.bazelversion
+++++ b/.bazelversion
++@@ -1 +1 @@
++-5.3.1
++\ No newline at end of file
+++6.3.2
++\ No newline at end of file
++-- 
++2.34.1
++
++
++From 9fd7eb9d1de0b6dbe1eb05275cc6e6bf6e3dc952 Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Wed, 27 Sep 2023 15:42:50 -0700
++Subject: [PATCH 07/27] Add additional distros
++
++---
++ repos/config/BUILD.bazel                    |   6 +-
++ repos/config/defs.bzl                       |  41 +-
++ repos/config/detail/generate_ros2_config.py |   8 +-
++ repos/config/detail/ros2_config.bzl         |   9 +-
++ repos/config/distros.bzl                    |  36 ++
++ repos/config/ros2_dashing.lock              | 520 ++++++++++++++++
++ repos/config/ros2_eloquent.lock             | 574 ++++++++++++++++++
++ repos/config/ros2_foxy.lock                 | 598 ++++++++++++++++++
++ repos/config/ros2_humble.lock               | 408 ++++++-------
++ repos/config/ros2_iron.lock                 | 640 ++++++++++++++++++++
++ 10 files changed, 2601 insertions(+), 239 deletions(-)
++ create mode 100644 repos/config/distros.bzl
++ create mode 100644 repos/config/ros2_dashing.lock
++ create mode 100644 repos/config/ros2_eloquent.lock
++ create mode 100644 repos/config/ros2_foxy.lock
++ create mode 100644 repos/config/ros2_iron.lock
++
++diff --git a/repos/config/BUILD.bazel b/repos/config/BUILD.bazel
++index bb45bbf..83497d2 100644
++--- a/repos/config/BUILD.bazel
+++++ b/repos/config/BUILD.bazel
++@@ -12,9 +12,9 @@
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++ 
++-exports_files(["ros2_humble.lock"])
+++exports_files(glob(["*.lock"]))
++ 
++ alias(
++     name = "repos_lock.update",
++-    actual = "//repos/config/detail:repos_lock.update"
++-)
++\ No newline at end of file
+++    actual = "//repos/config/detail:repos_lock.update",
+++)
++diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
++index 3767bd5..aea43a9 100644
++--- a/repos/config/defs.bzl
+++++ b/repos/config/defs.bzl
++@@ -12,34 +12,33 @@
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++ 
++-load("@rules_ros//repos/config/detail:ros2_config.bzl", _ros2_config = "ros2_config")
++-load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++-load("@bazel_tools//tools/build_defs/repo:git.bzl", _new_git_repository = "new_git_repository")
+++load("@rules_ros//repos/config/detail:ros2_config.bzl", "ros2_config")
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+++load("@rules_ros//repos/config:distros.bzl", "DISTROS")
++ 
++-def _configure_ros2_humble(*, name):
+++def _configure_ros2(*, name, distro_src):
+++    distro_src_wo_index = {k: v for k, v in distro_src.items() if k != "repo_index"}
+++    distro_src_wo_index["build_file_content"] = 'exports_files(["ros2.repos"])'
++ 
++-    _maybe(
++-        name = "ros2",
++-        repo_rule = _new_git_repository,
++-        remote = "https://github.com/ros2/ros2.git",
++-        build_file_content = 'exports_files(["ros2.repos"])',
++-        commit = "00f3ba9f73916a5eab322710edaaf197f0f10e31",
++-        shallow_since = "1660330451 -0400",
++-    )
++-    _ros2_config(
+++    maybe(name = "ros2", **distro_src_wo_index)
+++
+++    ros2_config(
++         name = name,
++-        repo_index = "@rules_ros//repos/config:ros2_humble.lock",
+++        repo_index = distro_src["repo_index"],
++         repo_index_overlays = [
++             "@rules_ros//repos/config:bazel.repos",
++-        ]
+++        ],
++     )
++ 
++ def configure_ros2(*, name = "ros2_config", distro):
++     """
++     """
++-    DISTROS = {
++-        "humble": _configure_ros2_humble,
++-    }
++-    if not distro in DISTROS:
++-        fail("Distro {} is not supported. Choose one of {}".format(distro, DISTROS.keys()))
++-    DISTROS[distro](name = name)
+++    if type(distro) == type(""):
+++        if not distro in DISTROS:
+++            fail("Distro {} is not supported. Choose one of {}".format(distro, DISTROS.keys()))
+++        distro_src = DISTROS[distro]
+++    else:
+++        if not type(distro) == type({}) or not "repo_rule" in distro:
+++            fail("Distro either needs to be a string (e.g. 'iron') or a dict with arguments for the maybe repo rule")
+++        distro_src = distro
+++    _configure_ros2(name = name, distro_src = distro_src)
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 234de73..450e517 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -35,12 +35,14 @@ def print_setup(repos):
++ 
++ 
++ def build_load_command(repo, spec):
++-    if spec['type'] == "git":
+++    if spec.get('type') == "git":
++         return build_remote_load_command(repo, spec)
++-    if spec['type'] == "local":
+++    if spec.get('type') == "local":
++         return build_local_load_command(repo, spec)
++     else:
++-        raise ValueError(f"Unknown repo type {spec['type']}")
+++        return f"""
+++    print("WARNING: Unknown repo type {spec.get('type')} for repo @{repo.replace('/', '.')}")
+++"""
++ 
++ 
++ def build_local_load_command(repo, spec):
++diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
++index aff3153..3faa5e4 100644
++--- a/repos/config/detail/ros2_config.bzl
+++++ b/repos/config/detail/ros2_config.bzl
++@@ -14,10 +14,6 @@
++ 
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "update_attrs")
++ 
++-BUILD_FILE_CONTENT = """
++-alias(name = 'ros2.lock', actual = '@rules_ros//repos/config:ros2_humble.lock')",
++-"""
++-
++ _archive_attrs = {
++     "repo_index": attr.label(
++         doc = "YAML file containing the details of every ros2 repository.",
++@@ -39,10 +35,9 @@ _archive_attrs = {
++ }
++ 
++ def _ros2_config_impl(ctx):
++-
++     result = ctx.execute(
++         [ctx.attr._generate_ros2_config, ctx.attr.repo_index] +
++-        ctx.attr.repo_index_overlays
+++        ctx.attr.repo_index_overlays,
++     )
++     if result.return_code != 0:
++         fail(result.stderr)
++@@ -58,5 +53,3 @@ ros2_config = repository_rule(
++     implementation = _ros2_config_impl,
++     attrs = _archive_attrs,
++ )
++-
++-
++diff --git a/repos/config/distros.bzl b/repos/config/distros.bzl
++new file mode 100644
++index 0000000..78084e4
++--- /dev/null
+++++ b/repos/config/distros.bzl
++@@ -0,0 +1,36 @@
+++load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+++load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+++
+++ROS_PROJECT = "https://github.com/ros2/ros2.git"
+++
+++_VERSIONS = [
+++    ("humble", "20230925", "57495eab51338591a0117b6763827607808e26344d134d6666ded66e479bdf8b"),
+++    ("iron", "20230912", "fd40b4d80eb9c27f57b2b59ad8a947cd5f7f34fc67c8df1d7cc0a659127fc9f7"),
+++    ("foxy", "20230620", "2cf7e3f9c5b01b7de2ec3c80097837758f3554e4f5c99a2aeca2bd7f4eb0bc1f"),
+++    ("galactic", "20221209", "fd251be0e1d16c1f943a8f083dce7b75c60fc2095404c5834209a68846be48c7"),
+++    ("eloquent", "2020-1212", "76f4b08bc4ecc6b126d2bdf5e8b86fa3d4b6d5101c122f7d0fd973aa77ef819a"),
+++    ("dashing", "20210610", "f0e00b81e93f764bef7591b0d9e3b89d73660696764663f18f926cd9795028c9"),
+++]
+++
+++_URL_TEMPLATE = "https://github.com/ros2/ros2/archive/refs/tags/release-{}-{}.tar.gz"
+++_STRIP_PREFIX_TEMPLATE = "ros2-release-{}-{}"
+++
+++DISTROS = {
+++    distro: dict(
+++        repo_rule = http_archive,
+++        url = _URL_TEMPLATE.format(distro, date),
+++        strip_prefix = _STRIP_PREFIX_TEMPLATE.format(distro, date),
+++        sha256 = sha,
+++        repo_index = "@rules_ros//repos/config:ros2_{}.lock".format(distro),
+++    )
+++    for distro, date, sha in _VERSIONS
+++} | {
+++    "rolling": dict(
+++        repo_rule = new_git_repository,
+++        remote = ROS_PROJECT,
+++        build_file_content = 'exports_files(["ros2.repos"])',
+++        commit = "1f5bd8ed43beea199dabe48bc8023af3aba9806c",
+++        #shallow_since = "1660330451 -0400",
+++        repo_index = "@rules_ros//repos/config:ros2_iron.lock",
+++    ),
+++}
++diff --git a/repos/config/ros2_dashing.lock b/repos/config/ros2_dashing.lock
++new file mode 100644
++index 0000000..893fb41
++--- /dev/null
+++++ b/repos/config/ros2_dashing.lock
++@@ -0,0 +1,520 @@
+++#
+++#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++repositories:
+++  ament/ament_cmake:
+++    hash: d75c029777ea4146728eba1947d390710020ee16
+++    shallow_since: 1606242243 -0800
+++    type: git
+++    url: https://github.com/ament/ament_cmake.git
+++    version: 0.7.6
+++  ament/ament_index:
+++    hash: 9d42ba13d7694ad8da5b1622e433e691996c4502
+++    shallow_since: 1571244457 -0700
+++    type: git
+++    url: https://github.com/ament/ament_index.git
+++    version: 0.7.2
+++  ament/ament_lint:
+++    hash: 0e725355914d44bb23ef0c34c045334b008a32dd
+++    shallow_since: 1594438323 -0400
+++    type: git
+++    url: https://github.com/ament/ament_lint.git
+++    version: 0.7.12
+++  ament/ament_package:
+++    hash: 68cb3ea4ad5009c2594eb835c34592e610cef975
+++    shallow_since: 1570825093 -0400
+++    type: git
+++    url: https://github.com/ament/ament_package.git
+++    version: 0.7.3
+++  ament/googletest:
+++    hash: 7e47d9759e8cd03322e5e19b451f44121dde98e2
+++    shallow_since: 1557357092 -0700
+++    type: git
+++    url: https://github.com/ament/googletest.git
+++    version: 1.8.9000
+++  ament/uncrustify_vendor:
+++    hash: 1d03dbdd78548289036d5c46d2a18b4c5a186456
+++    shallow_since: 1554990000 -0700
+++    type: git
+++    url: https://github.com/ament/uncrustify_vendor.git
+++    version: 1.2.0
+++  eProsima/Fast-CDR:
+++    hash: 174f6ff1d3a227c5c900a4587ee32fa888267f5e
+++    shallow_since: 1585310200 +0100
+++    type: git
+++    url: https://github.com/eProsima/Fast-CDR.git
+++    version: v1.0.13
+++  eProsima/Fast-RTPS:
+++    hash: 155087f6a3d445892e05d25a2e360513537457d6
+++    shallow_since: 1585322312 +0100
+++    type: git
+++    url: https://github.com/eProsima/Fast-DDS.git
+++    version: v1.8.4
+++  eclipse-cyclonedds/cyclonedds:
+++    hash: c261053186c455abc63ca5ac7d56c0808a59c364
+++    shallow_since: 1596471565 +0200
+++    type: git
+++    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+++    version: 0.7.0
+++  osrf/osrf_pycommon:
+++    hash: 0511d7b120048b826ff60465ba7532d332654b8c
+++    shallow_since: 1570737268 -0700
+++    type: git
+++    url: https://github.com/osrf/osrf_pycommon.git
+++    version: 0.1.9
+++  osrf/osrf_testing_tools_cpp:
+++    hash: a34bcc9e5bccc789f94933f9d2f967baf60d5e58
+++    shallow_since: 1606246952 -0800
+++    type: git
+++    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+++    version: 1.2.3
+++  ros-perception/laser_geometry:
+++    hash: ed2c9b548c77c7c373ef139ac0b40b0645a749fc
+++    shallow_since: 1530153917 -0700
+++    type: git
+++    url: https://github.com/ros-perception/laser_geometry.git
+++    version: 2.0.0
+++  ros-planning/navigation_msgs:
+++    hash: fe880e99d993e9d4dfbf37f00d839d32994610e1
+++    shallow_since: 1569867654 -0500
+++    type: git
+++    url: https://github.com/ros-planning/navigation_msgs.git
+++    version: 2.0.2
+++  ros-visualization/python_qt_binding:
+++    hash: a64b4929b3b5620c9785e9505c19e4e00a66c813
+++    shallow_since: 1569879255 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/python_qt_binding.git
+++    version: 1.0.2
+++  ros-visualization/qt_gui_core:
+++    hash: 004e25a5a118e9695d8fe4694b61200cc1e14b06
+++    shallow_since: 1590536933 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/qt_gui_core.git
+++    version: 1.0.9
+++  ros-visualization/rqt:
+++    hash: d06bacf1b5d7c356189a5f35e3dc0e20bd30643c
+++    shallow_since: 1612568901 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt.git
+++    version: 1.0.7
+++  ros-visualization/rqt_console:
+++    hash: addd6b251018aa66b4e5cc53d9c8e66d27f3eb06
+++    shallow_since: 1579042396 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_console.git
+++    version: 1.1.1
+++  ros-visualization/rqt_graph:
+++    hash: 874d7927cea0bfe721511ec403edd572e4363452
+++    shallow_since: 1600463827 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_graph.git
+++    version: 1.0.5
+++  ros-visualization/rqt_msg:
+++    hash: 5e9a8b02dc02039761bc5558adff130bdfb4e495
+++    shallow_since: 1557445337 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_msg.git
+++    version: 1.0.2
+++  ros-visualization/rqt_plot:
+++    hash: 986a95854601f2f1774a5d14c5de22a37f7e64ba
+++    shallow_since: 1570132866 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_plot.git
+++    version: 1.0.7
+++  ros-visualization/rqt_publisher:
+++    hash: 565ffc81069fe1ab53e5230d98be20cb95c6bea3
+++    shallow_since: 1570130261 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_publisher.git
+++    version: 1.1.0
+++  ros-visualization/rqt_py_console:
+++    hash: 359e33589e9c0dbe9861120250a0a67d43e92503
+++    shallow_since: 1544572306 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_py_console.git
+++    version: 1.0.0
+++  ros-visualization/rqt_service_caller:
+++    hash: 23a8213d750a25a555d8a4a18179063323188eb5
+++    shallow_since: 1559173297 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_service_caller.git
+++    version: 1.0.3
+++  ros-visualization/rqt_shell:
+++    hash: 56d240dddecadcd546d2638362533ef99f7c4e6b
+++    shallow_since: 1544582027 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_shell.git
+++    version: 1.0.0
+++  ros-visualization/rqt_srv:
+++    hash: 0126ee3040f94392ed626b489c44a25a694fc7e9
+++    shallow_since: 1544645384 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_srv.git
+++    version: 1.0.1
+++  ros-visualization/rqt_top:
+++    hash: af56baacaa26c23b13d3fc9713cb269199d9b557
+++    shallow_since: 1544596207 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_top.git
+++    version: 1.0.0
+++  ros/class_loader:
+++    hash: 88f52836487bcedb3013b983668116f17f6b2ed5
+++    shallow_since: 1584105098 -0400
+++    type: git
+++    url: https://github.com/ros/class_loader.git
+++    version: 1.3.3
+++  ros/pluginlib:
+++    hash: 2bdfd294699dc1a71116a3789a9843c9ea388560
+++    shallow_since: 1571344601 -0400
+++    type: git
+++    url: https://github.com/ros/pluginlib.git
+++    version: 2.3.3
+++  ros/resource_retriever:
+++    hash: 77f122028870de8f1470f690618c349840998b44
+++    shallow_since: 1594440619 -0400
+++    type: git
+++    url: https://github.com/ros/resource_retriever.git
+++    version: 2.1.3
+++  ros/ros_environment:
+++    hash: ba03418988d8af35019573a5e58c44afb2de76a2
+++    shallow_since: 1554993149 -0700
+++    type: git
+++    url: https://github.com/ros/ros_environment.git
+++    version: 2.3.0
+++  ros/ros_tutorials:
+++    hash: e85388de40a53a22f5056d878b525b06fc173a1e
+++    shallow_since: 1596642207 -0700
+++    type: git
+++    url: https://github.com/ros/ros_tutorials.git
+++    version: 1.0.3
+++  ros/urdfdom_headers:
+++    hash: 00c1c9c231e46b2300d04073ad696521758fa45c
+++    shallow_since: 1558394923 -0700
+++    type: git
+++    url: https://github.com/ros/urdfdom_headers.git
+++    version: 1.0.4
+++  ros2/ament_cmake_ros:
+++    hash: 070c7265354dc11ab04faac3b5ec7bb175b9e5d6
+++    shallow_since: 1555010761 -0700
+++    type: git
+++    url: https://github.com/ros2/ament_cmake_ros.git
+++    version: 0.7.0
+++  ros2/common_interfaces:
+++    hash: 30dbc60b45e22f2c88a4c46493388fdad3916845
+++    shallow_since: 1621610616 -0700
+++    type: git
+++    url: https://github.com/ros2/common_interfaces.git
+++    version: 0.7.1
+++  ros2/console_bridge_vendor:
+++    hash: d3be808a1b77028a152a8ee5aa56346ce32db987
+++    shallow_since: 1555013045 -0700
+++    type: git
+++    url: https://github.com/ros2/console_bridge_vendor.git
+++    version: 1.2.0
+++  ros2/demos:
+++    hash: c9e55acba6eaf377ccacce844853fd9eb20d1113
+++    shallow_since: 1570830190 -0700
+++    type: git
+++    url: https://github.com/ros2/demos.git
+++    version: 0.7.9
+++  ros2/eigen3_cmake_module:
+++    hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
+++    shallow_since: 1565307940 -0700
+++    type: git
+++    url: https://github.com/ros2/eigen3_cmake_module.git
+++    version: 0.1.1
+++  ros2/example_interfaces:
+++    hash: 5b118347114931620533aba142939b6a1db200bc
+++    shallow_since: 1559174767 -0700
+++    type: git
+++    url: https://github.com/ros2/example_interfaces.git
+++    version: 0.7.1
+++  ros2/examples:
+++    hash: 166c8294ab99417efde85c96783ff46ac2ac41af
+++    shallow_since: 1606266810 -0800
+++    type: git
+++    url: https://github.com/ros2/examples.git
+++    version: 0.7.5
+++  ros2/geometry2:
+++    hash: 2b639fa57c802386a40b0449cdb5c7ce1e5a62bb
+++    shallow_since: 1576000145 -0600
+++    type: git
+++    url: https://github.com/ros2/geometry2.git
+++    version: 0.11.6
+++  ros2/kdl_parser:
+++    hash: b3e9446f4af182fb499a07798a8b85de53677da7
+++    shallow_since: 1595362350 -0500
+++    type: git
+++    url: https://github.com/ros/kdl_parser.git
+++    version: 2.2.1
+++  ros2/launch:
+++    hash: 36a381026aacb586eaee2d0ba465414fd05a4cba
+++    shallow_since: 1570831179 -0700
+++    type: git
+++    url: https://github.com/ros2/launch.git
+++    version: 0.8.7
+++  ros2/launch_ros:
+++    hash: ab5db2fba3adc279d632c601ce7772aa78232852
+++    shallow_since: 1621611868 -0700
+++    type: git
+++    url: https://github.com/ros2/launch_ros.git
+++    version: 0.8.10
+++  ros2/libyaml_vendor:
+++    hash: c69f385ebb8c971b9bdd2a87fc983c5a12b12811
+++    shallow_since: 1529963667 -0700
+++    type: git
+++    url: https://github.com/ros2/libyaml_vendor.git
+++    version: 1.0.0
+++  ros2/message_filters:
+++    hash: 3d83c63fdcaf9263a5048a36e0573cc1cae11ed0
+++    shallow_since: 1575565019 -0500
+++    type: git
+++    url: https://github.com/ros2/message_filters.git
+++    version: 3.1.3
+++  ros2/orocos_kinematics_dynamics:
+++    hash: 65a38d304bc1d820160b263fe831aa17e0067a37
+++    shallow_since: 1594440803 -0400
+++    type: git
+++    url: https://github.com/ros2/orocos_kinematics_dynamics.git
+++    version: 3.2.2
+++  ros2/poco_vendor:
+++    hash: 6610e1fb283f566047077e25f34d55040f592900
+++    shallow_since: 1606249257 -0800
+++    type: git
+++    url: https://github.com/ros2/poco_vendor.git
+++    version: 1.2.1
+++  ros2/rcl:
+++    hash: f28fd0d5ee8e13a4955dbe84bd336eeee7e2be5d
+++    shallow_since: 1621608437 -0700
+++    type: git
+++    url: https://github.com/ros2/rcl.git
+++    version: 0.7.10
+++  ros2/rcl_interfaces:
+++    hash: bfa9c43dd7d8cfc5c6fcba8a164d8ef317a386d7
+++    shallow_since: 1559174983 -0700
+++    type: git
+++    url: https://github.com/ros2/rcl_interfaces.git
+++    version: 0.7.4
+++  ros2/rcl_logging:
+++    hash: 6b1880038fed2893557c931a202c16b974637e42
+++    shallow_since: 1557360130 -0500
+++    type: git
+++    url: https://github.com/ros2/rcl_logging.git
+++    version: 0.2.1
+++  ros2/rclcpp:
+++    hash: 403aac966271132feadffca93dcfb24f6ab90efb
+++    shallow_since: 1621608557 -0700
+++    type: git
+++    url: https://github.com/ros2/rclcpp.git
+++    version: 0.7.16
+++  ros2/rclpy:
+++    hash: 17576a7cc760bb3a0d04aa31832263766938a943
+++    shallow_since: 1594440478 -0400
+++    type: git
+++    url: https://github.com/ros2/rclpy.git
+++    version: 0.7.11
+++  ros2/rcpputils:
+++    hash: f8e638eb72bfbacea18ca1cf67c4f7d48561d9b2
+++    shallow_since: 1564532092 -0700
+++    type: git
+++    url: https://github.com/ros2/rcpputils.git
+++    version: 0.1.1
+++  ros2/rcutils:
+++    hash: f868e5cb0eaeb9ae9fc984f6783922f375411007
+++    shallow_since: 1606260966 -0800
+++    type: git
+++    url: https://github.com/ros2/rcutils.git
+++    version: 0.7.6
+++  ros2/realtime_support:
+++    hash: d9c7f16613d1a5a848df1beff71531d61269fd19
+++    shallow_since: 1557363033 -0700
+++    type: git
+++    url: https://github.com/ros2/realtime_support.git
+++    version: 0.7.1
+++  ros2/rmw:
+++    hash: 8652949435267cdf0fd65368f621146dea9a85eb
+++    shallow_since: 1560370615 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw.git
+++    version: 0.7.2
+++  ros2/rmw_connext:
+++    hash: ecb25fd543140f91e05d92720c34db1e3cb16b72
+++    shallow_since: 1606260513 -0800
+++    type: git
+++    url: https://github.com/ros2/rmw_connext.git
+++    version: 0.7.6
+++  ros2/rmw_cyclonedds:
+++    hash: 10b042d490e13ce0faf4971f92862c687cbe28f5
+++    shallow_since: 1600186908 -0500
+++    type: git
+++    url: https://github.com/ros2/rmw_cyclonedds.git
+++    version: de-0.7.0
+++  ros2/rmw_fastrtps:
+++    hash: 32a121a8c8d28cfe811d5179dd8bb1a75c48446b
+++    shallow_since: 1606260572 -0800
+++    type: git
+++    url: https://github.com/ros2/rmw_fastrtps.git
+++    version: 0.7.8
+++  ros2/rmw_implementation:
+++    hash: 9e3db8cf64e001a7ca8d20384ec32196f0a4d3cb
+++    shallow_since: 1576015315 -0500
+++    type: git
+++    url: https://github.com/ros2/rmw_implementation.git
+++    version: 0.7.2
+++  ros2/rmw_opensplice:
+++    hash: 824cfa4eec27be2d3fe14607e33d3b879cf7361c
+++    shallow_since: 1564620663 -0700
+++    type: git
+++    url: https://github.com/ros2/rmw_opensplice.git
+++    version: 0.7.3
+++  ros2/robot_state_publisher:
+++    hash: 64b5186fa6cbb694881ffe095f20fdb2cf324893
+++    shallow_since: 1575470809 -0800
+++    type: git
+++    url: https://github.com/ros/robot_state_publisher.git
+++    version: 2.2.5
+++  ros2/ros1_bridge:
+++    hash: 4677180c266bacb42dae6d606696efcf884928fd
+++    shallow_since: 1621613690 -0700
+++    type: git
+++    url: https://github.com/ros2/ros1_bridge.git
+++    version: 0.7.9
+++  ros2/ros2cli:
+++    hash: 8ff79e6cfc88a8d973c854a6709404eed6db47e0
+++    shallow_since: 1594441053 -0400
+++    type: git
+++    url: https://github.com/ros2/ros2cli.git
+++    version: 0.7.11
+++  ros2/ros_testing:
+++    hash: 87bef75b05c5e63e55e469e9560ad40f02c5bf2f
+++    shallow_since: 1571099941 -0400
+++    type: git
+++    url: https://github.com/ros2/ros_testing.git
+++    version: 0.1.1
+++  ros2/rosbag2:
+++    hash: 17581ca8430fb4e5d1611dde5e5ab161608b876b
+++    shallow_since: 1571244036 -0700
+++    type: git
+++    url: https://github.com/ros2/rosbag2.git
+++    version: 0.1.8
+++  ros2/rosidl:
+++    hash: 407b652ac8ca23beea2f1f24575dd57f0c9b4401
+++    shallow_since: 1606259638 -0800
+++    type: git
+++    url: https://github.com/ros2/rosidl.git
+++    version: 0.7.10
+++  ros2/rosidl_dds:
+++    hash: e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc
+++    shallow_since: 1557357026 -0500
+++    type: git
+++    url: https://github.com/ros2/rosidl_dds.git
+++    version: 0.7.1
+++  ros2/rosidl_defaults:
+++    hash: 926ce4d8f460fd8d7bb8c25544c2ebe294e691c1
+++    shallow_since: 1555243629 -0700
+++    type: git
+++    url: https://github.com/ros2/rosidl_defaults.git
+++    version: 0.7.0
+++  ros2/rosidl_python:
+++    hash: cbeb677f0afe54d2b5215ded894a27a80b6f7111
+++    shallow_since: 1606260003 -0800
+++    type: git
+++    url: https://github.com/ros2/rosidl_python.git
+++    version: 0.7.11
+++  ros2/rosidl_typesupport:
+++    hash: 38eb801f1f856a503676bb79875786b3a3b6d92d
+++    shallow_since: 1557357026 -0700
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport.git
+++    version: 0.7.1
+++  ros2/rosidl_typesupport_connext:
+++    hash: 852ac9a3da81e07befc4718414ca220930c39b93
+++    shallow_since: 1575569008 -0800
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_connext.git
+++    version: 0.7.3
+++  ros2/rosidl_typesupport_fastrtps:
+++    hash: 1482ec5a129d0a28a882df9335b85ec10a961c98
+++    shallow_since: 1606249600 -0800
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+++    version: 0.7.2
+++  ros2/rosidl_typesupport_opensplice:
+++    hash: 4ad5520055199ed3b011834575db16a08c599070
+++    shallow_since: 1567520741 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+++    version: 0.7.3
+++  ros2/rviz:
+++    hash: 693da2000dce463e4ddfc95caf9a30e2d4f24790
+++    shallow_since: 1621612242 -0700
+++    type: git
+++    url: https://github.com/ros2/rviz.git
+++    version: 6.1.8
+++  ros2/sros2:
+++    hash: f2ef72ad51cbe6c1254a7cf21ab12dc6b021356d
+++    shallow_since: 1592379751 +0200
+++    type: git
+++    url: https://github.com/ros2/sros2.git
+++    version: 0.7.2
+++  ros2/system_tests:
+++    hash: 0481d6bef4474b69afa45cc7ad3bd999e7fe6441
+++    shallow_since: 1564619935 -0700
+++    type: git
+++    url: https://github.com/ros2/system_tests.git
+++    version: 0.7.2
+++  ros2/test_interface_files:
+++    hash: a5dc898842fa23f3635298f140e97081a086d3e4
+++    shallow_since: 1559172037 -0700
+++    type: git
+++    url: https://github.com/ros2/test_interface_files.git
+++    version: 0.7.1
+++  ros2/tinydir_vendor:
+++    hash: 607fa785024557a756e60eae21b4dc9706136f81
+++    shallow_since: 1555254620 -0700
+++    type: git
+++    url: https://github.com/ros2/tinydir_vendor.git
+++    version: 1.1.0
+++  ros2/tinyxml2_vendor:
+++    hash: d0097aa9a8c2aa5990773dd81eb8b20d13d9fcf0
+++    shallow_since: 1547593812 -0800
+++    type: git
+++    url: https://github.com/ros2/tinyxml2_vendor.git
+++    version: 0.6.1
+++  ros2/tinyxml_vendor:
+++    hash: 3caa00bc33a5462e91eb5d44486ca3be4feaf62d
+++    shallow_since: 1554995391 -0700
+++    type: git
+++    url: https://github.com/ros2/tinyxml_vendor.git
+++    version: 0.7.0
+++  ros2/tlsf:
+++    hash: 1c4a13c3f76f79ce9f2a049a8b01cafbff775d4d
+++    shallow_since: 1529976968 +0000
+++    type: git
+++    url: https://github.com/ros2/tlsf.git
+++    version: 0.5.0
+++  ros2/unique_identifier_msgs:
+++    hash: 56c6f47aec363d47c66add1bb597db6cdaffc5d0
+++    shallow_since: 1587859523 -0700
+++    type: git
+++    url: https://github.com/ros2/unique_identifier_msgs.git
+++    version: 2.1.1
+++  ros2/urdf:
+++    hash: 9704679cf21e5b233df420f0cfb6dffab1741c42
+++    shallow_since: 1542738402 -0800
+++    type: git
+++    url: https://github.com/ros2/urdf.git
+++    version: 2.2.0
+++  ros2/urdfdom:
+++    hash: c7564771beb260fa7adaa7d584029811c40def1d
+++    shallow_since: 1555252035 -0700
+++    type: git
+++    url: https://github.com/ros/urdfdom.git
+++    version: 2.2.0
+++  ros2/yaml_cpp_vendor:
+++    hash: de4aa5e463e0549f688164b2bce8a4258766c614
+++    shallow_since: 1557352789 -0500
+++    type: git
+++    url: https://github.com/ros2/yaml_cpp_vendor.git
+++    version: 6.0.1
++diff --git a/repos/config/ros2_eloquent.lock b/repos/config/ros2_eloquent.lock
++new file mode 100644
++index 0000000..22a160e
++--- /dev/null
+++++ b/repos/config/ros2_eloquent.lock
++@@ -0,0 +1,574 @@
+++#
+++#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++repositories:
+++  ament/ament_cmake:
+++    hash: df62bb6bff09e39898bae0ddee2389d5b3524370
+++    shallow_since: 1606757242 +0000
+++    type: git
+++    url: https://github.com/ament/ament_cmake.git
+++    version: 0.8.3
+++  ament/ament_index:
+++    hash: 9d42ba13d7694ad8da5b1622e433e691996c4502
+++    shallow_since: 1571244457 -0700
+++    type: git
+++    url: https://github.com/ament/ament_index.git
+++    version: 0.7.2
+++  ament/ament_lint:
+++    hash: bc096819e71ae57c6740da02d1d74865ee009bb3
+++    shallow_since: 1607115033 -0600
+++    type: git
+++    url: https://github.com/ament/ament_lint.git
+++    version: 0.8.2
+++  ament/ament_package:
+++    hash: 9d245a3b2209fee71683973f1ba5e575acbf6e5a
+++    shallow_since: 1591381489 -0700
+++    type: git
+++    url: https://github.com/ament/ament_package.git
+++    version: 0.8.9
+++  ament/googletest:
+++    hash: 7e47d9759e8cd03322e5e19b451f44121dde98e2
+++    shallow_since: 1557357092 -0700
+++    type: git
+++    url: https://github.com/ament/googletest.git
+++    version: 1.8.9000
+++  ament/uncrustify_vendor:
+++    hash: 8d4f07a4bdf1c0d8a5aab3eb450d0a15de3e6f1e
+++    shallow_since: 1568741617 -0400
+++    type: git
+++    url: https://github.com/ament/uncrustify_vendor.git
+++    version: 1.3.0
+++  eProsima/Fast-CDR:
+++    hash: cc27c2490b694e97ca1bbcc169172fd63209bb90
+++    shallow_since: 1566903518 +0200
+++    type: git
+++    url: https://github.com/eProsima/Fast-CDR.git
+++    version: v1.0.11
+++  eProsima/Fast-DDS:
+++    hash: b5ae9e9c9ea7ce49c64c0ef3f6c96a3dc563b16f
+++    shallow_since: 1573725955 +0100
+++    type: git
+++    url: https://github.com/eProsima/Fast-DDS.git
+++    version: v1.9.3
+++  eProsima/foonathan_memory_vendor:
+++    hash: 017ff0bdfd2c93930bf525a01f8663a032337a14
+++    shallow_since: 1569302929 +0200
+++    type: git
+++    url: https://github.com/eProsima/foonathan_memory_vendor.git
+++    version: v0.3.0
+++  eclipse-cyclonedds/cyclonedds:
+++    hash: c261053186c455abc63ca5ac7d56c0808a59c364
+++    shallow_since: 1596471565 +0200
+++    type: git
+++    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+++    version: 0.7.0
+++  osrf/osrf_pycommon:
+++    hash: 0511d7b120048b826ff60465ba7532d332654b8c
+++    shallow_since: 1570737268 -0700
+++    type: git
+++    url: https://github.com/osrf/osrf_pycommon.git
+++    version: 0.1.9
+++  osrf/osrf_testing_tools_cpp:
+++    hash: ec743ff827473493d1437fdb0b477c6aa2fe7f17
+++    shallow_since: 1584498799 -0400
+++    type: git
+++    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+++    version: 1.2.2
+++  ros-perception/laser_geometry:
+++    hash: a615644c770006e66e4a78e4ed9107be5911790f
+++    shallow_since: 1580948914 -0800
+++    type: git
+++    url: https://github.com/ros-perception/laser_geometry.git
+++    version: 2.1.1
+++  ros-planning/navigation_msgs:
+++    hash: fe880e99d993e9d4dfbf37f00d839d32994610e1
+++    shallow_since: 1569867654 -0500
+++    type: git
+++    url: https://github.com/ros-planning/navigation_msgs.git
+++    version: 2.0.2
+++  ros-tracing/ros2_tracing:
+++    hash: 5cd2298545f9c1333126db0aaefd516eae17b141
+++    shallow_since: 1575926311 -0800
+++    type: git
+++    url: https://gitlab.com/ros-tracing/ros2_tracing.git
+++    version: 0.2.12
+++  ros-visualization/interactive_markers:
+++    hash: 674d15927caf41684833ec1f843cbb03781f148a
+++    shallow_since: 1571889026 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/interactive_markers.git
+++    version: 2.0.1
+++  ros-visualization/python_qt_binding:
+++    hash: 4ea84276fca25ef625e71bf1541716b17de10c71
+++    shallow_since: 1573609579 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/python_qt_binding.git
+++    version: 1.0.3
+++  ros-visualization/qt_gui_core:
+++    hash: 5de77352b48ff5724e521cac19bfdfad0b7a1aa8
+++    shallow_since: 1569880852 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/qt_gui_core.git
+++    version: 1.0.7
+++  ros-visualization/rqt:
+++    hash: f549803a6b3129b58e133e7fd19de7a4c1b9357f
+++    shallow_since: 1569885985 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt.git
+++    version: 1.0.5
+++  ros-visualization/rqt_action:
+++    hash: d6842bea658ecbcb83115c9bffe89bcf16a4b566
+++    shallow_since: 1551809854 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_action.git
+++    version: 1.0.1
+++  ros-visualization/rqt_console:
+++    hash: addd6b251018aa66b4e5cc53d9c8e66d27f3eb06
+++    shallow_since: 1579042396 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_console.git
+++    version: 1.1.1
+++  ros-visualization/rqt_graph:
+++    hash: 22952ef7604ed76f573cfae896c96c435203339a
+++    shallow_since: 1578336197 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_graph.git
+++    version: 1.0.4
+++  ros-visualization/rqt_msg:
+++    hash: 5e9a8b02dc02039761bc5558adff130bdfb4e495
+++    shallow_since: 1557445337 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_msg.git
+++    version: 1.0.2
+++  ros-visualization/rqt_plot:
+++    hash: 986a95854601f2f1774a5d14c5de22a37f7e64ba
+++    shallow_since: 1570132866 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_plot.git
+++    version: 1.0.7
+++  ros-visualization/rqt_publisher:
+++    hash: 565ffc81069fe1ab53e5230d98be20cb95c6bea3
+++    shallow_since: 1570130261 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_publisher.git
+++    version: 1.1.0
+++  ros-visualization/rqt_py_console:
+++    hash: 359e33589e9c0dbe9861120250a0a67d43e92503
+++    shallow_since: 1544572306 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_py_console.git
+++    version: 1.0.0
+++  ros-visualization/rqt_reconfigure:
+++    hash: b5a9516b1fc365f7d2ca07991b69ea7d4585a553
+++    shallow_since: 1570742618 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_reconfigure.git
+++    version: 1.0.4
+++  ros-visualization/rqt_service_caller:
+++    hash: 23a8213d750a25a555d8a4a18179063323188eb5
+++    shallow_since: 1559173297 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_service_caller.git
+++    version: 1.0.3
+++  ros-visualization/rqt_shell:
+++    hash: 56d240dddecadcd546d2638362533ef99f7c4e6b
+++    shallow_since: 1544582027 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_shell.git
+++    version: 1.0.0
+++  ros-visualization/rqt_srv:
+++    hash: 0126ee3040f94392ed626b489c44a25a694fc7e9
+++    shallow_since: 1544645384 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_srv.git
+++    version: 1.0.1
+++  ros-visualization/rqt_top:
+++    hash: af56baacaa26c23b13d3fc9713cb269199d9b557
+++    shallow_since: 1544596207 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_top.git
+++    version: 1.0.0
+++  ros-visualization/rqt_topic:
+++    hash: 2c83d5ad83322644495fc58d614dd2f07516a153
+++    shallow_since: 1573673433 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_topic.git
+++    version: 1.1.0
+++  ros/class_loader:
+++    hash: a7d2aadb4be603f54ded1d4f2fcd6e7c3622a16b
+++    shallow_since: 1579291969 +0000
+++    type: git
+++    url: https://github.com/ros/class_loader.git
+++    version: 1.4.1
+++  ros/kdl_parser:
+++    hash: b3e9446f4af182fb499a07798a8b85de53677da7
+++    shallow_since: 1595362350 -0500
+++    type: git
+++    url: https://github.com/ros/kdl_parser.git
+++    version: 2.2.1
+++  ros/pluginlib:
+++    hash: 6eca7691d046a060f24bb61ab380fa30d86fe621
+++    shallow_since: 1607115839 -0600
+++    type: git
+++    url: https://github.com/ros/pluginlib.git
+++    version: 2.4.2
+++  ros/resource_retriever:
+++    hash: 6cebdc0214a71662e9e5618515ed9dea94cd91fc
+++    shallow_since: 1575563397 -0500
+++    type: git
+++    url: https://github.com/ros/resource_retriever.git
+++    version: 2.2.1
+++  ros/robot_state_publisher:
+++    hash: 772a88a4c8cf973bf4bcf36276db32b2c75a8113
+++    shallow_since: 1571873830 -0700
+++    type: git
+++    url: https://github.com/ros/robot_state_publisher.git
+++    version: 2.3.1
+++  ros/ros_environment:
+++    hash: a0f400cfdf148298431cdc0323abc0908f310c09
+++    shallow_since: 1571870538 -0700
+++    type: git
+++    url: https://github.com/ros/ros_environment.git
+++    version: 2.4.1
+++  ros/ros_tutorials:
+++    hash: 519752af99a54a466d30cb31509c346e68f54c01
+++    shallow_since: 1573609159 -0800
+++    type: git
+++    url: https://github.com/ros/ros_tutorials.git
+++    version: 1.1.0
+++  ros/urdfdom:
+++    hash: c7564771beb260fa7adaa7d584029811c40def1d
+++    shallow_since: 1555252035 -0700
+++    type: git
+++    url: https://github.com/ros/urdfdom.git
+++    version: 2.2.0
+++  ros/urdfdom_headers:
+++    hash: 00c1c9c231e46b2300d04073ad696521758fa45c
+++    shallow_since: 1558394923 -0700
+++    type: git
+++    url: https://github.com/ros/urdfdom_headers.git
+++    version: 1.0.4
+++  ros2/ament_cmake_ros:
+++    hash: e7c18f52a32e42f8847e65661d0521e5c29238c4
+++    shallow_since: 1569344550 -0500
+++    type: git
+++    url: https://github.com/ros2/ament_cmake_ros.git
+++    version: 0.8.0
+++  ros2/common_interfaces:
+++    hash: 81663c07b93889c3d0afda9b99cd5f1c7c98c1f2
+++    shallow_since: 1571867898 -0700
+++    type: git
+++    url: https://github.com/ros2/common_interfaces.git
+++    version: 0.8.1
+++  ros2/console_bridge_vendor:
+++    hash: d3be808a1b77028a152a8ee5aa56346ce32db987
+++    shallow_since: 1555013045 -0700
+++    type: git
+++    url: https://github.com/ros2/console_bridge_vendor.git
+++    version: 1.2.0
+++  ros2/demos:
+++    hash: e1453fc25f0af51abe5aa6d75f5601f4ab69395c
+++    shallow_since: 1574228657 -0600
+++    type: git
+++    url: https://github.com/ros2/demos.git
+++    version: 0.8.4
+++  ros2/eigen3_cmake_module:
+++    hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
+++    shallow_since: 1565307940 -0700
+++    type: git
+++    url: https://github.com/ros2/eigen3_cmake_module.git
+++    version: 0.1.1
+++  ros2/example_interfaces:
+++    hash: 5b118347114931620533aba142939b6a1db200bc
+++    shallow_since: 1559174767 -0700
+++    type: git
+++    url: https://github.com/ros2/example_interfaces.git
+++    version: 0.7.1
+++  ros2/examples:
+++    hash: fbab64492748a462f9850db06a905c7b3ca957be
+++    shallow_since: 1607118777 -0600
+++    type: git
+++    url: https://github.com/ros2/examples.git
+++    version: 0.8.3
+++  ros2/geometry2:
+++    hash: a5e46e55e94ffe6420fc9a586c5bf6fb6cdad900
+++    shallow_since: 1607116536 -0600
+++    type: git
+++    url: https://github.com/ros2/geometry2.git
+++    version: 0.12.6
+++  ros2/launch:
+++    hash: 50763edc072b14be1af3d44256fa5b8f2b3eab7a
+++    shallow_since: 1607116772 -0600
+++    type: git
+++    url: https://github.com/ros2/launch.git
+++    version: 0.9.7
+++  ros2/launch_ros:
+++    hash: 07497cd1f6576b7d3aff79a490016d583f9f3dcb
+++    shallow_since: 1607116920 -0600
+++    type: git
+++    url: https://github.com/ros2/launch_ros.git
+++    version: 0.9.6
+++  ros2/libyaml_vendor:
+++    hash: c69f385ebb8c971b9bdd2a87fc983c5a12b12811
+++    shallow_since: 1529963667 -0700
+++    type: git
+++    url: https://github.com/ros2/libyaml_vendor.git
+++    version: 1.0.0
+++  ros2/message_filters:
+++    hash: 0b98d58e175ad93116aedb5782ce7c88f8846f3a
+++    shallow_since: 1574115205 -0800
+++    type: git
+++    url: https://github.com/ros2/message_filters.git
+++    version: 3.2.3
+++  ros2/orocos_kinematics_dynamics:
+++    hash: 1bc436e486c489ef71ff19ef31b807306c29f3bb
+++    shallow_since: 1573658255 -0500
+++    type: git
+++    url: https://github.com/ros2/orocos_kinematics_dynamics.git
+++    version: 3.2.1
+++  ros2/poco_vendor:
+++    hash: 6610e1fb283f566047077e25f34d55040f592900
+++    shallow_since: 1606249257 -0800
+++    type: git
+++    url: https://github.com/ros2/poco_vendor.git
+++    version: 1.2.1
+++  ros2/python_cmake_module:
+++    hash: c212c5e12b7c70baacc58684bb378c0fc8e1be86
+++    shallow_since: 1569264636 +0000
+++    type: git
+++    url: https://github.com/ros2/python_cmake_module.git
+++    version: 0.8.0
+++  ros2/rcl:
+++    hash: f5c01e4e2eb5d8f7fb16321f81815cd4b6b200bd
+++    shallow_since: 1607116198 -0600
+++    type: git
+++    url: https://github.com/ros2/rcl.git
+++    version: 0.8.5
+++  ros2/rcl_interfaces:
+++    hash: 93cedce2dacd25fa4f2969d022ccbe3f2903e3fe
+++    shallow_since: 1569518728 -0500
+++    type: git
+++    url: https://github.com/ros2/rcl_interfaces.git
+++    version: 0.8.0
+++  ros2/rcl_logging:
+++    hash: 3955fc4fc37e46dc397c52cebd3e40732db1157d
+++    shallow_since: 1571871211 +0000
+++    type: git
+++    url: https://github.com/ros2/rcl_logging.git
+++    version: 0.3.3
+++  ros2/rclcpp:
+++    hash: 82202ae71f14fed3a487da90d8f4f74c07c7d1f7
+++    shallow_since: 1607116009 -0600
+++    type: git
+++    url: https://github.com/ros2/rclcpp.git
+++    version: 0.8.5
+++  ros2/rclpy:
+++    hash: 126a9dff544ca8ae82444ad45d65a12a9a6e08f3
+++    shallow_since: 1607119307 -0600
+++    type: git
+++    url: https://github.com/ros2/rclpy.git
+++    version: 0.8.5
+++  ros2/rcpputils:
+++    hash: 33e2edb1dafd9dc1952e7f219c9ceee58905b831
+++    shallow_since: 1573612278 -0800
+++    type: git
+++    url: https://github.com/ros2/rcpputils.git
+++    version: 0.2.1
+++  ros2/rcutils:
+++    hash: ef201364d5af13f74a9c368f271c762326d838be
+++    shallow_since: 1607117730 -0600
+++    type: git
+++    url: https://github.com/ros2/rcutils.git
+++    version: 0.8.5
+++  ros2/realtime_support:
+++    hash: a9534f8638d58d38c57a26fa9a97642e642d3662
+++    shallow_since: 1573652897 -0600
+++    type: git
+++    url: https://github.com/ros2/realtime_support.git
+++    version: 0.8.2
+++  ros2/rmw:
+++    hash: 813b94ddd5650444b312304ad156f3b5d9f05e39
+++    shallow_since: 1571879357 -0700
+++    type: git
+++    url: https://github.com/ros2/rmw.git
+++    version: 0.8.1
+++  ros2/rmw_connext:
+++    hash: 15609cf48bc6d76390f3de2c3a45a245fdfaa7cf
+++    shallow_since: 1607118481 -0600
+++    type: git
+++    url: https://github.com/ros2/rmw_connext.git
+++    version: 0.8.2
+++  ros2/rmw_cyclonedds:
+++    hash: 10b042d490e13ce0faf4971f92862c687cbe28f5
+++    shallow_since: 1600186908 -0500
+++    type: git
+++    url: https://github.com/ros2/rmw_cyclonedds.git
+++    version: de-0.7.0
+++  ros2/rmw_fastrtps:
+++    hash: 0f904a13c6e8b6b32a2cf263d7c4d96a40be0884
+++    shallow_since: 1607118401 -0600
+++    type: git
+++    url: https://github.com/ros2/rmw_fastrtps.git
+++    version: 0.8.2
+++  ros2/rmw_implementation:
+++    hash: bb349e334fbfb665406f090d3f1c0ac7e04404c3
+++    shallow_since: 1573704951 -0500
+++    type: git
+++    url: https://github.com/ros2/rmw_implementation.git
+++    version: 0.8.2
+++  ros2/rmw_opensplice:
+++    hash: 1213249ca15e38225b374ddcacc3e03769f0ec78
+++    shallow_since: 1571891055 -0500
+++    type: git
+++    url: https://github.com/ros2/rmw_opensplice.git
+++    version: 0.8.1
+++  ros2/ros1_bridge:
+++    hash: b5e4931cefce6cc3351b31b04b0399a6d3bacac4
+++    shallow_since: 1607538853 +0000
+++    type: git
+++    url: https://github.com/ros2/ros1_bridge.git
+++    version: 0.8.3
+++  ros2/ros2cli:
+++    hash: 5d5b855369085d02631bc5bdd6ffb7fae680eb5b
+++    shallow_since: 1607117614 -0600
+++    type: git
+++    url: https://github.com/ros2/ros2cli.git
+++    version: 0.8.8
+++  ros2/ros_testing:
+++    hash: c06a59a3826a61884f2c8cdcd8c5a66c104192be
+++    shallow_since: 1569529607 +0000
+++    type: git
+++    url: https://github.com/ros2/ros_testing.git
+++    version: 0.2.0
+++  ros2/rosbag2:
+++    hash: 2b41ea40717b9228c0b736b6ea247799a0cf369e
+++    shallow_since: 1574128275 -0800
+++    type: git
+++    url: https://github.com/ros2/rosbag2.git
+++    version: 0.2.4
+++  ros2/rosidl:
+++    hash: 5f79cdcb7830999b527c2370b4397a3cc587374a
+++    shallow_since: 1607117948 -0600
+++    type: git
+++    url: https://github.com/ros2/rosidl.git
+++    version: 0.8.3
+++  ros2/rosidl_dds:
+++    hash: e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc
+++    shallow_since: 1557357026 -0500
+++    type: git
+++    url: https://github.com/ros2/rosidl_dds.git
+++    version: 0.7.1
+++  ros2/rosidl_defaults:
+++    hash: 94a24327f83e624eff5eb45ec675a53d534b3ffb
+++    shallow_since: 1569521531 -0500
+++    type: git
+++    url: https://github.com/ros2/rosidl_defaults.git
+++    version: 0.8.0
+++  ros2/rosidl_python:
+++    hash: 7adf415f0461f1c70db0c52802895ec700569ced
+++    shallow_since: 1607119114 -0600
+++    type: git
+++    url: https://github.com/ros2/rosidl_python.git
+++    version: 0.8.2
+++  ros2/rosidl_runtime_py:
+++    hash: fc2ea02f857d6a8faa9bc7fd658220801cbf5748
+++    shallow_since: 1573249219 -0600
+++    type: git
+++    url: https://github.com/ros2/rosidl_runtime_py.git
+++    version: 0.8.2
+++  ros2/rosidl_typesupport:
+++    hash: b51759ea94bfdc58afc8831d4c847c5891d14bc3
+++    shallow_since: 1607118075 -0600
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport.git
+++    version: 0.8.1
+++  ros2/rosidl_typesupport_connext:
+++    hash: d38c0b61db924f8c0cc3d95334463849af539cb8
+++    shallow_since: 1607118949 -0600
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_connext.git
+++    version: 0.8.5
+++  ros2/rosidl_typesupport_fastrtps:
+++    hash: b1d037b2f589ac78443f892d77f610a96c5f3e96
+++    shallow_since: 1569446233 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+++    version: 0.8.0
+++  ros2/rosidl_typesupport_opensplice:
+++    hash: 23274d5cb4db102b153eee7366a394acb3eee38c
+++    shallow_since: 1570210077 -0700
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
+++    version: 0.8.1
+++  ros2/rviz:
+++    hash: bd652f5e87d4cfad30bdc5457ab61c4286e8c85e
+++    shallow_since: 1606942491 +0000
+++    type: git
+++    url: https://github.com/ros2/rviz.git
+++    version: 7.0.7
+++  ros2/spdlog_vendor:
+++    hash: d78e5c8fa8cf87d0db0056e752b292f316e17929
+++    shallow_since: 1570123657 +0000
+++    type: git
+++    url: https://github.com/ros2/spdlog_vendor.git
+++    version: 1.0.1
+++  ros2/sros2:
+++    hash: aa15b4addd9a3b7c3fa45f82ad71407965fdb897
+++    shallow_since: 1592334052 +0200
+++    type: git
+++    url: https://github.com/ros2/sros2.git
+++    version: 0.8.2
+++  ros2/system_tests:
+++    hash: 1a54cb2a6c554ca89ff5a00af412cd552b84e243
+++    shallow_since: 1574294136 -0600
+++    type: git
+++    url: https://github.com/ros2/system_tests.git
+++    version: 0.8.0
+++  ros2/test_interface_files:
+++    hash: c4d710e3394ad09a71a257f5490688653fb441b3
+++    shallow_since: 1569343508 -0500
+++    type: git
+++    url: https://github.com/ros2/test_interface_files.git
+++    version: 0.8.0
+++  ros2/tinydir_vendor:
+++    hash: 9f1c63bc38b2928946fcc427a404faa4cacaeebb
+++    shallow_since: 1573612773 -0800
+++    type: git
+++    url: https://github.com/ros2/tinydir_vendor.git
+++    version: 1.1.1
+++  ros2/tinyxml2_vendor:
+++    hash: d0097aa9a8c2aa5990773dd81eb8b20d13d9fcf0
+++    shallow_since: 1547593812 -0800
+++    type: git
+++    url: https://github.com/ros2/tinyxml2_vendor.git
+++    version: 0.6.1
+++  ros2/tinyxml_vendor:
+++    hash: 3caa00bc33a5462e91eb5d44486ca3be4feaf62d
+++    shallow_since: 1554995391 -0700
+++    type: git
+++    url: https://github.com/ros2/tinyxml_vendor.git
+++    version: 0.7.0
+++  ros2/tlsf:
+++    hash: 1c4a13c3f76f79ce9f2a049a8b01cafbff775d4d
+++    shallow_since: 1529976968 +0000
+++    type: git
+++    url: https://github.com/ros2/tlsf.git
+++    version: 0.5.0
+++  ros2/unique_identifier_msgs:
+++    hash: 56c6f47aec363d47c66add1bb597db6cdaffc5d0
+++    shallow_since: 1587859523 -0700
+++    type: git
+++    url: https://github.com/ros2/unique_identifier_msgs.git
+++    version: 2.1.1
+++  ros2/urdf:
+++    hash: 9704679cf21e5b233df420f0cfb6dffab1741c42
+++    shallow_since: 1542738402 -0800
+++    type: git
+++    url: https://github.com/ros2/urdf.git
+++    version: 2.2.0
+++  ros2/yaml_cpp_vendor:
+++    hash: 54feb9dfcf88c6925ee16aed4d5d7eda1eea946c
+++    shallow_since: 1568908683 -0500
+++    type: git
+++    url: https://github.com/ros2/yaml_cpp_vendor.git
+++    version: 7.0.0
++diff --git a/repos/config/ros2_foxy.lock b/repos/config/ros2_foxy.lock
++new file mode 100644
++index 0000000..02fa9b4
++--- /dev/null
+++++ b/repos/config/ros2_foxy.lock
++@@ -0,0 +1,598 @@
+++#
+++#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++repositories:
+++  ament/ament_cmake:
+++    hash: 66de46c160e289ec8ac2f31407803ae56a271087
+++    shallow_since: 1685148721 +0000
+++    type: git
+++    url: https://github.com/ament/ament_cmake.git
+++    version: 0.9.12
+++  ament/ament_index:
+++    hash: 07492c3ada0f835464ef55178080f3df93c22292
+++    shallow_since: 1625088023 -0700
+++    type: git
+++    url: https://github.com/ament/ament_index.git
+++    version: 1.1.0
+++  ament/ament_lint:
+++    hash: 87f826b8f5c63b35d4d80c8f1520e35560326762
+++    shallow_since: 1678107663 +0000
+++    type: git
+++    url: https://github.com/ament/ament_lint.git
+++    version: 0.9.8
+++  ament/ament_package:
+++    hash: 3397bb0ae1cc93d93e1e27da31c0bcb0f4fe0f46
+++    shallow_since: 1619069192 -0700
+++    type: git
+++    url: https://github.com/ament/ament_package.git
+++    version: 0.9.5
+++  ament/google_benchmark_vendor:
+++    hash: 5f7ea6709618af640499b717f66899a33798390c
+++    shallow_since: 1600189262 -0700
+++    type: git
+++    url: https://github.com/ament/google_benchmark_vendor.git
+++    version: 0.0.3
+++  ament/googletest:
+++    hash: 7c20e2597a2d1503cf9afa159206ab8e9b233830
+++    shallow_since: 1630440154 -0700
+++    type: git
+++    url: https://github.com/ament/googletest.git
+++    version: 1.8.9001
+++  ament/uncrustify_vendor:
+++    hash: 0291bc988c45846400aca50cb973bf04a4de3d56
+++    shallow_since: 1586541269 +0000
+++    type: git
+++    url: https://github.com/ament/uncrustify_vendor.git
+++    version: 1.4.0
+++  eProsima/Fast-CDR:
+++    hash: 174f6ff1d3a227c5c900a4587ee32fa888267f5e
+++    shallow_since: 1585310200 +0100
+++    type: git
+++    url: https://github.com/eProsima/Fast-CDR.git
+++    version: v1.0.13
+++  eProsima/Fast-DDS:
+++    hash: 680cb71c7f3a9fb4b7e348d7d68ee2dbf4dd6d8d
+++    shallow_since: 1674805970 +0100
+++    type: git
+++    url: https://github.com/eProsima/Fast-DDS.git
+++    version: v2.1.3
+++  eProsima/foonathan_memory_vendor:
+++    hash: da062db05975d24a4b53de5a4122b47f6824997f
+++    shallow_since: 1637848987 +0100
+++    type: git
+++    url: https://github.com/eProsima/foonathan_memory_vendor.git
+++    version: v1.2.0
+++  eclipse-cyclonedds/cyclonedds:
+++    hash: c261053186c455abc63ca5ac7d56c0808a59c364
+++    shallow_since: 1596471565 +0200
+++    type: git
+++    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+++    version: 0.7.0
+++  osrf/osrf_pycommon:
+++    hash: cbf70da8ada598f81bd86cdc0654b66f44d88d49
+++    shallow_since: 1630447467 -0700
+++    type: git
+++    url: https://github.com/osrf/osrf_pycommon.git
+++    version: 0.1.11
+++  osrf/osrf_testing_tools_cpp:
+++    hash: 1798d936e48b945d07d1c3209573f7c6de6137d0
+++    shallow_since: 1630448207 -0700
+++    type: git
+++    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+++    version: 1.3.4
+++  ros-perception/laser_geometry:
+++    hash: 2a94c2114832496852804f120559e545a90058e3
+++    shallow_since: 1588279117 +0000
+++    type: git
+++    url: https://github.com/ros-perception/laser_geometry.git
+++    version: 2.2.0
+++  ros-planning/navigation_msgs:
+++    hash: fe880e99d993e9d4dfbf37f00d839d32994610e1
+++    shallow_since: 1569867654 -0500
+++    type: git
+++    url: https://github.com/ros-planning/navigation_msgs.git
+++    version: 2.0.2
+++  ros-tooling/libstatistics_collector:
+++    hash: 28e3c4634dc106b1e5209a776e9a56325f16c84a
+++    shallow_since: 1678980793 -0400
+++    type: git
+++    url: https://github.com/ros-tooling/libstatistics_collector.git
+++    version: 1.0.2
+++  ros-visualization/interactive_markers:
+++    hash: 649aa3f5cfaea70847568bd6a679c67c797e0634
+++    shallow_since: 1607467079 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/interactive_markers.git
+++    version: 2.1.3
+++  ros-visualization/python_qt_binding:
+++    hash: 7ff71b0bfd201cc1dbc328bcec42254dd55b523f
+++    shallow_since: 1611588397 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/python_qt_binding.git
+++    version: 1.0.6
+++  ros-visualization/qt_gui_core:
+++    hash: c62463ce58a331511e74ed0d9b50551cfd0e6fca
+++    shallow_since: 1630449477 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/qt_gui_core.git
+++    version: 1.1.3
+++  ros-visualization/rqt:
+++    hash: a545fbe3d36930f20e71c2df9bc318fa14dec392
+++    shallow_since: 1630449731 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt.git
+++    version: 1.1.2
+++  ros-visualization/rqt_action:
+++    hash: c4790fb653f37028a772ba51d524ba27f77899b0
+++    shallow_since: 1678960338 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_action.git
+++    version: 1.0.2
+++  ros-visualization/rqt_console:
+++    hash: 0ee70d7f2912c75e840a925b666ed794fb41383f
+++    shallow_since: 1657920903 +0900
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_console.git
+++    version: 1.1.2
+++  ros-visualization/rqt_graph:
+++    hash: e3495e424ba748605a5d08ebc35fb2b6a5a467b5
+++    shallow_since: 1643664354 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_graph.git
+++    version: 1.1.3
+++  ros-visualization/rqt_msg:
+++    hash: 6aec29bdb3079f545279f267fe8c237de177de30
+++    shallow_since: 1678960359 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_msg.git
+++    version: 1.1.1
+++  ros-visualization/rqt_plot:
+++    hash: d2e7329fd49cf72aa12ff7348dc2df2b93bb9fcb
+++    shallow_since: 1642183460 -0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_plot.git
+++    version: 1.1.1
+++  ros-visualization/rqt_publisher:
+++    hash: b1f49f95a5aa7d07187deb5c5b0954a140e0020d
+++    shallow_since: 1659469749 -0400
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_publisher.git
+++    version: 1.3.0
+++  ros-visualization/rqt_py_console:
+++    hash: 36ad6e467f7add9279a4cd54d3e02ebcbd936d5b
+++    shallow_since: 1630451545 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_py_console.git
+++    version: 1.0.2
+++  ros-visualization/rqt_reconfigure:
+++    hash: 9c848b0e5ff583f1161a7ba39ec5ac1fe9075be9
+++    shallow_since: 1620652868 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_reconfigure.git
+++    version: 1.0.8
+++  ros-visualization/rqt_service_caller:
+++    hash: c9afeb84e9db4807c895e345294f2d521abf3859
+++    shallow_since: 1630451643 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_service_caller.git
+++    version: 1.0.5
+++  ros-visualization/rqt_shell:
+++    hash: 50639b2252fc0d02bcc3361284b67baa44a87c3b
+++    shallow_since: 1630452741 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_shell.git
+++    version: 1.0.2
+++  ros-visualization/rqt_srv:
+++    hash: 46e8e71560008857456525ad7977aa6bd87391d5
+++    shallow_since: 1630452880 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_srv.git
+++    version: 1.0.3
+++  ros-visualization/rqt_top:
+++    hash: 0862fef3e4982d714d352ae8cd78f928af48c3c2
+++    shallow_since: 1630453266 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_top.git
+++    version: 1.0.2
+++  ros-visualization/rqt_topic:
+++    hash: 165c40154320ff613cc52e1375c6a48d30d548fd
+++    shallow_since: 1652229850 -0700
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_topic.git
+++    version: 1.3.0
+++  ros-visualization/tango_icons_vendor:
+++    hash: b349608986293db04c9d05b09f05685312a15ae6
+++    shallow_since: 1619722112 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/tango_icons_vendor.git
+++    version: 0.1.0
+++  ros/class_loader:
+++    hash: 58102cf049b20fcf361330ae7f400a89a530c23a
+++    shallow_since: 1658530578 -0700
+++    type: git
+++    url: https://github.com/ros/class_loader.git
+++    version: 2.0.3
+++  ros/kdl_parser:
+++    hash: 77d8ab5f6260283c1941e424e2100951c71d7892
+++    shallow_since: 1596836291 -0700
+++    type: git
+++    url: https://github.com/ros/kdl_parser.git
+++    version: 2.4.1
+++  ros/pluginlib:
+++    hash: df8ba5196fc0897e3ed9448437c32306f2708f5d
+++    shallow_since: 1643665148 -0800
+++    type: git
+++    url: https://github.com/ros/pluginlib.git
+++    version: 2.5.4
+++  ros/resource_retriever:
+++    hash: f20037d20a3a69c4f580a1f127b528884c3575ac
+++    shallow_since: 1607452438 -0800
+++    type: git
+++    url: https://github.com/ros/resource_retriever.git
+++    version: 2.3.4
+++  ros/robot_state_publisher:
+++    hash: a1346e963b04b2c452eccdcbf69c7b8f81db314d
+++    shallow_since: 1628083173 +0000
+++    type: git
+++    url: https://github.com/ros/robot_state_publisher.git
+++    version: 2.4.5
+++  ros/ros_environment:
+++    hash: acb84116c976fdd9441bdf5b22337b10bfec2b2a
+++    shallow_since: 1658530668 -0700
+++    type: git
+++    url: https://github.com/ros/ros_environment.git
+++    version: 2.5.1
+++  ros/ros_tutorials:
+++    hash: 2a2eba45652c62f907daec3338fcc36cdae90fb5
+++    shallow_since: 1658530772 -0700
+++    type: git
+++    url: https://github.com/ros/ros_tutorials.git
+++    version: 1.2.6
+++  ros/urdfdom:
+++    hash: 219c51f1aaec87f85ea696ef264d8f096cd39065
+++    shallow_since: 1601924035 +0000
+++    type: git
+++    url: https://github.com/ros/urdfdom.git
+++    version: 2.3.3
+++  ros/urdfdom_headers:
+++    hash: a15d906ff16a7fcbf037687b9c63b946c0cc04a1
+++    shallow_since: 1588962007 -0700
+++    type: git
+++    url: https://github.com/ros/urdfdom_headers.git
+++    version: 1.0.5
+++  ros2/ament_cmake_ros:
+++    hash: 7b6b599c3fc8023806db2a97b344e8610902adac
+++    shallow_since: 1620823254 +0000
+++    type: git
+++    url: https://github.com/ros2/ament_cmake_ros.git
+++    version: 0.9.2
+++  ros2/common_interfaces:
+++    hash: 6356bc82f3a034f5d2c61c6760df0007a6cadfb0
+++    shallow_since: 1640218063 +0000
+++    type: git
+++    url: https://github.com/ros2/common_interfaces.git
+++    version: 2.0.5
+++  ros2/console_bridge_vendor:
+++    hash: 86cb35321cf27f747ca07b3759ccacf5798dfd01
+++    shallow_since: 1618437921 -0700
+++    type: git
+++    url: https://github.com/ros2/console_bridge_vendor.git
+++    version: 1.2.4
+++  ros2/demos:
+++    hash: 1d01c8e3d06644c0d706ef83697a68efda7d0ad4
+++    shallow_since: 1658775204 -0700
+++    type: git
+++    url: https://github.com/ros2/demos.git
+++    version: 0.9.4
+++  ros2/eigen3_cmake_module:
+++    hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
+++    shallow_since: 1565307940 -0700
+++    type: git
+++    url: https://github.com/ros2/eigen3_cmake_module.git
+++    version: 0.1.1
+++  ros2/example_interfaces:
+++    hash: e3caaaf66bf664afc6c59d88a127f9c15597107e
+++    shallow_since: 1616077283 +0000
+++    type: git
+++    url: https://github.com/ros2/example_interfaces.git
+++    version: 0.9.1
+++  ros2/examples:
+++    hash: 355adf068fccd1b147acd89de62ad7d1bece9a78
+++    shallow_since: 1607453205 -0800
+++    type: git
+++    url: https://github.com/ros2/examples.git
+++    version: 0.9.4
+++  ros2/geometry2:
+++    hash: d1dc38b8a0e706fbd67a800a241fee950fce39f4
+++    shallow_since: 1678961741 +0000
+++    type: git
+++    url: https://github.com/ros2/geometry2.git
+++    version: 0.13.14
+++  ros2/launch:
+++    hash: acfe0766a72474872587eb38dfdc1b04a177763b
+++    shallow_since: 1665608331 -0700
+++    type: git
+++    url: https://github.com/ros2/launch.git
+++    version: 0.10.10
+++  ros2/launch_ros:
+++    hash: 68e2b620865a7bacc3bb4009ea607f96a5a9628e
+++    shallow_since: 1663027177 -0700
+++    type: git
+++    url: https://github.com/ros2/launch_ros.git
+++    version: 0.11.7
+++  ros2/libyaml_vendor:
+++    hash: 4d360d783b3018dfaed6d9ab9c736b720c109702
+++    shallow_since: 1618436898 -0700
+++    type: git
+++    url: https://github.com/ros2/libyaml_vendor.git
+++    version: 1.0.4
+++  ros2/message_filters:
+++    hash: 5042d46bee8d4e31f64fe5610c1c4c2401e62788
+++    shallow_since: 1686020953 +0000
+++    type: git
+++    url: https://github.com/ros2/message_filters.git
+++    version: 3.2.7
+++  ros2/mimick_vendor:
+++    hash: 1328d4fd261e5c1c22620bf60ac4292992f9df9d
+++    shallow_since: 1616098264 -0700
+++    type: git
+++    url: https://github.com/ros2/mimick_vendor.git
+++    version: 0.2.6
+++  ros2/orocos_kinematics_dynamics:
+++    hash: 76b0f4ea5ea4f4212dc9d2d38ffa913560f7d798
+++    shallow_since: 1678962243 +0000
+++    type: git
+++    url: https://github.com/ros2/orocos_kinematics_dynamics.git
+++    version: 3.3.5
+++  ros2/performance_test_fixture:
+++    hash: afb01872d0c03e31cd4fda04e91af8e5548de0a3
+++    shallow_since: 1658776414 -0700
+++    type: git
+++    url: https://github.com/ros2/performance_test_fixture.git
+++    version: 0.0.9
+++  ros2/python_cmake_module:
+++    hash: 45a2744285c7ba310bdc6aeda1aa7e33186dab4a
+++    shallow_since: 1616076958 +0000
+++    type: git
+++    url: https://github.com/ros2/python_cmake_module.git
+++    version: 0.8.1
+++  ros2/rcl:
+++    hash: 287ccd9ed06ff5bdded4dfb1130920d592a71bb7
+++    shallow_since: 1658776609 -0700
+++    type: git
+++    url: https://github.com/ros2/rcl.git
+++    version: 1.1.14
+++  ros2/rcl_interfaces:
+++    hash: 48cb91129051a494f3b4b097dccd6c921bb50552
+++    shallow_since: 1590522301 +0000
+++    type: git
+++    url: https://github.com/ros2/rcl_interfaces.git
+++    version: 1.0.0
+++  ros2/rcl_logging:
+++    hash: d22a6630f039bee97c6667394def926a5426a673
+++    shallow_since: 1618435530 -0700
+++    type: git
+++    url: https://github.com/ros2/rcl_logging.git
+++    version: 1.1.0
+++  ros2/rclcpp:
+++    hash: b0c25d5f22237d42e2cedad05dbb2e5cc31a3cf4
+++    shallow_since: 1685154213 +0000
+++    type: git
+++    url: https://github.com/ros2/rclcpp.git
+++    version: 2.4.3
+++  ros2/rclpy:
+++    hash: 8cf7680362cd9f84fbb2f882be004296316b9ddd
+++    shallow_since: 1685154247 +0000
+++    type: git
+++    url: https://github.com/ros2/rclpy.git
+++    version: 1.0.13
+++  ros2/rcpputils:
+++    hash: f4ce24de0b9b6b2c0c3807d6ce43418d4e1db331
+++    shallow_since: 1630457027 -0700
+++    type: git
+++    url: https://github.com/ros2/rcpputils.git
+++    version: 1.3.2
+++  ros2/rcutils:
+++    hash: 7cc5a47ee5d85d605d2291c1b04ac570a4c0faf6
+++    shallow_since: 1678961835 +0000
+++    type: git
+++    url: https://github.com/ros2/rcutils.git
+++    version: 1.1.5
+++  ros2/realtime_support:
+++    hash: 934621219b8421f52fdd9a980e3011131a6a2943
+++    shallow_since: 1588277808 +0000
+++    type: git
+++    url: https://github.com/ros2/realtime_support.git
+++    version: 0.9.0
+++  ros2/rmw:
+++    hash: 7fa45cb0d86fef00488e707b9ef37914d7ff0369
+++    shallow_since: 1678961864 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw.git
+++    version: 1.0.4
+++  ros2/rmw_connext:
+++    hash: 86ba57ddad8d3a653a49c10b1bd736a226856b94
+++    shallow_since: 1607456760 -0800
+++    type: git
+++    url: https://github.com/ros2/rmw_connext.git
+++    version: 1.0.3
+++  ros2/rmw_cyclonedds:
+++    hash: c12abc56983204f1d91f2d839d394528c7b29b42
+++    shallow_since: 1663705274 -0700
+++    type: git
+++    url: https://github.com/ros2/rmw_cyclonedds.git
+++    version: 0.7.11
+++  ros2/rmw_dds_common:
+++    hash: 39d01cf8b174ffbd09e9601893f82390a770525a
+++    shallow_since: 1618434424 -0700
+++    type: git
+++    url: https://github.com/ros2/rmw_dds_common.git
+++    version: 1.0.3
+++  ros2/rmw_fastrtps:
+++    hash: 7da03b330655d0cdad08e60c7536e85526b62b12
+++    shallow_since: 1685154262 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw_fastrtps.git
+++    version: 1.3.2
+++  ros2/rmw_implementation:
+++    hash: a21d275a56140977802a82373c8796d1f7fac636
+++    shallow_since: 1643666512 -0800
+++    type: git
+++    url: https://github.com/ros2/rmw_implementation.git
+++    version: 1.0.3
+++  ros2/ros1_bridge:
+++    hash: 689a932499befbd1ec3cb273a1054430e55a43c3
+++    shallow_since: 1685154274 +0000
+++    type: git
+++    url: https://github.com/ros2/ros1_bridge.git
+++    version: 0.9.7
+++  ros2/ros2_tracing:
+++    hash: f10fb2c13775fa0220833c5fa4ff82660640362a
+++    shallow_since: 1608651744 -0500
+++    type: git
+++    url: https://github.com/ros2/ros2_tracing.git
+++    version: 1.0.5
+++  ros2/ros2cli:
+++    hash: 26715cbb0948258d6f04b94c909d035c5130456a
+++    shallow_since: 1678961891 +0000
+++    type: git
+++    url: https://github.com/ros2/ros2cli.git
+++    version: 0.9.13
+++  ros2/ros2cli_common_extensions:
+++    hash: 4f2d47f4417475c5036c9930b5d348a5e0774007
+++    shallow_since: 1616076624 +0000
+++    type: git
+++    url: https://github.com/ros2/ros2cli_common_extensions.git
+++    version: 0.1.1
+++  ros2/ros_testing:
+++    hash: 45055af5100f981454f2c4c6f672e0e16fe0d0c3
+++    shallow_since: 1588232802 -0700
+++    type: git
+++    url: https://github.com/ros2/ros_testing.git
+++    version: 0.2.1
+++  ros2/rosbag2:
+++    hash: 77f5a51b4d5cd70ea6a78d53cffe964e3b9afaf7
+++    shallow_since: 1685547940 -0700
+++    type: git
+++    url: https://github.com/ros2/rosbag2.git
+++    version: 0.3.11
+++  ros2/rosidl:
+++    hash: 62bc7072d9078cfd7c63ebb1d12ca6e9732491b4
+++    shallow_since: 1685154334 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl.git
+++    version: 1.3.1
+++  ros2/rosidl_dds:
+++    hash: e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc
+++    shallow_since: 1557357026 -0500
+++    type: git
+++    url: https://github.com/ros2/rosidl_dds.git
+++    version: 0.7.1
+++  ros2/rosidl_defaults:
+++    hash: cbc7ffd38d98c5b15823fc62b0891d2264ae4472
+++    shallow_since: 1618433870 -0700
+++    type: git
+++    url: https://github.com/ros2/rosidl_defaults.git
+++    version: 1.0.1
+++  ros2/rosidl_python:
+++    hash: 6630bdf134b0d37e466c6d232e57e7de268be1b3
+++    shallow_since: 1678961921 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_python.git
+++    version: 0.9.7
+++  ros2/rosidl_runtime_py:
+++    hash: 63a9c99ad735ef08b9cfda69ba35322b5f8b75f3
+++    shallow_since: 1616078071 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_runtime_py.git
+++    version: 0.9.1
+++  ros2/rosidl_typesupport:
+++    hash: 08bec09e39f68a29ca15d8177f084118a47eaa92
+++    shallow_since: 1685154344 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport.git
+++    version: 1.0.3
+++  ros2/rosidl_typesupport_connext:
+++    hash: 3cde17b7b5eeaa460e4593ce44f6dbf3ebcbfeef
+++    shallow_since: 1618433168 -0700
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_connext.git
+++    version: 1.0.3
+++  ros2/rosidl_typesupport_fastrtps:
+++    hash: 9741bc17dedbf6a4f3fed86c6d5bc30c1603d0f0
+++    shallow_since: 1630458352 -0700
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+++    version: 1.0.4
+++  ros2/rpyutils:
+++    hash: 3e41fe4d71bc16f5a727a010f835fb49376b52b3
+++    shallow_since: 1599856543 -0700
+++    type: git
+++    url: https://github.com/ros2/rpyutils.git
+++    version: 0.2.0
+++  ros2/rviz:
+++    hash: 22179fc7a2fed72cd3f38e6712c62e2228a36001
+++    shallow_since: 1678961939 +0000
+++    type: git
+++    url: https://github.com/ros2/rviz.git
+++    version: 8.2.8
+++  ros2/spdlog_vendor:
+++    hash: 8eb6d4f2c64e7166596e4a57f7293b899ece34e0
+++    shallow_since: 1617908033 -0700
+++    type: git
+++    url: https://github.com/ros2/spdlog_vendor.git
+++    version: 1.1.3
+++  ros2/sros2:
+++    hash: f67f66ec39ae4dc35a58493f76558fba36d5d88d
+++    shallow_since: 1643667677 -0800
+++    type: git
+++    url: https://github.com/ros2/sros2.git
+++    version: 0.9.5
+++  ros2/system_tests:
+++    hash: ac07337c0b26b54b8c13403e7fce417132c1f359
+++    shallow_since: 1643667750 -0800
+++    type: git
+++    url: https://github.com/ros2/system_tests.git
+++    version: 0.9.2
+++  ros2/test_interface_files:
+++    hash: d0ee98f449c428fc2afa888b06fea48b87dc6645
+++    shallow_since: 1616075821 +0000
+++    type: git
+++    url: https://github.com/ros2/test_interface_files.git
+++    version: 0.8.1
+++  ros2/tinyxml2_vendor:
+++    hash: 2905a56d59f0e1de436d83a7035ab850a5a75c8f
+++    shallow_since: 1616075299 +0000
+++    type: git
+++    url: https://github.com/ros2/tinyxml2_vendor.git
+++    version: 0.7.4
+++  ros2/tinyxml_vendor:
+++    hash: 8d5ec29ca6ba2716006ad84553016cb03b237716
+++    shallow_since: 1616075138 +0000
+++    type: git
+++    url: https://github.com/ros2/tinyxml_vendor.git
+++    version: 0.8.2
+++  ros2/tlsf:
+++    hash: 1c4a13c3f76f79ce9f2a049a8b01cafbff775d4d
+++    shallow_since: 1529976968 +0000
+++    type: git
+++    url: https://github.com/ros2/tlsf.git
+++    version: 0.5.0
+++  ros2/unique_identifier_msgs:
+++    hash: 099923f53d58aa8eba2e1590523457f9d7f20eed
+++    shallow_since: 1617907574 -0700
+++    type: git
+++    url: https://github.com/ros2/unique_identifier_msgs.git
+++    version: 2.1.3
+++  ros2/urdf:
+++    hash: 533de85e9a4611fc42855b1d65d9f32cb42b0d6b
+++    shallow_since: 1590548494 -0700
+++    type: git
+++    url: https://github.com/ros2/urdf.git
+++    version: 2.4.0
+++  ros2/yaml_cpp_vendor:
+++    hash: 7c80af3b3178d645283bed0817c70af48ca97944
+++    shallow_since: 1663960122 -0700
+++    type: git
+++    url: https://github.com/ros2/yaml_cpp_vendor.git
+++    version: 7.0.3
++diff --git a/repos/config/ros2_humble.lock b/repos/config/ros2_humble.lock
++index ca5cdc1..8fa3af3 100644
++--- a/repos/config/ros2_humble.lock
+++++ b/repos/config/ros2_humble.lock
++@@ -3,47 +3,47 @@
++ #
++ repositories:
++   ament/ament_cmake:
++-    hash: 8050b39fe960e0b6d12c4611ff2b258456138bbb
++-    shallow_since: 1660310386 -0400
+++    hash: 571379977af23528fb805f812c0e20466e140fb1
+++    shallow_since: 1687452086 -0700
++     type: git
++     url: https://github.com/ament/ament_cmake.git
++-    version: humble
+++    version: 1.3.5
++   ament/ament_index:
++     hash: f019d6c40991799a13b18c9c3dcc583e3fde0381
++     shallow_since: 1646168510 +0000
++     type: git
++     url: https://github.com/ament/ament_index.git
++-    version: humble
+++    version: 1.4.0
++   ament/ament_lint:
++-    hash: 159b10de6c710c7838da8cf8a7420245a9c8e89a
++-    shallow_since: 1652131557 -0700
+++    hash: 03609e90e76d9be745dfdf8846dd8ee1ba92f5ec
+++    shallow_since: 1695129776 +0000
++     type: git
++     url: https://github.com/ament/ament_lint.git
++-    version: humble
+++    version: 0.12.8
++   ament/ament_package:
++     hash: f8ea958fd02cff6f4192425e28566369c92b5e34
++     shallow_since: 1642531281 -0800
++     type: git
++     url: https://github.com/ament/ament_package.git
++-    version: humble
+++    version: 0.14.0
++   ament/google_benchmark_vendor:
++-    hash: f2ec348081b438f34c550123a8528d5e29482e81
++-    shallow_since: 1648581335 +0000
+++    hash: d75f3a8897a8846064e00c3ac3be46db1f98d51e
+++    shallow_since: 1689716271 +0000
++     type: git
++     url: https://github.com/ament/google_benchmark_vendor.git
++-    version: humble
+++    version: 0.1.2
++   ament/googletest:
++     hash: 6df7425fdcbd368d2d1b99ffd89b9168014abb07
++     shallow_since: 1642171980 -0800
++     type: git
++     url: https://github.com/ament/googletest.git
++-    version: humble
+++    version: 1.10.9004
++   ament/uncrustify_vendor:
++     hash: ec8f8b4d03483671e8ea2b3039f1015f92b0ef89
++     shallow_since: 1648503100 +0000
++     type: git
++     url: https://github.com/ament/uncrustify_vendor.git
++-    version: humble
+++    version: 2.0.2
++   eProsima/Fast-CDR:
++     hash: da2987299ee3104bb0393cf0afc8aad6fb848dc1
++     shallow_since: 1647345218 +0100
++@@ -51,572 +51,572 @@ repositories:
++     url: https://github.com/eProsima/Fast-CDR.git
++     version: v1.0.24
++   eProsima/Fast-DDS:
++-    hash: 4b77c39e9bb263a7fe79310e9e9790512790c52f
++-    shallow_since: 1664965571 +0200
+++    hash: cffaa679ec8cd9c84b4d5b3fe1e3c22974d63be0
+++    shallow_since: 1691144938 +0200
++     type: git
++     url: https://github.com/eProsima/Fast-DDS.git
++-    version: 2.6.x
+++    version: v2.6.6
++   eProsima/foonathan_memory_vendor:
++-    hash: 5d315b2147585688368ecd9657ab6d628d077949
++-    shallow_since: 1645699214 +0100
+++    hash: e91681a25711c1811b2eaf2ba1e6996e0d9ecc84
+++    shallow_since: 1683727792 +0200
++     type: git
++     url: https://github.com/eProsima/foonathan_memory_vendor.git
++-    version: master
+++    version: v1.3.1
++   eclipse-cyclonedds/cyclonedds:
++-    hash: 0e2cd3e303be2171dd0e4fc685cc5031f70b0f52
++-    shallow_since: 1652445884 +0200
+++    hash: 63b6eab0e0660009eaf5e54d10509ea587ce199e
+++    shallow_since: 1679487279 +0100
++     type: git
++     url: https://github.com/eclipse-cyclonedds/cyclonedds.git
++-    version: releases/0.9.x
+++    version: 0.10.3
++   eclipse-iceoryx/iceoryx:
++-    hash: f756b7c99ddf714d05929374492b34c5c69355bb
++-    shallow_since: 1649434233 +0200
+++    hash: 40ef24e9515940564af63987234d51dc7f02f6b3
+++    shallow_since: 1675094707 +0100
++     type: git
++     url: https://github.com/eclipse-iceoryx/iceoryx.git
++-    version: release_2.0
+++    version: v2.0.3
++   ignition/ignition_cmake2_vendor:
++     hash: adcee1687a6f77bdc345702d7ce1f518e97a6a66
++     shallow_since: 1648558265 +0000
++     type: git
++     url: https://github.com/ignition-release/ignition_cmake2_vendor.git
++-    version: humble
+++    version: 0.0.2
++   ignition/ignition_math6_vendor:
++     hash: 177e74c31767e60c5bd8167f9ec66017b8e8020b
++     shallow_since: 1648558450 +0000
++     type: git
++     url: https://github.com/ignition-release/ignition_math6_vendor.git
++-    version: humble
+++    version: 0.0.2
++   osrf/osrf_pycommon:
++-    hash: d03cf0319c1110f0fa6fa66586e884ab87f5a516
++-    shallow_since: 1652230841 -0700
+++    hash: d70a3bd3c8aa23bc9c2fff267a5b12d674516646
+++    shallow_since: 1649454420 -0700
++     type: git
++     url: https://github.com/osrf/osrf_pycommon.git
++-    version: master
+++    version: 2.0.2
++   osrf/osrf_testing_tools_cpp:
++-    hash: 330849044357701c83ce2222845e045eb3c622bf
++-    shallow_since: 1662991356 -0500
+++    hash: ccfe94a685884155cb619896df1e71b8507c5c70
+++    shallow_since: 1667830580 -0600
++     type: git
++     url: https://github.com/osrf/osrf_testing_tools_cpp.git
++-    version: master
+++    version: 1.5.2
++   ros-perception/image_common:
++-    hash: 40e0df25928950d757058302c29526667c385cbe
++-    shallow_since: 1648187870 +0000
+++    hash: 7ebae2f92257e1746fd9ec7787fb820a6f28d91a
+++    shallow_since: 1692024443 +0200
++     type: git
++     url: https://github.com/ros-perception/image_common.git
++-    version: humble
+++    version: 3.1.7
++   ros-perception/laser_geometry:
++     hash: ba53212e6908e6f4e022a1ae2fb3b5bb1388d1d0
++     shallow_since: 1646168108 +0000
++     type: git
++     url: https://github.com/ros-perception/laser_geometry.git
++-    version: humble
+++    version: 2.4.0
++   ros-planning/navigation_msgs:
++     hash: 1d8683359734a2c829b5cdb6b5a4e015bbbcb6a5
++     shallow_since: 1616703818 +0000
++     type: git
++     url: https://github.com/ros-planning/navigation_msgs.git
++-    version: humble
+++    version: 2.1.0
++   ros-tooling/keyboard_handler:
++-    hash: 404398000bc2b2483bb3e7f4e75ed6c4181da8cb
++-    shallow_since: 1664424147 -0700
+++    hash: a80cbfc93be6a545bb0892d1b5a408d2b5ef29b1
+++    shallow_since: 1667916008 -0500
++     type: git
++     url: https://github.com/ros-tooling/keyboard_handler.git
++-    version: humble
+++    version: 0.0.5
++   ros-tooling/libstatistics_collector:
++-    hash: ed40c1825fb17c244ddf69fb6c7927060dff812b
++-    shallow_since: 1649090613 +0000
+++    hash: 6d473eb7533a3db385512d5721e3a46ceb06f96f
+++    shallow_since: 1677042096 -0800
++     type: git
++     url: https://github.com/ros-tooling/libstatistics_collector.git
++-    version: humble
+++    version: 1.3.1
++   ros-visualization/interactive_markers:
++     hash: b4e6a0df87cddba49d844f6798387faf8db2dd37
++     shallow_since: 1649450982 +0000
++     type: git
++     url: https://github.com/ros-visualization/interactive_markers.git
++-    version: humble
+++    version: 2.3.2
++   ros-visualization/python_qt_binding:
++     hash: 89492df890f390d956b7f829811f29ccc7f1cd87
++     shallow_since: 1638839032 -0800
++     type: git
++     url: https://github.com/ros-visualization/python_qt_binding.git
++-    version: humble
+++    version: 1.1.1
++   ros-visualization/qt_gui_core:
++     hash: 4a1010a702ea4b922a25b0b1cebc33904de88c0c
++     shallow_since: 1660584395 +0000
++     type: git
++     url: https://github.com/ros-visualization/qt_gui_core.git
++-    version: humble
+++    version: 2.2.2
++   ros-visualization/rqt:
++-    hash: 6cf57076b8501264497fd7355997335b3d05d511
++-    shallow_since: 1652231633 -0700
+++    hash: d954ac6727f873a2c2e1b7f9e7cb1bd7642fc461
+++    shallow_since: 1682459372 +0000
++     type: git
++     url: https://github.com/ros-visualization/rqt.git
++-    version: humble
+++    version: 1.1.5
++   ros-visualization/rqt_action:
++     hash: 86e5c65a708b562f220cf6bafa7a3f10e075dad8
++     shallow_since: 1642182537 -0800
++     type: git
++     url: https://github.com/ros-visualization/rqt_action.git
++-    version: humble
+++    version: 2.0.1
++   ros-visualization/rqt_bag:
++-    hash: 5ebb4cddd63efa75f3b25d8c9b9ce3adb9d1c4a1
++-    shallow_since: 1662393474 -0300
+++    hash: a860837d1a52459ed5a97674546faf526f175402
+++    shallow_since: 1667831876 -0600
++     type: git
++     url: https://github.com/ros-visualization/rqt_bag.git
++-    version: humble
+++    version: 1.1.4
++   ros-visualization/rqt_console:
++-    hash: d293cc3423c23547dfc430dde293cc15304da88b
++-    shallow_since: 1645062903 +0900
+++    hash: 3f2fd4e066562e8a9b630bcba5dee95a20fbdca9
+++    shallow_since: 1635300128 +0900
++     type: git
++     url: https://github.com/ros-visualization/rqt_console.git
++-    version: humble
+++    version: 2.0.2
++   ros-visualization/rqt_graph:
++     hash: e512cd7a246ca1032422c454bb103a5beb3cf4c1
++     shallow_since: 1663109940 +0000
++     type: git
++     url: https://github.com/ros-visualization/rqt_graph.git
++-    version: humble
+++    version: 1.3.0
++   ros-visualization/rqt_msg:
++     hash: e73c05e6b4a2601a587231eacafad75e5fa07aa4
++     shallow_since: 1663096424 -0700
++     type: git
++     url: https://github.com/ros-visualization/rqt_msg.git
++-    version: humble
+++    version: 1.2.0
++   ros-visualization/rqt_plot:
++     hash: d44f4a6b5ddb39d03ddc201dd202f1f8c324a262
++     shallow_since: 1652231949 -0700
++     type: git
++     url: https://github.com/ros-visualization/rqt_plot.git
++-    version: humble
+++    version: 1.1.2
++   ros-visualization/rqt_publisher:
++     hash: db902c8dd75527dbc0e9e533b42f650a56dbe03e
++     shallow_since: 1659477921 -0400
++     type: git
++     url: https://github.com/ros-visualization/rqt_publisher.git
++-    version: humble
+++    version: 1.5.0
++   ros-visualization/rqt_py_console:
++     hash: 36ad6e467f7add9279a4cd54d3e02ebcbd936d5b
++     shallow_since: 1630451545 -0700
++     type: git
++     url: https://github.com/ros-visualization/rqt_py_console.git
++-    version: humble
+++    version: 1.0.2
++   ros-visualization/rqt_reconfigure:
++     hash: 3cdeeb3cb6bdf4931b8b49b87b6aa95c24e378ba
++     shallow_since: 1663106666 +0000
++     type: git
++     url: https://github.com/ros-visualization/rqt_reconfigure.git
++-    version: humble
+++    version: 1.1.1
++   ros-visualization/rqt_service_caller:
++     hash: c9afeb84e9db4807c895e345294f2d521abf3859
++     shallow_since: 1630451643 -0700
++     type: git
++     url: https://github.com/ros-visualization/rqt_service_caller.git
++-    version: humble
+++    version: 1.0.5
++   ros-visualization/rqt_shell:
++     hash: 50639b2252fc0d02bcc3361284b67baa44a87c3b
++     shallow_since: 1630452741 -0700
++     type: git
++     url: https://github.com/ros-visualization/rqt_shell.git
++-    version: humble
+++    version: 1.0.2
++   ros-visualization/rqt_srv:
++     hash: 46e8e71560008857456525ad7977aa6bd87391d5
++     shallow_since: 1630452880 -0700
++     type: git
++     url: https://github.com/ros-visualization/rqt_srv.git
++-    version: humble
+++    version: 1.0.3
++   ros-visualization/rqt_topic:
++     hash: 19141d759cfa35515182677f9d4e60a898e86c74
++     shallow_since: 1663095690 -0700
++     type: git
++     url: https://github.com/ros-visualization/rqt_topic.git
++-    version: humble
+++    version: 1.5.0
++   ros-visualization/tango_icons_vendor:
++     hash: 6829ad2201c6b42973edcfc9f5755b8b9f5b67ff
++     shallow_since: 1649249706 +0000
++     type: git
++     url: https://github.com/ros-visualization/tango_icons_vendor.git
++-    version: humble
+++    version: 0.1.1
++   ros/class_loader:
++     hash: b59bce93380b73ac9061fba28e96bba540e2befe
++     shallow_since: 1642184223 -0800
++     type: git
++     url: https://github.com/ros/class_loader.git
++-    version: humble
+++    version: 2.2.0
++   ros/kdl_parser:
++-    hash: df0309937e61435d7d3f09adec04c94665d45a4e
++-    shallow_since: 1659733945 -0700
+++    hash: a4ad6b3c1dbf3730a579b250be81e4a74e838b94
+++    shallow_since: 1673360125 -0600
++     type: git
++     url: https://github.com/ros/kdl_parser.git
++-    version: humble
+++    version: 2.6.4
++   ros/pluginlib:
++     hash: fc2d015a594bb582c1143a9e2b8b8d9f6f8c75fc
++     shallow_since: 1642186000 -0800
++     type: git
++     url: https://github.com/ros/pluginlib.git
++-    version: humble
+++    version: 5.1.0
++   ros/resource_retriever:
++-    hash: 3f35939ae4221df600f8fe44fb2887f7e82da274
++-    shallow_since: 1646167227 +0000
+++    hash: 6c82181f7c0c893f50dbacdafe51bc83b9a56803
+++    shallow_since: 1673360221 -0600
++     type: git
++     url: https://github.com/ros/resource_retriever.git
++-    version: humble
+++    version: 3.1.1
++   ros/robot_state_publisher:
++     hash: 6e11ed88d24a63a00472c000075f568f270334ed
++     shallow_since: 1649194244 -0700
++     type: git
++     url: https://github.com/ros/robot_state_publisher.git
++-    version: humble
+++    version: 3.0.2
++   ros/ros_environment:
++-    hash: 26f8deed11e57361dd9ad98508972aa9713f2053
++-    shallow_since: 1654881379 -0700
+++    hash: cf4d7c2b770fec588e8d35de09e12d5bfd056067
+++    shallow_since: 1667832063 -0600
++     type: git
++     url: https://github.com/ros/ros_environment.git
++-    version: humble
+++    version: 3.2.2
++   ros/ros_tutorials:
++     hash: ba29c3f376197e3736f497639299f855cbf73390
++     shallow_since: 1652796435 -0400
++     type: git
++     url: https://github.com/ros/ros_tutorials.git
++-    version: humble
+++    version: 1.4.2
++   ros/urdfdom:
++     hash: dbecca095cf81b755991b4d785f87a8e6b7358d6
++     shallow_since: 1648511537 -0700
++     type: git
++     url: https://github.com/ros/urdfdom.git
++-    version: humble
+++    version: 3.0.2
++   ros/urdfdom_headers:
++     hash: d3643d2acd8567c6522ceaf7ded6e3c3755a5244
++     shallow_since: 1648511357 -0700
++     type: git
++     url: https://github.com/ros/urdfdom_headers.git
++-    version: humble
+++    version: 1.0.6
++   ros2/ament_cmake_ros:
++     hash: 60572fa1bec50b9e6fbe64e1b23640d21c15e9d0
++     shallow_since: 1642109880 -0800
++     type: git
++     url: https://github.com/ros2/ament_cmake_ros.git
++-    version: humble
+++    version: 0.10.0
++   ros2/common_interfaces:
++-    hash: 60df44894caafa67767da4c71d91f8c5eb7abf38
++-    shallow_since: 1652996362 -0700
+++    hash: f4eac72f0bbd70f7955a5f709d4a6705eb6ca7e8
+++    shallow_since: 1673281597 -0600
++     type: git
++     url: https://github.com/ros2/common_interfaces.git
++-    version: humble
+++    version: 4.2.3
++   ros2/console_bridge_vendor:
++-    hash: 9c93da4dafea40bcf8e5aa09a2f1fdfd8652ad02
++-    shallow_since: 1648558980 +0000
+++    hash: d445245912786a7a03216e9d47f102e1997320f2
+++    shallow_since: 1673357965 -0600
++     type: git
++     url: https://github.com/ros2/console_bridge_vendor.git
++-    version: humble
+++    version: 1.4.1
++   ros2/demos:
++-    hash: 735905e23b97cd20283d374c99e09ad1c5d5aa3e
++-    shallow_since: 1652232030 -0700
+++    hash: f258b8182c7ad680c8cceba38eac72e01fdb0a3c
+++    shallow_since: 1673358561 -0600
++     type: git
++     url: https://github.com/ros2/demos.git
++-    version: humble
+++    version: 0.20.3
++   ros2/eigen3_cmake_module:
++     hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
++     shallow_since: 1565307940 -0700
++     type: git
++     url: https://github.com/ros2/eigen3_cmake_module.git
++-    version: humble
+++    version: 0.1.1
++   ros2/example_interfaces:
++     hash: f8deb566a1facf91bd38b9f00c4cf684c5007d85
++     shallow_since: 1649249608 +0000
++     type: git
++     url: https://github.com/ros2/example_interfaces.git
++-    version: humble
+++    version: 0.9.3
++   ros2/examples:
++-    hash: 357183cfb0e82195e54235ffb51e1071711a8661
++-    shallow_since: 1658769078 -0400
+++    hash: fac7da74281cbe6912e74aa78db633945b9ed930
+++    shallow_since: 1667832202 -0600
++     type: git
++     url: https://github.com/ros2/examples.git
++-    version: humble
+++    version: 0.15.1
++   ros2/geometry2:
++-    hash: ae2120833d1777eaa91a3fa4943d56b675db3e52
++-    shallow_since: 1659733742 -0700
+++    hash: a73160df358c52d1f506fce21f15f8243e9b87f4
+++    shallow_since: 1695130569 +0000
++     type: git
++     url: https://github.com/ros2/geometry2.git
++-    version: humble
+++    version: 0.25.4
++   ros2/launch:
++-    hash: b6a7f31c1972395cb8c23d753c1da7d0f566dfe6
++-    shallow_since: 1665596819 -0400
+++    hash: aed025e04e0b143362c69bf29a67b2ffff4c59ee
+++    shallow_since: 1673358862 -0600
++     type: git
++     url: https://github.com/ros2/launch.git
++-    version: humble
+++    version: 1.0.4
++   ros2/launch_ros:
++-    hash: 5434428a30a981aeee1dbadfd5b43622cef12d67
++-    shallow_since: 1652796256 -0400
+++    hash: 2bf4e6057dea57669c19395f6f39d390bd420ee7
+++    shallow_since: 1695130640 +0000
++     type: git
++     url: https://github.com/ros2/launch_ros.git
++-    version: humble
+++    version: 0.19.6
++   ros2/libyaml_vendor:
++     hash: 239f695ceaa0820255f3d0fe02ec8c2bd41b8e78
++     shallow_since: 1648732255 +0000
++     type: git
++     url: https://github.com/ros2/libyaml_vendor.git
++-    version: humble
+++    version: 1.2.2
++   ros2/message_filters:
++-    hash: 1062b259704e7bb171b09e1c29cdace22a7ae6fb
++-    shallow_since: 1655701479 +0000
+++    hash: bb405b0d55646fbcb6acf7c2d42911d0efb11415
+++    shallow_since: 1682458765 +0000
++     type: git
++     url: https://github.com/ros2/message_filters.git
++-    version: humble
+++    version: 4.3.3
++   ros2/mimick_vendor:
++     hash: 39ec45b347721c8c90c0e31450e91c00fb0ec856
++     shallow_since: 1648188875 +0000
++     type: git
++     url: https://github.com/ros2/mimick_vendor.git
++-    version: humble
+++    version: 0.2.8
++   ros2/orocos_kdl_vendor:
++-    hash: 1e8abdf193fd0ca4d143216336ee03a34d7ed10b
++-    shallow_since: 1659712218 -0700
+++    hash: d390ba45a77d8d49746a784d10a88cb77e86f703
+++    shallow_since: 1674245380 -0600
++     type: git
++     url: https://github.com/ros2/orocos_kdl_vendor.git
++-    version: humble
+++    version: 0.2.5
++   ros2/performance_test_fixture:
++     hash: afb01872d0c03e31cd4fda04e91af8e5548de0a3
++     shallow_since: 1658776414 -0700
++     type: git
++     url: https://github.com/ros2/performance_test_fixture.git
++-    version: main
+++    version: 0.0.9
++   ros2/pybind11_vendor:
++-    hash: 087b40ba8c7730fddf2b5b600ac595a8341255e9
++-    shallow_since: 1652232157 -0700
+++    hash: 06dff083cdef3381c1d1d16159ac19227f646ad9
+++    shallow_since: 1670369976 -0800
++     type: git
++     url: https://github.com/ros2/pybind11_vendor.git
++-    version: humble
+++    version: 2.4.2
++   ros2/python_cmake_module:
++     hash: 859115408416e77d37711912d5c36cd3147fe136
++     shallow_since: 1646164088 +0000
++     type: git
++     url: https://github.com/ros2/python_cmake_module.git
++-    version: humble
+++    version: 0.10.0
++   ros2/rcl:
++-    hash: 7bb8d4d039a3a3c7bee452464358270d6f4ab616
++-    shallow_since: 1662659355 -0500
+++    hash: 3804c35f6dd31d5ac54a1acb426bff253cce8272
+++    shallow_since: 1695130701 +0000
++     type: git
++     url: https://github.com/ros2/rcl.git
++-    version: humble
+++    version: 5.3.5
++   ros2/rcl_interfaces:
++-    hash: 4be87b33fb6aef6ea5ec5a0662c53f923f9fe9be
++-    shallow_since: 1646163405 +0000
+++    hash: 5e01a28f9866a564491480e12d8659a134678741
+++    shallow_since: 1667833699 -0600
++     type: git
++     url: https://github.com/ros2/rcl_interfaces.git
++-    version: humble
+++    version: 1.2.1
++   ros2/rcl_logging:
++-    hash: 764508af43391d4583bb1aa310e809409ab166d5
++-    shallow_since: 1656611429 -0400
+++    hash: 1b7a4e34884005f28eeb04065b5d94565c67b11d
+++    shallow_since: 1667833800 -0600
++     type: git
++     url: https://github.com/ros2/rcl_logging.git
++-    version: humble
+++    version: 2.3.1
++   ros2/rclcpp:
++-    hash: 7f575103d8fe06285bd46474a0324c7dfbb2a2f0
++-    shallow_since: 1662749700 -0700
+++    hash: 0f6b5449f66f131735a423be4a84d6f14751d3b2
+++    shallow_since: 1695130763 +0000
++     type: git
++     url: https://github.com/ros2/rclcpp.git
++-    version: humble
+++    version: 16.0.6
++   ros2/rclpy:
++-    hash: 878c549ac9fdd4e2f4cea02df1cb174e70c4de2b
++-    shallow_since: 1665598362 -0400
+++    hash: 242f78a3d856ed1552a56d1e06713553e9d65fdf
+++    shallow_since: 1695130817 +0000
++     type: git
++     url: https://github.com/ros2/rclpy.git
++-    version: humble
+++    version: 3.3.10
++   ros2/rcpputils:
++-    hash: a7898d98ab684bb5d0cb2c20c823a1b4014fa0dc
++-    shallow_since: 1646162575 +0000
+++    hash: 3eb281afdc891855b5feb367c79ede1e2fbb0acb
+++    shallow_since: 1682457603 +0000
++     type: git
++     url: https://github.com/ros2/rcpputils.git
++-    version: humble
+++    version: 2.4.1
++   ros2/rcutils:
++-    hash: 6724d8a0f842e13cac07f2e90a06f79ae6fcfc48
++-    shallow_since: 1663764013 -0400
+++    hash: 2d9d74e72ecd1eea240412be3dacd413dcb5f680
+++    shallow_since: 1682457695 +0000
++     type: git
++     url: https://github.com/ros2/rcutils.git
++-    version: humble
+++    version: 5.1.3
++   ros2/realtime_support:
++     hash: 0e3faef4b7aa7985726dba97c761a6783f62a958
++     shallow_since: 1646162410 +0000
++     type: git
++     url: https://github.com/ros2/realtime_support.git
++-    version: humble
+++    version: 0.13.0
++   ros2/rmw:
++-    hash: 01d0db60c5bac242fe6f8a6d49494512f1e20c61
++-    shallow_since: 1648232762 +0000
+++    hash: 2a4ee718d0da004d5629f50afd2896fbd1f4aedd
+++    shallow_since: 1667834517 -0600
++     type: git
++     url: https://github.com/ros2/rmw.git
++-    version: humble
+++    version: 6.1.1
++   ros2/rmw_connextdds:
++-    hash: 1252ed842c92385787fb59b15a385e34408b1602
++-    shallow_since: 1651005883 +0000
+++    hash: 94bde7556d069bee8f9540171a9b87593c3be51e
+++    shallow_since: 1689700540 +0000
++     type: git
++     url: https://github.com/ros2/rmw_connextdds.git
++-    version: humble
+++    version: 0.11.2
++   ros2/rmw_cyclonedds:
++-    hash: d978115ddcf049288c48dc6b52caa3be1439eba7
++-    shallow_since: 1664815405 -0700
+++    hash: 7cb3b38a21e14fbcc84aadcc460e4d812d0c7a7f
+++    shallow_since: 1667834582 -0600
++     type: git
++     url: https://github.com/ros2/rmw_cyclonedds.git
++-    version: humble
+++    version: 1.3.4
++   ros2/rmw_dds_common:
++     hash: e26ba1079886c5598614172db0b27526aa6af07d
++     shallow_since: 1648761511 +0000
++     type: git
++     url: https://github.com/ros2/rmw_dds_common.git
++-    version: humble
+++    version: 1.6.0
++   ros2/rmw_fastrtps:
++-    hash: fe73970c674af7ff286e5a77337dc11865fc2691
++-    shallow_since: 1662566084 -0700
+++    hash: 4b0f30f15fad0e1a9824db0bf54dbbaa5085fa5d
+++    shallow_since: 1695130886 +0000
++     type: git
++     url: https://github.com/ros2/rmw_fastrtps.git
++-    version: humble
+++    version: 6.2.4
++   ros2/rmw_implementation:
++-    hash: 31843adc17f28a4af0dc5f160e9e3b4dfb9710ea
++-    shallow_since: 1648508522 -0700
+++    hash: 413eb313f7e128c6977cd453818e1a39bf70da40
+++    shallow_since: 1673359327 -0600
++     type: git
++     url: https://github.com/ros2/rmw_implementation.git
++-    version: humble
+++    version: 2.8.2
++   ros2/ros2_tracing:
++-    hash: 638fa0ab095ae1e941b05187418f0089c431e8d9
++-    shallow_since: 1653488135 +0000
+++    hash: 548634dd2837d65c043436c8186614e924be5c6c
+++    shallow_since: 1667834775 -0600
++     type: git
++     url: https://github.com/ros2/ros2_tracing.git
++-    version: humble
+++    version: 4.1.1
++   ros2/ros2cli:
++-    hash: 9e7f72150ab0c47188984787da138d6c16dde386
++-    shallow_since: 1663860341 -0400
+++    hash: 38d4fa97fa8091e211e190d70e9fa0b0e817689d
+++    shallow_since: 1689700836 +0000
++     type: git
++     url: https://github.com/ros2/ros2cli.git
++-    version: humble
+++    version: 0.18.7
++   ros2/ros2cli_common_extensions:
++     hash: 4f2d47f4417475c5036c9930b5d348a5e0774007
++     shallow_since: 1616076624 +0000
++     type: git
++     url: https://github.com/ros2/ros2cli_common_extensions.git
++-    version: humble
+++    version: 0.1.1
++   ros2/ros_testing:
++     hash: d258cbca54a5e6fbbf7be38ddd78592273ccee78
++     shallow_since: 1642109145 -0800
++     type: git
++     url: https://github.com/ros2/ros_testing.git
++-    version: humble
+++    version: 0.4.0
++   ros2/rosbag2:
++-    hash: b71944abb16a9acc24e002536e82a5265920dbab
++-    shallow_since: 1663894361 -0700
+++    hash: 0b4deb3311ed8397410d84b462a86b2d1c9db153
+++    shallow_since: 1695151794 -0500
++     type: git
++     url: https://github.com/ros2/rosbag2.git
++-    version: humble
+++    version: 0.15.8
++   ros2/rosidl:
++-    hash: bdc43f017e537649ca4306a977e838d3f1d0e825
++-    shallow_since: 1658165071 -0700
+++    hash: cf3b637605c8c1dc0b1266ca0090963e9186c7dd
+++    shallow_since: 1689702714 +0000
++     type: git
++     url: https://github.com/ros2/rosidl.git
++-    version: humble
+++    version: 3.1.5
++   ros2/rosidl_dds:
++     hash: ab8497770c652edb40d6b1591118198cbcf14237
++     shallow_since: 1648665003 -0700
++     type: git
++     url: https://github.com/ros2/rosidl_dds.git
++-    version: humble
+++    version: 0.8.1
++   ros2/rosidl_defaults:
++     hash: 1f1ee2a6169837b10302ffb2a52fb2f2a57239b2
++     shallow_since: 1648762308 +0000
++     type: git
++     url: https://github.com/ros2/rosidl_defaults.git
++-    version: humble
+++    version: 1.2.0
++   ros2/rosidl_python:
++-    hash: eb847a07bf851f125eb0bd47d4b161f13cdc8e1d
++-    shallow_since: 1662150425 -0400
+++    hash: 2507d5dbc1aebe2254d9eac088f007dcaea2ff03
+++    shallow_since: 1667923359 +0000
++     type: git
++     url: https://github.com/ros2/rosidl_python.git
++-    version: humble
+++    version: 0.14.4
++   ros2/rosidl_runtime_py:
++-    hash: 527cd1006269df81753ddcdcbc9e41be6ab9c585
++-    shallow_since: 1663268137 -0300
+++    hash: 02b91d6f9acbfe3dbfa4feb34bd7c30e219aa178
+++    shallow_since: 1667835469 -0600
++     type: git
++     url: https://github.com/ros2/rosidl_runtime_py.git
++-    version: humble
+++    version: 0.9.3
++   ros2/rosidl_typesupport:
++-    hash: 1e5560a46a9dee79cec7815c35020b97008ea379
++-    shallow_since: 1648664530 -0700
+++    hash: aa522c4bf1a1b6c10766b84ca6625a8c494c0928
+++    shallow_since: 1689702809 +0000
++     type: git
++     url: https://github.com/ros2/rosidl_typesupport.git
++-    version: humble
+++    version: 2.0.1
++   ros2/rosidl_typesupport_fastrtps:
++-    hash: 89b19c15d615fc07479707e6584e29b1f67f5e23
++-    shallow_since: 1648665285 +0000
+++    hash: c1c132960f466db26020c01913a7827695fc15af
+++    shallow_since: 1689702902 +0000
++     type: git
++     url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
++-    version: humble
+++    version: 2.2.1
++   ros2/rpyutils:
++     hash: 4cb9e1b5c1c4c585694196377ab918e7e70639f0
++     shallow_since: 1646159541 +0000
++     type: git
++     url: https://github.com/ros2/rpyutils.git
++-    version: humble
+++    version: 0.2.1
++   ros2/rviz:
++-    hash: d1b066455474a3c7424b9d2de5b8ec2998301bef
++-    shallow_since: 1664225677 -0700
+++    hash: 6ecfcecf5bd14ce77e1c3078a65b736c9cac00b6
+++    shallow_since: 1695131351 +0000
++     type: git
++     url: https://github.com/ros2/rviz.git
++-    version: humble
+++    version: 11.2.8
++   ros2/spdlog_vendor:
++-    hash: f38518c40bbe8798d07017c8e35ed701f2400782
++-    shallow_since: 1617715455 +0000
+++    hash: 2de3e7f6ee157a7e3a2dd24f33046f6d25c099be
+++    shallow_since: 1673359578 -0600
++     type: git
++     url: https://github.com/ros2/spdlog_vendor.git
++-    version: humble
+++    version: 1.3.1
++   ros2/sros2:
++     hash: bb3859098f123c65f8cfc90f45e21502be521d48
++     shallow_since: 1649450801 +0000
++     type: git
++     url: https://github.com/ros2/sros2.git
++-    version: humble
+++    version: 0.10.4
++   ros2/system_tests:
++     hash: 83a4e481624a6d171104fe4c89d2fb56da91ab6d
++     shallow_since: 1649180453 +0000
++     type: git
++     url: https://github.com/ros2/system_tests.git
++-    version: humble
+++    version: 0.12.3
++   ros2/test_interface_files:
++     hash: a0c8f5e338490ddf8b98238dce35c06810115e8b
++     shallow_since: 1649179981 +0000
++     type: git
++     url: https://github.com/ros2/test_interface_files.git
++-    version: humble
+++    version: 0.9.1
++   ros2/tinyxml2_vendor:
++     hash: 4ec721bf7f6adaa604db28e6ef1ae4beb205a773
++     shallow_since: 1649179758 +0000
++     type: git
++     url: https://github.com/ros2/tinyxml2_vendor.git
++-    version: humble
+++    version: 0.7.5
++   ros2/tinyxml_vendor:
++     hash: b226bdf9a7dbdcf9ac47961e09f3d730525c1667
++     shallow_since: 1649179658 +0000
++     type: git
++     url: https://github.com/ros2/tinyxml_vendor.git
++-    version: humble
+++    version: 0.8.3
++   ros2/tlsf:
++     hash: d39351de61894a8b4ce65a682ea3593628a9a179
++     shallow_since: 1646157096 +0000
++     type: git
++     url: https://github.com/ros2/tlsf.git
++-    version: humble
+++    version: 0.7.0
++   ros2/unique_identifier_msgs:
++     hash: 27767cefcf8a80da44641dc208c57722c28aa11c
++     shallow_since: 1617715220 +0000
++     type: git
++     url: https://github.com/ros2/unique_identifier_msgs.git
++-    version: humble
+++    version: 2.2.1
++   ros2/urdf:
++     hash: 3fa99149d8300dcd90bfc05b58ce0fc0bceaae5d
++     shallow_since: 1646156722 +0000
++     type: git
++     url: https://github.com/ros2/urdf.git
++-    version: humble
+++    version: 2.6.0
++   ros2/yaml_cpp_vendor:
++-    hash: 25e36cc6cea3a55db45157408b00fbee1c9b922e
++-    shallow_since: 1649899450 -0700
+++    hash: 77bebe7a90c0bc26df3137f15bad4a9712f9b74e
+++    shallow_since: 1673359652 -0600
++     type: git
++     url: https://github.com/ros2/yaml_cpp_vendor.git
++-    version: humble
+++    version: 8.0.2
++diff --git a/repos/config/ros2_iron.lock b/repos/config/ros2_iron.lock
++new file mode 100644
++index 0000000..7e03cac
++--- /dev/null
+++++ b/repos/config/ros2_iron.lock
++@@ -0,0 +1,640 @@
+++#
+++#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++repositories:
+++  ament/ament_cmake:
+++    hash: 4248cdfcf0d8d0a462c04e5dce498fee5721da4b
+++    shallow_since: 1687451108 -0700
+++    type: git
+++    url: https://github.com/ament/ament_cmake.git
+++    version: 2.0.3
+++  ament/ament_index:
+++    hash: ba818db036e82d5f752d17e3e6fe6e3efd583bfb
+++    shallow_since: 1676390119 +0000
+++    type: git
+++    url: https://github.com/ament/ament_index.git
+++    version: 1.5.2
+++  ament/ament_lint:
+++    hash: f4f0f7fd061575a22367a5ecfa5fa5e5b8ed0895
+++    shallow_since: 1694147882 +0800
+++    type: git
+++    url: https://github.com/ament/ament_lint.git
+++    version: 0.14.2
+++  ament/ament_package:
+++    hash: cf415e74bb8faff896bb6915ee3d120cc7b60fc3
+++    shallow_since: 1681221907 +0000
+++    type: git
+++    url: https://github.com/ament/ament_package.git
+++    version: 0.15.3
+++  ament/google_benchmark_vendor:
+++    hash: 953cee9382bdbdde1b85c0406ce34f71acf0534c
+++    shallow_since: 1676386698 -0600
+++    type: git
+++    url: https://github.com/ament/google_benchmark_vendor.git
+++    version: 0.3.0
+++  ament/googletest:
+++    hash: 1c2fdcd80b08fcfe6b70fa2a369ae6bab9d5f78e
+++    shallow_since: 1681222174 +0000
+++    type: git
+++    url: https://github.com/ament/googletest.git
+++    version: 1.10.9005
+++  ament/uncrustify_vendor:
+++    hash: 94ed3f68d1d2e44e04398c4538509f5e78114dae
+++    shallow_since: 1676390520 +0000
+++    type: git
+++    url: https://github.com/ament/uncrustify_vendor.git
+++    version: 2.1.2
+++  eProsima/Fast-CDR:
+++    hash: 5d782877435b569e0ed38541f362e212c9123dd4
+++    shallow_since: 1679466588 +0100
+++    type: git
+++    url: https://github.com/eProsima/Fast-CDR.git
+++    version: v1.0.27
+++  eProsima/Fast-DDS:
+++    hash: 2be7879185bfa2b67d5a9777ddee0a7e637776f3
+++    shallow_since: 1692360029 +0200
+++    type: git
+++    url: https://github.com/eProsima/Fast-DDS.git
+++    version: 2.10.2
+++  eProsima/foonathan_memory_vendor:
+++    hash: 8db2afc097db4cebe414ae27cdb3af1480ae46e7
+++    shallow_since: 1676364830 +0100
+++    type: git
+++    url: https://github.com/eProsima/foonathan_memory_vendor.git
+++    version: v1.3.0
+++  eclipse-cyclonedds/cyclonedds:
+++    hash: 63b6eab0e0660009eaf5e54d10509ea587ce199e
+++    shallow_since: 1679487279 +0100
+++    type: git
+++    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+++    version: 0.10.3
+++  eclipse-iceoryx/iceoryx:
+++    hash: 40ef24e9515940564af63987234d51dc7f02f6b3
+++    shallow_since: 1675094707 +0100
+++    type: git
+++    url: https://github.com/eclipse-iceoryx/iceoryx.git
+++    version: v2.0.3
+++  gazebo-release/gz_cmake2_vendor:
+++    hash: 01bd9e0a4e49b272645200a782dead88188cdb2e
+++    shallow_since: 1681223004 +0000
+++    type: git
+++    url: https://github.com/gazebo-release/gz_cmake2_vendor.git
+++    version: 0.1.0
+++  gazebo-release/gz_math6_vendor:
+++    hash: c4784e998bbce003f8db8e87b62c73750cb8be0f
+++    shallow_since: 1682703105 +0000
+++    type: git
+++    url: https://github.com/gazebo-release/gz_math6_vendor.git
+++    version: 0.1.0
+++  osrf/osrf_pycommon:
+++    hash: 815073ebe4eb892cf1f5bb5fa064ffb1dd45b170
+++    shallow_since: 1676392123 +0000
+++    type: git
+++    url: https://github.com/osrf/osrf_pycommon.git
+++    version: 2.1.2
+++  osrf/osrf_testing_tools_cpp:
+++    hash: 557ce7827b09b22d58de1c726a2caf71fc32e3e7
+++    shallow_since: 1682703503 +0000
+++    type: git
+++    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+++    version: 1.6.0
+++  ros-perception/image_common:
+++    hash: a32e834234af161c19d9a2b1cc03991dd6af53e7
+++    shallow_since: 1692024961 +0200
+++    type: git
+++    url: https://github.com/ros-perception/image_common.git
+++    version: 4.2.2
+++  ros-perception/laser_geometry:
+++    hash: de79acf96ecaafcba7a62dba12e644b5747cb19c
+++    shallow_since: 1676387774 -0600
+++    type: git
+++    url: https://github.com/ros-perception/laser_geometry.git
+++    version: 2.5.0
+++  ros-planning/navigation_msgs:
+++    hash: 6ceaaf521f604c1c9d2cdb2b80f69e7406681978
+++    shallow_since: 1676389678 -0600
+++    type: git
+++    url: https://github.com/ros-planning/navigation_msgs.git
+++    version: 2.2.0
+++  ros-tooling/keyboard_handler:
+++    hash: 93e4743ea2918626b3f441c443abe7533e366bbc
+++    shallow_since: 1667916946 -0500
+++    type: git
+++    url: https://github.com/ros-tooling/keyboard_handler.git
+++    version: 0.1.0
+++  ros-tooling/libstatistics_collector:
+++    hash: 00b9371c15fdc9b3f42faee3cb718214b787eb13
+++    shallow_since: 1681306122 +0000
+++    type: git
+++    url: https://github.com/ros-tooling/libstatistics_collector.git
+++    version: 1.5.1
+++  ros-visualization/interactive_markers:
+++    hash: ae67485ee39c77c17946c0708af4bb77a39b96b3
+++    shallow_since: 1676389612 -0600
+++    type: git
+++    url: https://github.com/ros-visualization/interactive_markers.git
+++    version: 2.4.0
+++  ros-visualization/python_qt_binding:
+++    hash: ae0c68db584a88b56cffc1485d1dd8b776729602
+++    shallow_since: 1681223869 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/python_qt_binding.git
+++    version: 1.2.3
+++  ros-visualization/qt_gui_core:
+++    hash: 4abf0eebc7a0da73f00c1c8432166efb16e244b1
+++    shallow_since: 1684469026 +0800
+++    type: git
+++    url: https://github.com/ros-visualization/qt_gui_core.git
+++    version: 2.4.2
+++  ros-visualization/rqt:
+++    hash: dba23643d88f3f0f7990aa9d92a4959af7213518
+++    shallow_since: 1684468389 +0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt.git
+++    version: 1.3.3
+++  ros-visualization/rqt_action:
+++    hash: 485841029f88d93b6cc4d8104786f42f8bb45e1e
+++    shallow_since: 1676391928 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_action.git
+++    version: 2.1.2
+++  ros-visualization/rqt_bag:
+++    hash: 7130a33b0d22171a27d4f831d0de3729e916b90a
+++    shallow_since: 1694149679 +0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_bag.git
+++    version: 1.3.4
+++  ros-visualization/rqt_console:
+++    hash: 7b4797c29746ea1f39b05beac63d836a5ded8cd3
+++    shallow_since: 1676391823 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_console.git
+++    version: 2.1.1
+++  ros-visualization/rqt_graph:
+++    hash: 9f8314d91cf0a3b3f525770f62470c33d650629c
+++    shallow_since: 1683795583 +0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_graph.git
+++    version: 1.4.2
+++  ros-visualization/rqt_msg:
+++    hash: 9eb293818a27bda6a6300637ec497bc778928256
+++    shallow_since: 1676391592 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_msg.git
+++    version: 1.3.1
+++  ros-visualization/rqt_plot:
+++    hash: 709dbb8deeb0982b9e1cbf0bda7293132c18a635
+++    shallow_since: 1683797105 +0800
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_plot.git
+++    version: 1.2.3
+++  ros-visualization/rqt_publisher:
+++    hash: 33dd6e32f74b9b160cbcee519ac46ad937647350
+++    shallow_since: 1681224497 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_publisher.git
+++    version: 1.6.3
+++  ros-visualization/rqt_py_console:
+++    hash: c7570778bbed0e4c3ab564eae2dfceb6d4052e4f
+++    shallow_since: 1676391315 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_py_console.git
+++    version: 1.1.1
+++  ros-visualization/rqt_reconfigure:
+++    hash: a7057ba5642546f5f59cf29893e9f23b3025ac5d
+++    shallow_since: 1681303854 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_reconfigure.git
+++    version: 1.3.3
+++  ros-visualization/rqt_service_caller:
+++    hash: 20d2bc0385d37c1a4a7d686b966f7b46b4dda29c
+++    shallow_since: 1676391104 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_service_caller.git
+++    version: 1.1.1
+++  ros-visualization/rqt_shell:
+++    hash: 142244b512cf07971de9d53516dad8c335592a15
+++    shallow_since: 1676390997 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_shell.git
+++    version: 1.1.1
+++  ros-visualization/rqt_srv:
+++    hash: 55389081d4b830a248d75d6a7dac4418ab8f2926
+++    shallow_since: 1676390915 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_srv.git
+++    version: 1.1.1
+++  ros-visualization/rqt_topic:
+++    hash: b983018ef6722570faf7e8267f8a70ae74d049c6
+++    shallow_since: 1676390816 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/rqt_topic.git
+++    version: 1.6.1
+++  ros-visualization/tango_icons_vendor:
+++    hash: 9b7d001ea4201f113c0876b52de16d528ee6824f
+++    shallow_since: 1676386541 +0000
+++    type: git
+++    url: https://github.com/ros-visualization/tango_icons_vendor.git
+++    version: 0.2.2
+++  ros/class_loader:
+++    hash: 2f360ba29d094b843f359033b8ece76ee0eb1a1e
+++    shallow_since: 1676325429 +0000
+++    type: git
+++    url: https://github.com/ros/class_loader.git
+++    version: 2.5.0
+++  ros/kdl_parser:
+++    hash: e2d652441561bae71bd33a6b8285f49b97dafa82
+++    shallow_since: 1676323420 +0000
+++    type: git
+++    url: https://github.com/ros/kdl_parser.git
+++    version: 2.9.0
+++  ros/pluginlib:
+++    hash: 30042370880c5a476d0a2817187aab11c1c886f6
+++    shallow_since: 1677682055 +0000
+++    type: git
+++    url: https://github.com/ros/pluginlib.git
+++    version: 5.2.2
+++  ros/resource_retriever:
+++    hash: 8046f3dc41e9646a035802b53556dd31f13525fe
+++    shallow_since: 1667410648 +0000
+++    type: git
+++    url: https://github.com/ros/resource_retriever.git
+++    version: 3.2.2
+++  ros/robot_state_publisher:
+++    hash: f52c7ca4c85f0ac7cd11f6d371b64f48da78b562
+++    shallow_since: 1681224612 +0000
+++    type: git
+++    url: https://github.com/ros/robot_state_publisher.git
+++    version: 3.2.0
+++  ros/ros_environment:
+++    hash: 9ba0e07e089082051d674df94fd5a78d262765f4
+++    shallow_since: 1682716516 +0000
+++    type: git
+++    url: https://github.com/ros/ros_environment.git
+++    version: 4.1.1
+++  ros/ros_tutorials:
+++    hash: 441071ee52275a7c6569573d7de10b3db2f602ba
+++    shallow_since: 1683813824 +0000
+++    type: git
+++    url: https://github.com/ros/ros_tutorials.git
+++    version: 1.6.1
+++  ros/urdfdom:
+++    hash: 1ed7ca95b917f38feb4ff7bd1aa033baf2cfce0e
+++    shallow_since: 1681253424 -0700
+++    type: git
+++    url: https://github.com/ros/urdfdom.git
+++    version: 3.1.1
+++  ros/urdfdom_headers:
+++    hash: 2981892df9da19d10f58dc84de63820e4f554f63
+++    shallow_since: 1652227372 -0700
+++    type: git
+++    url: https://github.com/ros/urdfdom_headers.git
+++    version: 1.1.0
+++  ros2/ament_cmake_ros:
+++    hash: ede6248e1f36aaef85eb4eac23c782a134ef2bff
+++    shallow_since: 1676324288 +0000
+++    type: git
+++    url: https://github.com/ros2/ament_cmake_ros.git
+++    version: 0.11.2
+++  ros2/common_interfaces:
+++    hash: 86801a504b97f25a3b6e1c36e42a445500c98f79
+++    shallow_since: 1681224748 +0000
+++    type: git
+++    url: https://github.com/ros2/common_interfaces.git
+++    version: 5.0.0
+++  ros2/console_bridge_vendor:
+++    hash: 2617013ef72fec17877ed25c8deba347fd1a29a7
+++    shallow_since: 1676385245 +0000
+++    type: git
+++    url: https://github.com/ros2/console_bridge_vendor.git
+++    version: 1.6.0
+++  ros2/demos:
+++    hash: cae576969faf98eb44bfc85090c71be0230da788
+++    shallow_since: 1683799437 +0800
+++    type: git
+++    url: https://github.com/ros2/demos.git
+++    version: 0.27.1
+++  ros2/eigen3_cmake_module:
+++    hash: b7d875ee0628b579060e19874570bcfb30ecca8c
+++    shallow_since: 1676324365 +0000
+++    type: git
+++    url: https://github.com/ros2/eigen3_cmake_module.git
+++    version: 0.2.2
+++  ros2/example_interfaces:
+++    hash: 58899de0f85388be333e32bcb78c551a6877db4d
+++    shallow_since: 1676324462 +0000
+++    type: git
+++    url: https://github.com/ros2/example_interfaces.git
+++    version: 0.10.2
+++  ros2/examples:
+++    hash: cbeb3135f932dc6297d3e8675912b2209270e796
+++    shallow_since: 1681224974 +0000
+++    type: git
+++    url: https://github.com/ros2/examples.git
+++    version: 0.18.0
+++  ros2/geometry2:
+++    hash: 00e0805a581e8fe97d87b6093a5978014295712c
+++    shallow_since: 1694150506 +0800
+++    type: git
+++    url: https://github.com/ros2/geometry2.git
+++    version: 0.31.5
+++  ros2/launch:
+++    hash: f15691c341d32e53970fa18a9a22c9206c2edfbe
+++    shallow_since: 1689268429 +0800
+++    type: git
+++    url: https://github.com/ros2/launch.git
+++    version: 2.0.2
+++  ros2/launch_ros:
+++    hash: 03031d629f78115ea7a0b838fb48034b0d7ae92b
+++    shallow_since: 1681227952 +0000
+++    type: git
+++    url: https://github.com/ros2/launch_ros.git
+++    version: 0.24.0
+++  ros2/libyaml_vendor:
+++    hash: 0c814892fe8c31aeb20688a8b43906aeefda015e
+++    shallow_since: 1676325166 +0000
+++    type: git
+++    url: https://github.com/ros2/libyaml_vendor.git
+++    version: 1.5.0
+++  ros2/message_filters:
+++    hash: c81a914f16e5852ea3b2fe4bd99d06b4269bd385
+++    shallow_since: 1676324832 +0000
+++    type: git
+++    url: https://github.com/ros2/message_filters.git
+++    version: 4.7.0
+++  ros2/mimick_vendor:
+++    hash: 3f2e27e2ca82bf08e7c935461dafc3d526e20ea1
+++    shallow_since: 1676390314 +0000
+++    type: git
+++    url: https://github.com/ros2/mimick_vendor.git
+++    version: 0.3.2
+++  ros2/orocos_kdl_vendor:
+++    hash: 60532cef2935bdb03aa0cf197108896773c29e42
+++    shallow_since: 1663101745 +0000
+++    type: git
+++    url: https://github.com/ros2/orocos_kdl_vendor.git
+++    version: 0.3.4
+++  ros2/performance_test_fixture:
+++    hash: a3f2988118cd36bffdf2e027c1d9b3cbdd192c37
+++    shallow_since: 1681228085 +0000
+++    type: git
+++    url: https://github.com/ros2/performance_test_fixture.git
+++    version: 0.1.1
+++  ros2/pybind11_vendor:
+++    hash: b68d6210fbe8dc7ec5b97751dbe278d29834662d
+++    shallow_since: 1681226123 -0700
+++    type: git
+++    url: https://github.com/ros2/pybind11_vendor.git
+++    version: 3.0.3
+++  ros2/python_cmake_module:
+++    hash: c961a2671638560295b453b43d9315bbf07ecfe2
+++    shallow_since: 1676324123 +0000
+++    type: git
+++    url: https://github.com/ros2/python_cmake_module.git
+++    version: 0.10.2
+++  ros2/rcl:
+++    hash: 71ecc97db05490981f3e37ced27c66f8905879e8
+++    shallow_since: 1694151357 +0800
+++    type: git
+++    url: https://github.com/ros2/rcl.git
+++    version: 6.0.3
+++  ros2/rcl_interfaces:
+++    hash: 6d28b16a6f74485af03a2c4f043dd568e576c25e
+++    shallow_since: 1681820432 +0000
+++    type: git
+++    url: https://github.com/ros2/rcl_interfaces.git
+++    version: 1.6.0
+++  ros2/rcl_logging:
+++    hash: 2bc49ab7ff557a45d4fa152e2f400e9ad2bb6a68
+++    shallow_since: 1681252296 -0700
+++    type: git
+++    url: https://github.com/ros2/rcl_logging.git
+++    version: 2.5.1
+++  ros2/rclcpp:
+++    hash: 45df3555d2daee48332f7dad1e6dabc7e4a7fd60
+++    shallow_since: 1694151852 +0800
+++    type: git
+++    url: https://github.com/ros2/rclcpp.git
+++    version: 21.0.3
+++  ros2/rclpy:
+++    hash: 236f7c9f36588471531802078c40362be8f9b162
+++    shallow_since: 1694152525 +0800
+++    type: git
+++    url: https://github.com/ros2/rclpy.git
+++    version: 4.1.3
+++  ros2/rcpputils:
+++    hash: 39b20134e571ba74baa7c77750eab586da90b7a5
+++    shallow_since: 1676322161 +0000
+++    type: git
+++    url: https://github.com/ros2/rcpputils.git
+++    version: 2.6.1
+++  ros2/rcutils:
+++    hash: 04aa9804feb46403f0058f4b089134a6985e19d3
+++    shallow_since: 1681305660 +0000
+++    type: git
+++    url: https://github.com/ros2/rcutils.git
+++    version: 6.2.1
+++  ros2/realtime_support:
+++    hash: 7e2a29adc2ccd4aef425a3e91ffc9ae976147e79
+++    shallow_since: 1676384696 +0000
+++    type: git
+++    url: https://github.com/ros2/realtime_support.git
+++    version: 0.15.0
+++  ros2/rmw:
+++    hash: 17e3a94e447cd043dc20aec7dd620b5eb26241c6
+++    shallow_since: 1681312425 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw.git
+++    version: 7.1.0
+++  ros2/rmw_connextdds:
+++    hash: a59d530c39de969ef3ac15d9942ddc481c906e59
+++    shallow_since: 1683804810 +0800
+++    type: git
+++    url: https://github.com/ros2/rmw_connextdds.git
+++    version: 0.14.1
+++  ros2/rmw_cyclonedds:
+++    hash: c9e7001e6bf5373bdf1931535354b52eeddb2053
+++    shallow_since: 1681312572 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw_cyclonedds.git
+++    version: 1.6.0
+++  ros2/rmw_dds_common:
+++    hash: 5cbab3f3dcc83097d462d6bded8a6a724c6972ad
+++    shallow_since: 1681242861 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw_dds_common.git
+++    version: 2.0.1
+++  ros2/rmw_fastrtps:
+++    hash: 120ecb1c028d87b5db5175ec04f16a17a8b79152
+++    shallow_since: 1681333781 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw_fastrtps.git
+++    version: 7.1.1
+++  ros2/rmw_implementation:
+++    hash: 124a45b2c65df5e69017dec230740c23d937787e
+++    shallow_since: 1681230516 +0000
+++    type: git
+++    url: https://github.com/ros2/rmw_implementation.git
+++    version: 2.12.0
+++  ros2/ros2_tracing:
+++    hash: fb240709fda0e0cc6c08f12ae8052d3a32221d29
+++    shallow_since: 1683805768 +0800
+++    type: git
+++    url: https://github.com/ros2/ros2_tracing.git
+++    version: 6.3.1
+++  ros2/ros2cli:
+++    hash: 4d92fa27ca0d7796c1f792864fd98dd3b7437f8f
+++    shallow_since: 1694153559 +0800
+++    type: git
+++    url: https://github.com/ros2/ros2cli.git
+++    version: 0.25.3
+++  ros2/ros2cli_common_extensions:
+++    hash: 83e51bbe477d0c9bc1a747d2d2c628ff9cf8b078
+++    shallow_since: 1676385018 +0000
+++    type: git
+++    url: https://github.com/ros2/ros2cli_common_extensions.git
+++    version: 0.2.2
+++  ros2/ros_testing:
+++    hash: aede5d75060dcbf30897d1bd9a35bc9b503874ac
+++    shallow_since: 1676325044 +0000
+++    type: git
+++    url: https://github.com/ros2/ros_testing.git
+++    version: 0.5.2
+++  ros2/rosbag2:
+++    hash: 8f0aee155c87c6607d4b080bbc1436af330d8729
+++    shallow_since: 1694404507 +0800
+++    type: git
+++    url: https://github.com/ros2/rosbag2.git
+++    version: 0.22.3
+++  ros2/rosidl:
+++    hash: 995917e9ce14d17821c04bf28d5a092111537842
+++    shallow_since: 1689270954 +0800
+++    type: git
+++    url: https://github.com/ros2/rosidl.git
+++    version: 4.0.1
+++  ros2/rosidl_core:
+++    hash: 83df4c6574f90a8479d0b0211a463a7806ad6179
+++    shallow_since: 1676323731 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_core.git
+++    version: 0.1.1
+++  ros2/rosidl_dds:
+++    hash: f074b295c316e9bbb9845344cc6ab882339e9305
+++    shallow_since: 1676323645 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_dds.git
+++    version: 0.10.1
+++  ros2/rosidl_defaults:
+++    hash: 34a204f3ce0528c6ec3bb89d33404422eb879995
+++    shallow_since: 1676319666 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_defaults.git
+++    version: 1.5.0
+++  ros2/rosidl_dynamic_typesupport:
+++    hash: 9e9264c5718489dea75337657473a183ed5ec19c
+++    shallow_since: 1694154531 +0800
+++    type: git
+++    url: https://github.com/ros2/rosidl_dynamic_typesupport
+++    version: 0.0.4
+++  ros2/rosidl_dynamic_typesupport_fastrtps:
+++    hash: d85e3f6dca4e4e69623cfec754415187bd2ae948
+++    shallow_since: 1681234060 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps
+++    version: 0.0.2
+++  ros2/rosidl_python:
+++    hash: 52eaf342deea5fda49d9589deaad6fbb481a6221
+++    shallow_since: 1681228744 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_python.git
+++    version: 0.18.0
+++  ros2/rosidl_runtime_py:
+++    hash: 614bf2784350d42acb289966570c8c56f164b0a2
+++    shallow_since: 1681228847 +0000
+++    type: git
+++    url: https://github.com/ros2/rosidl_runtime_py.git
+++    version: 0.12.0
+++  ros2/rosidl_typesupport:
+++    hash: 7cadef85a4f4e633d8598210ce99d47a3dde52a9
+++    shallow_since: 1689271321 +0800
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport.git
+++    version: 3.0.1
+++  ros2/rosidl_typesupport_fastrtps:
+++    hash: 5ce3c2a8586305107ad9af9b014340dd6765524b
+++    shallow_since: 1689271552 +0800
+++    type: git
+++    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+++    version: 3.0.1
+++  ros2/rpyutils:
+++    hash: b2b2d88e256b471494a38f47cd7f8482465572ae
+++    shallow_since: 1676323000 +0000
+++    type: git
+++    url: https://github.com/ros2/rpyutils.git
+++    version: 0.3.2
+++  ros2/rviz:
+++    hash: 40325f53622e750dc042afc4fad5040cca3bd864
+++    shallow_since: 1694157278 +0800
+++    type: git
+++    url: https://github.com/ros2/rviz.git
+++    version: 12.4.4
+++  ros2/spdlog_vendor:
+++    hash: f467d8a0cc77206df37390db904a717e2175ebb8
+++    shallow_since: 1681225577 -0700
+++    type: git
+++    url: https://github.com/ros2/spdlog_vendor.git
+++    version: 1.4.4
+++  ros2/sros2:
+++    hash: 2a48333bc916246acd2409aa447972326cc93529
+++    shallow_since: 1684467056 +0800
+++    type: git
+++    url: https://github.com/ros2/sros2.git
+++    version: 0.11.3
+++  ros2/system_tests:
+++    hash: 20d99d56a0bdfbcd6a327c03606baba40bcce961
+++    shallow_since: 1689272180 +0800
+++    type: git
+++    url: https://github.com/ros2/system_tests.git
+++    version: 0.15.2
+++  ros2/test_interface_files:
+++    hash: 3abbbf68d939cac86e53992b68ee93f9a37fff41
+++    shallow_since: 1676323227 +0000
+++    type: git
+++    url: https://github.com/ros2/test_interface_files.git
+++    version: 0.10.2
+++  ros2/tinyxml2_vendor:
+++    hash: 5ab72a0066240820f82aaaa350e3faba93b224da
+++    shallow_since: 1694159411 +0800
+++    type: git
+++    url: https://github.com/ros2/tinyxml2_vendor.git
+++    version: 0.8.3
+++  ros2/tinyxml_vendor:
+++    hash: 82db8fdf7d00e9d2ca8947b631a4c1fe6c2681e3
+++    shallow_since: 1676384403 +0000
+++    type: git
+++    url: https://github.com/ros2/tinyxml_vendor.git
+++    version: 0.9.2
+++  ros2/tlsf:
+++    hash: 87d6056c39a6224d166480148c921552a8455f3c
+++    shallow_since: 1676384319 +0000
+++    type: git
+++    url: https://github.com/ros2/tlsf.git
+++    version: 0.8.2
+++  ros2/unique_identifier_msgs:
+++    hash: 1ced881f07e5d5744d01867b1caedbc13c856195
+++    shallow_since: 1676323080 +0000
+++    type: git
+++    url: https://github.com/ros2/unique_identifier_msgs.git
+++    version: 2.3.2
+++  ros2/urdf:
+++    hash: a4e593d04a921d8450006432a4c33843419179a2
+++    shallow_since: 1676324735 +0000
+++    type: git
+++    url: https://github.com/ros2/urdf.git
+++    version: 2.8.2
+++  ros2/yaml_cpp_vendor:
+++    hash: 1c54425e7a017498b14840d864a6acb237de2afd
+++    shallow_since: 1676322906 +0000
+++    type: git
+++    url: https://github.com/ros2/yaml_cpp_vendor.git
+++    version: 8.1.2
++-- 
++2.34.1
++
++
++From 8b2c48e27b7b47f6ac966b499e8e9fec2b32388d Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Wed, 27 Sep 2023 21:00:25 -0700
++Subject: [PATCH 08/27] Add http_archive support
++
++---
++ repos/config/detail/generate_ros2_config.py |  24 +-
++ repos/config/detail/http_archive.bzl        |  80 ++
++ repos/config/detail/lock_repos.py           |  65 +-
++ repos/config/ros2_foxy.lock                 | 792 +++++++++---------
++ repos/config/ros2_humble.lock               | 824 +++++++++----------
++ repos/config/ros2_iron.lock                 | 850 ++++++++++----------
++ 6 files changed, 1392 insertions(+), 1243 deletions(-)
++ create mode 100644 repos/config/detail/http_archive.bzl
++
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 450e517..399ab2e 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -19,6 +19,7 @@ import yaml
++ 
++ HEADER = """
++ load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
++ load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++ 
++@@ -36,7 +37,9 @@ def print_setup(repos):
++ 
++ def build_load_command(repo, spec):
++     if spec.get('type') == "git":
++-        return build_remote_load_command(repo, spec)
+++        return build_git_load_command(repo, spec)
+++    if spec.get('type') == "http_archive":
+++        return build_http_archive_load_command(repo, spec)
++     if spec.get('type') == "local":
++         return build_local_load_command(repo, spec)
++     else:
++@@ -45,6 +48,22 @@ def build_load_command(repo, spec):
++ """
++ 
++ 
+++def build_http_archive_load_command(repo, spec):
+++    build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
+++    return f"""
+++    print("Loading: @{repo.replace('/','.')}")
+++    _maybe(
+++        name = "{repo.replace('/','.')}",
+++        build_files = {{
+++{build_files}
+++        }},
+++        url = "{spec['url']}",
+++        sha256 = "{spec['hash']}",
+++        strip_prefix = "{spec['strip_prefix']}",
+++        repo_rule = http_archive,
+++    )
+++"""
+++
++ def build_local_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""
++@@ -55,11 +74,12 @@ def build_local_load_command(repo, spec):
++ {build_files}
++         }},
++         path = "{spec['path']}",
+++        sha256 = "{spec['hash']}",
++         repo_rule = _new_local_repository,
++     )
++ """
++ 
++-def build_remote_load_command(repo, spec):
+++def build_git_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""
++     print("Loading: @{repo.replace('/','.')}")
++diff --git a/repos/config/detail/http_archive.bzl b/repos/config/detail/http_archive.bzl
++new file mode 100644
++index 0000000..e34d594
++--- /dev/null
+++++ b/repos/config/detail/http_archive.bzl
++@@ -0,0 +1,80 @@
+++# Copyright 2022 Apex.AI, Inc.
+++#
+++# Licensed under the Apache License, Version 2.0 (the "License");
+++# you may not use this file except in compliance with the License.
+++# You may obtain a copy of the License at
+++#
+++#     http://www.apache.org/licenses/LICENSE-2.0
+++#
+++# Unless required by applicable law or agreed to in writing, software
+++# distributed under the License is distributed on an "AS IS" BASIS,
+++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+++# See the License for the specific language governing permissions and
+++# limitations under the License.
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", "update_attrs")
+++
+++_archive_attrs = {
+++    "url": attr.string(
+++        doc = "URI of the archive.",
+++    ),
+++    "strip_prefix": attr.string(
+++        doc =
+++            "Path prefix to be stripped.",
+++    ),
+++    "sha256": attr.string(
+++        doc =
+++            "Hash of the commit to be checked out.",
+++    ),
+++    "build_files": attr.label_keyed_string_dict(
+++        doc =
+++            "Same as in native rule.",
+++    ),
+++}
+++
+++def _execute_or_fail(ctx, args, **kwargs):
+++    result = ctx.execute(args, **kwargs)
+++    if result.return_code != 0:
+++        fail(result.stderr)
+++    return result
+++
+++def _file_exists(ctx, file_name):
+++    exec_result = ctx.execute(["ls", file_name])
+++    if exec_result.return_code != 0:
+++        return False
+++    return True
+++
+++def _workspace_and_buildfiles(ctx):
+++    if not _file_exists(ctx, "WORKSPACE") and not _file_exists(ctx, "WORKSPACE.bazel"):
+++        ctx.file("WORKSPACE", content = 'workspace(name = "{}")'.format(ctx.name))
+++
+++    if not _file_exists(ctx, "WORKSPACE"):
+++        ctx.symlink("WORKSPACE", "WORKSPACE.bazel")
+++
+++    for label, destinations in ctx.attr.build_files.items():
+++        if type(destinations) != type([]):
+++            destinations = [destinations]
+++            for destination in destinations:
+++                ctx.symlink(label, destination)
+++
+++def _http_archve_impl(ctx):
+++    """Implementation of the git_repository rule."""
+++
+++    download_info = ctx.download_and_extract(
+++        ctx.attr.url,
+++        sha256 = ctx.attr.sha256,
+++        stripPrefix = ctx.attr.strip_prefix,
+++    )
+++
+++    _workspace_and_buildfiles(ctx)
+++
+++    return update_attrs(ctx.attr, _archive_attrs.keys(), {"sha256": download_info.sha256})
+++
+++http_archive = repository_rule(
+++    implementation = _http_archve_impl,
+++    attrs = _archive_attrs,
+++    doc =
+++        """Custom rule to clone a git repo as external dependency.
+++        It allows to inject multiple BUILD files.
+++        """,
+++)
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index 1feaf77..b2804ff 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -19,11 +19,16 @@ import tempfile
++ import yaml
++ import subprocess
++ import os
+++import hashlib
+++from pathlib import Path
+++
+++REPO_TYPES = ["git", "tar"]
++ 
++ def main():
++     parser = argparse.ArgumentParser(description="Generate a lock file for a given repos file.")
++     parser.add_argument('repos', type=str, help='Input YAML file')
++     parser.add_argument('lock', type=str, help='Output YAML file with pinned repos')
+++    parser.add_argument('--tar', action='store_true', help='Use the Github archive download.')
++ 
++     args = parser.parse_args()
++     print(f"Calling {args.repos} {args.lock}")
++@@ -35,12 +40,14 @@ def main():
++         raise ValueError("No repositories attribute found")
++ 
++     for repo, spec in repos["repositories"].items():
++-        if spec["type"] != "git":
++-            raise ValueError(f"Repo type {spec['type']} not supported.")
++-        commit_hash, time = fetch_repo_details(spec['url'], spec['version'])
++-        repos["repositories"][repo]["hash"] = commit_hash
++-        repos["repositories"][repo]["shallow_since"] = time
++-        print("{}: {}, {}".format(repo, commit_hash, time))
+++        if not spec["type"] in REPO_TYPES:
+++            raise ValueError(f"Repo type {spec['type']} not supported. Need one of {REPO_TYPES} instead.")
+++        if args.tar == True:
+++            additional_attributes = fetch_archive_details(spec['url'], spec['version'])
+++        else:
+++            additional_attributes = fetch_repo_details(spec['url'], spec['version'])
+++        add_attributes(repos["repositories"][repo], additional_attributes)
+++        print("{}: {}".format(repo, [*additional_attributes.values()]))
++ 
++     with open(args.lock, "w", encoding='utf8') as lock_file:
++         print(
++@@ -49,6 +56,45 @@ def main():
++         )
++         yaml.dump(repos, lock_file, default_flow_style=False, allow_unicode=True)
++ 
+++def add_attributes(dictionary, additional_attributes):
+++    for k,v in additional_attributes.items():
+++        dictionary[k] = v
+++
+++def fetch_archive_details(url, tag):
+++    cwd = os.getcwd()
+++    with tempfile.TemporaryDirectory() as tempdir:
+++        url = url.rsplit(".git", 1)[0]
+++        project = url.split('/')[-1]
+++        url += f"/archive/refs/tags/{tag}.tar.gz"
+++        result = subprocess.run(
+++            ["curl", "-L", "-f", "-o", "archive.tar.gz", url],
+++            stdout=subprocess.PIPE,
+++            encoding='utf8'
+++        )
+++        if result.returncode != 0:
+++            raise ValueError(f"Error loading {url}, {tag}: " + (result.stderr or ""))
+++
+++        archive_bytes = Path('archive.tar.gz').read_bytes()
+++        hash = hashlib.sha256(archive_bytes).hexdigest()
+++        strip_prefix = extract_archive_root_folder("archive.tar.gz", url)
+++
+++    return {
+++        "hash":hash,
+++        "url": url,
+++        "strip_prefix": strip_prefix,
+++        "type": "http_archive",
+++    }
+++
+++def extract_archive_root_folder(path, origin):
+++    result = subprocess.run(
+++        ["tar", "-tf", path],
+++        capture_output = True,
+++        encoding='utf8'
+++    )
+++    if result.returncode != 0:
+++        raise ValueError(f"Not able to read archive from {origin}: " + result.stderr)
+++    return result.stdout.split('\n')[0].split('/')[0]
+++
++ 
++ def fetch_repo_details(url, branch):
++     cwd = os.getcwd()
++@@ -56,7 +102,7 @@ def fetch_repo_details(url, branch):
++         result = subprocess.run(
++             ["git", "clone", url, "--no-checkout", tempdir, "--depth", "1",
++              "--branch", branch, "--bare", "-q"],
++-            stdout=subprocess.PIPE,
+++            capture_output = True,
++             encoding='utf8'
++         )
++         if result.returncode != 0:
++@@ -71,7 +117,10 @@ def fetch_repo_details(url, branch):
++             raise ValueError(result.stderr)
++         commit_hash, time = result.stdout.split("/")
++         os.chdir(cwd)
++-    return commit_hash, time
+++    return {
+++        "hash":commit_hash,
+++        "shallow_since": time,
+++    }
++ 
++ 
++ if __name__ == "__main__":
++diff --git a/repos/config/ros2_foxy.lock b/repos/config/ros2_foxy.lock
++index 02fa9b4..5a853da 100644
++--- a/repos/config/ros2_foxy.lock
+++++ b/repos/config/ros2_foxy.lock
++@@ -3,596 +3,596 @@
++ #
++ repositories:
++   ament/ament_cmake:
++-    hash: 66de46c160e289ec8ac2f31407803ae56a271087
++-    shallow_since: 1685148721 +0000
++-    type: git
++-    url: https://github.com/ament/ament_cmake.git
+++    hash: cc47e150f5a278d0e6f3dd3748732bfaf944ac3d30ff53c71195f9bda9895c6e
+++    strip_prefix: ament_cmake-0.9.12
+++    type: http_archive
+++    url: https://github.com/ament/ament_cmake/archive/refs/tags/0.9.12.tar.gz
++     version: 0.9.12
++   ament/ament_index:
++-    hash: 07492c3ada0f835464ef55178080f3df93c22292
++-    shallow_since: 1625088023 -0700
++-    type: git
++-    url: https://github.com/ament/ament_index.git
+++    hash: a3d2342039d3f8270ce910f13c087f4cc05fad16fa5ff28d874a15b3b5b345b6
+++    strip_prefix: ament_index-1.1.0
+++    type: http_archive
+++    url: https://github.com/ament/ament_index/archive/refs/tags/1.1.0.tar.gz
++     version: 1.1.0
++   ament/ament_lint:
++-    hash: 87f826b8f5c63b35d4d80c8f1520e35560326762
++-    shallow_since: 1678107663 +0000
++-    type: git
++-    url: https://github.com/ament/ament_lint.git
+++    hash: e5f8b11691bc296aff8be0c46370c92e7cd1b6162603ee7990c2bb23d93309db
+++    strip_prefix: ament_lint-0.9.8
+++    type: http_archive
+++    url: https://github.com/ament/ament_lint/archive/refs/tags/0.9.8.tar.gz
++     version: 0.9.8
++   ament/ament_package:
++-    hash: 3397bb0ae1cc93d93e1e27da31c0bcb0f4fe0f46
++-    shallow_since: 1619069192 -0700
++-    type: git
++-    url: https://github.com/ament/ament_package.git
+++    hash: 634fca3becf9567a36e9bc967cbd5189eed25604723f30b1c69273c111f36b1a
+++    strip_prefix: ament_package-0.9.5
+++    type: http_archive
+++    url: https://github.com/ament/ament_package/archive/refs/tags/0.9.5.tar.gz
++     version: 0.9.5
++   ament/google_benchmark_vendor:
++-    hash: 5f7ea6709618af640499b717f66899a33798390c
++-    shallow_since: 1600189262 -0700
++-    type: git
++-    url: https://github.com/ament/google_benchmark_vendor.git
+++    hash: b254da85b1c58a371a38e8342aa65bd3b00a4e2ef432a8ab6553eba5048106e7
+++    strip_prefix: google_benchmark_vendor-0.0.3
+++    type: http_archive
+++    url: https://github.com/ament/google_benchmark_vendor/archive/refs/tags/0.0.3.tar.gz
++     version: 0.0.3
++   ament/googletest:
++-    hash: 7c20e2597a2d1503cf9afa159206ab8e9b233830
++-    shallow_since: 1630440154 -0700
++-    type: git
++-    url: https://github.com/ament/googletest.git
+++    hash: 829df71f77d678b15456ebb41dcf38dacf2b1621e1e40abcfcdd4ad26b985720
+++    strip_prefix: googletest-1.8.9001
+++    type: http_archive
+++    url: https://github.com/ament/googletest/archive/refs/tags/1.8.9001.tar.gz
++     version: 1.8.9001
++   ament/uncrustify_vendor:
++-    hash: 0291bc988c45846400aca50cb973bf04a4de3d56
++-    shallow_since: 1586541269 +0000
++-    type: git
++-    url: https://github.com/ament/uncrustify_vendor.git
+++    hash: 38f0a52ab917900d81c21d7ff6b2a4f7b44bfe896f4e0e7b6aea96795610b917
+++    strip_prefix: uncrustify_vendor-1.4.0
+++    type: http_archive
+++    url: https://github.com/ament/uncrustify_vendor/archive/refs/tags/1.4.0.tar.gz
++     version: 1.4.0
++   eProsima/Fast-CDR:
++-    hash: 174f6ff1d3a227c5c900a4587ee32fa888267f5e
++-    shallow_since: 1585310200 +0100
++-    type: git
++-    url: https://github.com/eProsima/Fast-CDR.git
+++    hash: e4a2e545703fbc33174daa352d2f0f2973cd00c06c17b87f67c4f139f36dc9dd
+++    strip_prefix: Fast-CDR-1.0.13
+++    type: http_archive
+++    url: https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.13.tar.gz
++     version: v1.0.13
++   eProsima/Fast-DDS:
++-    hash: 680cb71c7f3a9fb4b7e348d7d68ee2dbf4dd6d8d
++-    shallow_since: 1674805970 +0100
++-    type: git
++-    url: https://github.com/eProsima/Fast-DDS.git
+++    hash: 38aafd12e4defba7ebcb08bcf15674325bbb69c9cf2e93bd0f56c95d78a761ea
+++    strip_prefix: Fast-DDS-2.1.3
+++    type: http_archive
+++    url: https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.1.3.tar.gz
++     version: v2.1.3
++   eProsima/foonathan_memory_vendor:
++-    hash: da062db05975d24a4b53de5a4122b47f6824997f
++-    shallow_since: 1637848987 +0100
++-    type: git
++-    url: https://github.com/eProsima/foonathan_memory_vendor.git
+++    hash: b10278c877e274fe751b4b3eebeefabc34efe264c28850d05f1c22b310a84562
+++    strip_prefix: foonathan_memory_vendor-1.2.0
+++    type: http_archive
+++    url: https://github.com/eProsima/foonathan_memory_vendor/archive/refs/tags/v1.2.0.tar.gz
++     version: v1.2.0
++   eclipse-cyclonedds/cyclonedds:
++-    hash: c261053186c455abc63ca5ac7d56c0808a59c364
++-    shallow_since: 1596471565 +0200
++-    type: git
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+++    hash: ff3a8545c78c0019014bbb906da2f44184e919a4f9985995014a0b08238d86e5
+++    strip_prefix: cyclonedds-0.7.0
+++    type: http_archive
+++    url: https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.7.0.tar.gz
++     version: 0.7.0
++   osrf/osrf_pycommon:
++-    hash: cbf70da8ada598f81bd86cdc0654b66f44d88d49
++-    shallow_since: 1630447467 -0700
++-    type: git
++-    url: https://github.com/osrf/osrf_pycommon.git
+++    hash: 79ecd4c267e2eb0effd376528226581d66cbdb81daa1d8b78c81bb0007b21c69
+++    strip_prefix: osrf_pycommon-0.1.11
+++    type: http_archive
+++    url: https://github.com/osrf/osrf_pycommon/archive/refs/tags/0.1.11.tar.gz
++     version: 0.1.11
++   osrf/osrf_testing_tools_cpp:
++-    hash: 1798d936e48b945d07d1c3209573f7c6de6137d0
++-    shallow_since: 1630448207 -0700
++-    type: git
++-    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+++    hash: c62f1b5d392773a4661429d2f3163858af6a5cc3892b5933513f004890109b02
+++    strip_prefix: osrf_testing_tools_cpp-1.3.4
+++    type: http_archive
+++    url: https://github.com/osrf/osrf_testing_tools_cpp/archive/refs/tags/1.3.4.tar.gz
++     version: 1.3.4
++   ros-perception/laser_geometry:
++-    hash: 2a94c2114832496852804f120559e545a90058e3
++-    shallow_since: 1588279117 +0000
++-    type: git
++-    url: https://github.com/ros-perception/laser_geometry.git
+++    hash: 387c30d258f23c2c76884b7517d318b1f4dd9ccb4cf5de825833b4bede0c7ddb
+++    strip_prefix: laser_geometry-2.2.0
+++    type: http_archive
+++    url: https://github.com/ros-perception/laser_geometry/archive/refs/tags/2.2.0.tar.gz
++     version: 2.2.0
++   ros-planning/navigation_msgs:
++-    hash: fe880e99d993e9d4dfbf37f00d839d32994610e1
++-    shallow_since: 1569867654 -0500
++-    type: git
++-    url: https://github.com/ros-planning/navigation_msgs.git
+++    hash: 121d024c6fe421c0f8af725cf3fbb0ca3ef305abb712f094b4a1c22b1369d103
+++    strip_prefix: navigation_msgs-2.0.2
+++    type: http_archive
+++    url: https://github.com/ros-planning/navigation_msgs/archive/refs/tags/2.0.2.tar.gz
++     version: 2.0.2
++   ros-tooling/libstatistics_collector:
++-    hash: 28e3c4634dc106b1e5209a776e9a56325f16c84a
++-    shallow_since: 1678980793 -0400
++-    type: git
++-    url: https://github.com/ros-tooling/libstatistics_collector.git
+++    hash: 3f8fbc7839e3c08b66110b37117e4f54aaf7b7772082580fb1598098590d0a9e
+++    strip_prefix: libstatistics_collector-1.0.2
+++    type: http_archive
+++    url: https://github.com/ros-tooling/libstatistics_collector/archive/refs/tags/1.0.2.tar.gz
++     version: 1.0.2
++   ros-visualization/interactive_markers:
++-    hash: 649aa3f5cfaea70847568bd6a679c67c797e0634
++-    shallow_since: 1607467079 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/interactive_markers.git
+++    hash: acd0d8f9bd8e320354975cb708196260975cce81d11c52d0de0d6f2c1b574a24
+++    strip_prefix: interactive_markers-2.1.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/interactive_markers/archive/refs/tags/2.1.3.tar.gz
++     version: 2.1.3
++   ros-visualization/python_qt_binding:
++-    hash: 7ff71b0bfd201cc1dbc328bcec42254dd55b523f
++-    shallow_since: 1611588397 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/python_qt_binding.git
+++    hash: df703274415a231bffe87f394c17e6da08c1ef8b0a495dbad24e15f265993251
+++    strip_prefix: python_qt_binding-1.0.6
+++    type: http_archive
+++    url: https://github.com/ros-visualization/python_qt_binding/archive/refs/tags/1.0.6.tar.gz
++     version: 1.0.6
++   ros-visualization/qt_gui_core:
++-    hash: c62463ce58a331511e74ed0d9b50551cfd0e6fca
++-    shallow_since: 1630449477 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/qt_gui_core.git
+++    hash: fa30a9bb3bc141e593fc4d4d0e14bae9e429d8b094b5135b52eb715d53e04e10
+++    strip_prefix: qt_gui_core-1.1.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/qt_gui_core/archive/refs/tags/1.1.3.tar.gz
++     version: 1.1.3
++   ros-visualization/rqt:
++-    hash: a545fbe3d36930f20e71c2df9bc318fa14dec392
++-    shallow_since: 1630449731 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt.git
+++    hash: 35c1f18e923d55e0b95fa13def53e092e6b39982679752267dbbd3684f0a3137
+++    strip_prefix: rqt-1.1.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt/archive/refs/tags/1.1.2.tar.gz
++     version: 1.1.2
++   ros-visualization/rqt_action:
++-    hash: c4790fb653f37028a772ba51d524ba27f77899b0
++-    shallow_since: 1678960338 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_action.git
+++    hash: dc67ca6ea25dd82540fd4fe1e9d9abd6bff8b50c97455d746a64b99046fb4c46
+++    strip_prefix: rqt_action-1.0.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_action/archive/refs/tags/1.0.2.tar.gz
++     version: 1.0.2
++   ros-visualization/rqt_console:
++-    hash: 0ee70d7f2912c75e840a925b666ed794fb41383f
++-    shallow_since: 1657920903 +0900
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_console.git
+++    hash: 1073cc0173fc9be9fc3f015fdc55ec6fe97a5aff3809496ef93e8421afffcc1c
+++    strip_prefix: rqt_console-1.1.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_console/archive/refs/tags/1.1.2.tar.gz
++     version: 1.1.2
++   ros-visualization/rqt_graph:
++-    hash: e3495e424ba748605a5d08ebc35fb2b6a5a467b5
++-    shallow_since: 1643664354 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_graph.git
+++    hash: 1432db629ebad3b9bfee458a5c73171ff12a494d6724dae99b867a1cf992a069
+++    strip_prefix: rqt_graph-1.1.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_graph/archive/refs/tags/1.1.3.tar.gz
++     version: 1.1.3
++   ros-visualization/rqt_msg:
++-    hash: 6aec29bdb3079f545279f267fe8c237de177de30
++-    shallow_since: 1678960359 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_msg.git
+++    hash: fd459c93e822d41916edc9b1c55017f6f462b9db1868db2e8eeeabe90d62572c
+++    strip_prefix: rqt_msg-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_msg/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/rqt_plot:
++-    hash: d2e7329fd49cf72aa12ff7348dc2df2b93bb9fcb
++-    shallow_since: 1642183460 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_plot.git
+++    hash: 3728fb1b694e4ea7c5458cfca308195b8de0fee31f85c5839ce5c52166f9ddd0
+++    strip_prefix: rqt_plot-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_plot/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/rqt_publisher:
++-    hash: b1f49f95a5aa7d07187deb5c5b0954a140e0020d
++-    shallow_since: 1659469749 -0400
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_publisher.git
+++    hash: 6165c7893bf9df8497e0b26c02ba3bd9ed7c61f79c89b5fc8a57f13f88aa217b
+++    strip_prefix: rqt_publisher-1.3.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_publisher/archive/refs/tags/1.3.0.tar.gz
++     version: 1.3.0
++   ros-visualization/rqt_py_console:
++-    hash: 36ad6e467f7add9279a4cd54d3e02ebcbd936d5b
++-    shallow_since: 1630451545 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_py_console.git
+++    hash: 1cb589b7c2b6bb445eef1cbfdceedd8d517b2f9d1b8cb2f22a767d612cba40b6
+++    strip_prefix: rqt_py_console-1.0.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_py_console/archive/refs/tags/1.0.2.tar.gz
++     version: 1.0.2
++   ros-visualization/rqt_reconfigure:
++-    hash: 9c848b0e5ff583f1161a7ba39ec5ac1fe9075be9
++-    shallow_since: 1620652868 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_reconfigure.git
+++    hash: 2be8f32eeab024c32d452795a91957c72eb662e5930b77f60daaf4d0ed354fa7
+++    strip_prefix: rqt_reconfigure-1.0.8
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_reconfigure/archive/refs/tags/1.0.8.tar.gz
++     version: 1.0.8
++   ros-visualization/rqt_service_caller:
++-    hash: c9afeb84e9db4807c895e345294f2d521abf3859
++-    shallow_since: 1630451643 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_service_caller.git
+++    hash: 5e3802f444b50594f3a7dc80977286609b88a50f1ad77f9208e45911889ae825
+++    strip_prefix: rqt_service_caller-1.0.5
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_service_caller/archive/refs/tags/1.0.5.tar.gz
++     version: 1.0.5
++   ros-visualization/rqt_shell:
++-    hash: 50639b2252fc0d02bcc3361284b67baa44a87c3b
++-    shallow_since: 1630452741 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_shell.git
+++    hash: 0308be57b7e1ed81d66035c21ce37d37ab00a599c85a7667d7487b8786805987
+++    strip_prefix: rqt_shell-1.0.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_shell/archive/refs/tags/1.0.2.tar.gz
++     version: 1.0.2
++   ros-visualization/rqt_srv:
++-    hash: 46e8e71560008857456525ad7977aa6bd87391d5
++-    shallow_since: 1630452880 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_srv.git
+++    hash: 719a48657574e2abbdf3469773d894d542c5fbe15b2d81784868979c13fbf095
+++    strip_prefix: rqt_srv-1.0.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_srv/archive/refs/tags/1.0.3.tar.gz
++     version: 1.0.3
++   ros-visualization/rqt_top:
++-    hash: 0862fef3e4982d714d352ae8cd78f928af48c3c2
++-    shallow_since: 1630453266 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_top.git
+++    hash: a459216881372b8d3da18e484f4ed1c4edb7b1dd3e066ec778c717f0d4ab8a42
+++    strip_prefix: rqt_top-1.0.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_top/archive/refs/tags/1.0.2.tar.gz
++     version: 1.0.2
++   ros-visualization/rqt_topic:
++-    hash: 165c40154320ff613cc52e1375c6a48d30d548fd
++-    shallow_since: 1652229850 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_topic.git
+++    hash: 30bc690fa6102759a629d10a03182517beeca747ff7fb6cb5f5d15dbb9a921b4
+++    strip_prefix: rqt_topic-1.3.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_topic/archive/refs/tags/1.3.0.tar.gz
++     version: 1.3.0
++   ros-visualization/tango_icons_vendor:
++-    hash: b349608986293db04c9d05b09f05685312a15ae6
++-    shallow_since: 1619722112 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/tango_icons_vendor.git
+++    hash: 918e3b3138bd2769b9781b0d7015132d815d540f8f2b8b1c16efbeda46b8916e
+++    strip_prefix: tango_icons_vendor-0.1.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/tango_icons_vendor/archive/refs/tags/0.1.0.tar.gz
++     version: 0.1.0
++   ros/class_loader:
++-    hash: 58102cf049b20fcf361330ae7f400a89a530c23a
++-    shallow_since: 1658530578 -0700
++-    type: git
++-    url: https://github.com/ros/class_loader.git
+++    hash: 3cb3488410a9d5986e4b64cc9c754a81cc3b6fe41d6e376e5b5923806731358a
+++    strip_prefix: class_loader-2.0.3
+++    type: http_archive
+++    url: https://github.com/ros/class_loader/archive/refs/tags/2.0.3.tar.gz
++     version: 2.0.3
++   ros/kdl_parser:
++-    hash: 77d8ab5f6260283c1941e424e2100951c71d7892
++-    shallow_since: 1596836291 -0700
++-    type: git
++-    url: https://github.com/ros/kdl_parser.git
+++    hash: 91b5e3e55f2b1fe746e2f39b2d06dd72334e3eeda30c086fdfd7e026ce369885
+++    strip_prefix: kdl_parser-2.4.1
+++    type: http_archive
+++    url: https://github.com/ros/kdl_parser/archive/refs/tags/2.4.1.tar.gz
++     version: 2.4.1
++   ros/pluginlib:
++-    hash: df8ba5196fc0897e3ed9448437c32306f2708f5d
++-    shallow_since: 1643665148 -0800
++-    type: git
++-    url: https://github.com/ros/pluginlib.git
+++    hash: f0659a828bc77c588c26237c3998752a3172a93dbc84e3200dccf084e5611bae
+++    strip_prefix: pluginlib-2.5.4
+++    type: http_archive
+++    url: https://github.com/ros/pluginlib/archive/refs/tags/2.5.4.tar.gz
++     version: 2.5.4
++   ros/resource_retriever:
++-    hash: f20037d20a3a69c4f580a1f127b528884c3575ac
++-    shallow_since: 1607452438 -0800
++-    type: git
++-    url: https://github.com/ros/resource_retriever.git
+++    hash: a754feeb1018f488a639f13ed64e7dafe5a9322c235af0ca841ba4827a6b2924
+++    strip_prefix: resource_retriever-2.3.4
+++    type: http_archive
+++    url: https://github.com/ros/resource_retriever/archive/refs/tags/2.3.4.tar.gz
++     version: 2.3.4
++   ros/robot_state_publisher:
++-    hash: a1346e963b04b2c452eccdcbf69c7b8f81db314d
++-    shallow_since: 1628083173 +0000
++-    type: git
++-    url: https://github.com/ros/robot_state_publisher.git
+++    hash: 28e86197f722b54e47b6bcdac5d3715a69702176c0a6f743b0570882e14a02ed
+++    strip_prefix: robot_state_publisher-2.4.5
+++    type: http_archive
+++    url: https://github.com/ros/robot_state_publisher/archive/refs/tags/2.4.5.tar.gz
++     version: 2.4.5
++   ros/ros_environment:
++-    hash: acb84116c976fdd9441bdf5b22337b10bfec2b2a
++-    shallow_since: 1658530668 -0700
++-    type: git
++-    url: https://github.com/ros/ros_environment.git
+++    hash: 2a4d5b38f7ddc2c77023b53c9997c789d54676cd4486ccd4eb0850b0da515c1b
+++    strip_prefix: ros_environment-2.5.1
+++    type: http_archive
+++    url: https://github.com/ros/ros_environment/archive/refs/tags/2.5.1.tar.gz
++     version: 2.5.1
++   ros/ros_tutorials:
++-    hash: 2a2eba45652c62f907daec3338fcc36cdae90fb5
++-    shallow_since: 1658530772 -0700
++-    type: git
++-    url: https://github.com/ros/ros_tutorials.git
+++    hash: 94836061109633c9f6774a4ecb6be7eeba57077560c4c0eefd24664e431a343f
+++    strip_prefix: ros_tutorials-1.2.6
+++    type: http_archive
+++    url: https://github.com/ros/ros_tutorials/archive/refs/tags/1.2.6.tar.gz
++     version: 1.2.6
++   ros/urdfdom:
++-    hash: 219c51f1aaec87f85ea696ef264d8f096cd39065
++-    shallow_since: 1601924035 +0000
++-    type: git
++-    url: https://github.com/ros/urdfdom.git
+++    hash: a0ec5819efc7747f22a12ccab5e2e7c4739f1f498cb4d1ee55be771f19df1510
+++    strip_prefix: urdfdom-2.3.3
+++    type: http_archive
+++    url: https://github.com/ros/urdfdom/archive/refs/tags/2.3.3.tar.gz
++     version: 2.3.3
++   ros/urdfdom_headers:
++-    hash: a15d906ff16a7fcbf037687b9c63b946c0cc04a1
++-    shallow_since: 1588962007 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom_headers.git
+++    hash: 76a68657c38e54bb45bddc4bd7d823a3b04edcd08064a56d8e7d46b9912035ac
+++    strip_prefix: urdfdom_headers-1.0.5
+++    type: http_archive
+++    url: https://github.com/ros/urdfdom_headers/archive/refs/tags/1.0.5.tar.gz
++     version: 1.0.5
++   ros2/ament_cmake_ros:
++-    hash: 7b6b599c3fc8023806db2a97b344e8610902adac
++-    shallow_since: 1620823254 +0000
++-    type: git
++-    url: https://github.com/ros2/ament_cmake_ros.git
+++    hash: 6d7d8e4612e155953327d40a7c4d6c6c57ab02f6accfc21969bae679618a5560
+++    strip_prefix: ament_cmake_ros-0.9.2
+++    type: http_archive
+++    url: https://github.com/ros2/ament_cmake_ros/archive/refs/tags/0.9.2.tar.gz
++     version: 0.9.2
++   ros2/common_interfaces:
++-    hash: 6356bc82f3a034f5d2c61c6760df0007a6cadfb0
++-    shallow_since: 1640218063 +0000
++-    type: git
++-    url: https://github.com/ros2/common_interfaces.git
+++    hash: 8cfe9b00f0dc75e6e5e2fae8de0b2c84564ce43b94c68b227e317d4dcfe77073
+++    strip_prefix: common_interfaces-2.0.5
+++    type: http_archive
+++    url: https://github.com/ros2/common_interfaces/archive/refs/tags/2.0.5.tar.gz
++     version: 2.0.5
++   ros2/console_bridge_vendor:
++-    hash: 86cb35321cf27f747ca07b3759ccacf5798dfd01
++-    shallow_since: 1618437921 -0700
++-    type: git
++-    url: https://github.com/ros2/console_bridge_vendor.git
+++    hash: d6fa9351b465fe882808ce8db7d8784a2a72bf866d524f5fba0ea1569fa286e2
+++    strip_prefix: console_bridge_vendor-1.2.4
+++    type: http_archive
+++    url: https://github.com/ros2/console_bridge_vendor/archive/refs/tags/1.2.4.tar.gz
++     version: 1.2.4
++   ros2/demos:
++-    hash: 1d01c8e3d06644c0d706ef83697a68efda7d0ad4
++-    shallow_since: 1658775204 -0700
++-    type: git
++-    url: https://github.com/ros2/demos.git
+++    hash: 5bf103f0f2d17732f2605677899a50e6aaae0af5884490e06f8ba0e713ca13c2
+++    strip_prefix: demos-0.9.4
+++    type: http_archive
+++    url: https://github.com/ros2/demos/archive/refs/tags/0.9.4.tar.gz
++     version: 0.9.4
++   ros2/eigen3_cmake_module:
++-    hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
++-    shallow_since: 1565307940 -0700
++-    type: git
++-    url: https://github.com/ros2/eigen3_cmake_module.git
+++    hash: 15d85f7c96fc14c48484e3d2e8484581e1077cf64d593b5e1fb4096700824b43
+++    strip_prefix: eigen3_cmake_module-0.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/eigen3_cmake_module/archive/refs/tags/0.1.1.tar.gz
++     version: 0.1.1
++   ros2/example_interfaces:
++-    hash: e3caaaf66bf664afc6c59d88a127f9c15597107e
++-    shallow_since: 1616077283 +0000
++-    type: git
++-    url: https://github.com/ros2/example_interfaces.git
+++    hash: 6e9c7ead1346e0fc82d4a5b7bfe48d4c0fca746c9bc9e3f035efb0589cf83be7
+++    strip_prefix: example_interfaces-0.9.1
+++    type: http_archive
+++    url: https://github.com/ros2/example_interfaces/archive/refs/tags/0.9.1.tar.gz
++     version: 0.9.1
++   ros2/examples:
++-    hash: 355adf068fccd1b147acd89de62ad7d1bece9a78
++-    shallow_since: 1607453205 -0800
++-    type: git
++-    url: https://github.com/ros2/examples.git
+++    hash: 2d92cb703992de91b1f6d71a8a5ef6eb4e9b292fd7975c7f06ad1463bafd270a
+++    strip_prefix: examples-0.9.4
+++    type: http_archive
+++    url: https://github.com/ros2/examples/archive/refs/tags/0.9.4.tar.gz
++     version: 0.9.4
++   ros2/geometry2:
++-    hash: d1dc38b8a0e706fbd67a800a241fee950fce39f4
++-    shallow_since: 1678961741 +0000
++-    type: git
++-    url: https://github.com/ros2/geometry2.git
+++    hash: ed7cf4ba0899d106870fa8fe86ff8212632fed6dc57268b6e72afcf3b035b3bd
+++    strip_prefix: geometry2-0.13.14
+++    type: http_archive
+++    url: https://github.com/ros2/geometry2/archive/refs/tags/0.13.14.tar.gz
++     version: 0.13.14
++   ros2/launch:
++-    hash: acfe0766a72474872587eb38dfdc1b04a177763b
++-    shallow_since: 1665608331 -0700
++-    type: git
++-    url: https://github.com/ros2/launch.git
+++    hash: 4f63d41cb3ed61c01f632346bdc7f0d5bd75a598b7c601e747214cdf947cd409
+++    strip_prefix: launch-0.10.10
+++    type: http_archive
+++    url: https://github.com/ros2/launch/archive/refs/tags/0.10.10.tar.gz
++     version: 0.10.10
++   ros2/launch_ros:
++-    hash: 68e2b620865a7bacc3bb4009ea607f96a5a9628e
++-    shallow_since: 1663027177 -0700
++-    type: git
++-    url: https://github.com/ros2/launch_ros.git
+++    hash: afd6f1b31a6bc985682cf2753ea96056e1132eeb0ac5d0f063ab60515f79a2ce
+++    strip_prefix: launch_ros-0.11.7
+++    type: http_archive
+++    url: https://github.com/ros2/launch_ros/archive/refs/tags/0.11.7.tar.gz
++     version: 0.11.7
++   ros2/libyaml_vendor:
++-    hash: 4d360d783b3018dfaed6d9ab9c736b720c109702
++-    shallow_since: 1618436898 -0700
++-    type: git
++-    url: https://github.com/ros2/libyaml_vendor.git
+++    hash: 813f23c58c2b3f5bd8ca4a755203dfafb882385f1e62b4d198276052690206df
+++    strip_prefix: libyaml_vendor-1.0.4
+++    type: http_archive
+++    url: https://github.com/ros2/libyaml_vendor/archive/refs/tags/1.0.4.tar.gz
++     version: 1.0.4
++   ros2/message_filters:
++-    hash: 5042d46bee8d4e31f64fe5610c1c4c2401e62788
++-    shallow_since: 1686020953 +0000
++-    type: git
++-    url: https://github.com/ros2/message_filters.git
+++    hash: 99adbb3d32dbd09d1aad7379ce05e88ade026076b6bd98c5c87dd39eef3c45e5
+++    strip_prefix: message_filters-3.2.7
+++    type: http_archive
+++    url: https://github.com/ros2/message_filters/archive/refs/tags/3.2.7.tar.gz
++     version: 3.2.7
++   ros2/mimick_vendor:
++-    hash: 1328d4fd261e5c1c22620bf60ac4292992f9df9d
++-    shallow_since: 1616098264 -0700
++-    type: git
++-    url: https://github.com/ros2/mimick_vendor.git
+++    hash: fe8d39b26a05f77cadcf0c4d68a9ffe8ace494f3b608378812c5bf577a6b7e65
+++    strip_prefix: mimick_vendor-0.2.6
+++    type: http_archive
+++    url: https://github.com/ros2/mimick_vendor/archive/refs/tags/0.2.6.tar.gz
++     version: 0.2.6
++   ros2/orocos_kinematics_dynamics:
++-    hash: 76b0f4ea5ea4f4212dc9d2d38ffa913560f7d798
++-    shallow_since: 1678962243 +0000
++-    type: git
++-    url: https://github.com/ros2/orocos_kinematics_dynamics.git
+++    hash: 8cb951d4351193575250263756029cc727232d4e0b838151269451a50cbd41eb
+++    strip_prefix: orocos_kinematics_dynamics-3.3.5
+++    type: http_archive
+++    url: https://github.com/ros2/orocos_kinematics_dynamics/archive/refs/tags/3.3.5.tar.gz
++     version: 3.3.5
++   ros2/performance_test_fixture:
++-    hash: afb01872d0c03e31cd4fda04e91af8e5548de0a3
++-    shallow_since: 1658776414 -0700
++-    type: git
++-    url: https://github.com/ros2/performance_test_fixture.git
+++    hash: 28d6039ef9fcc9281efce60d42c769d014a6a82f0a228d5bf887868282a2d770
+++    strip_prefix: performance_test_fixture-0.0.9
+++    type: http_archive
+++    url: https://github.com/ros2/performance_test_fixture/archive/refs/tags/0.0.9.tar.gz
++     version: 0.0.9
++   ros2/python_cmake_module:
++-    hash: 45a2744285c7ba310bdc6aeda1aa7e33186dab4a
++-    shallow_since: 1616076958 +0000
++-    type: git
++-    url: https://github.com/ros2/python_cmake_module.git
+++    hash: 970334bcfa231568ba6d055a4022b85b5643c9c1b665c0115d6ca73944780564
+++    strip_prefix: python_cmake_module-0.8.1
+++    type: http_archive
+++    url: https://github.com/ros2/python_cmake_module/archive/refs/tags/0.8.1.tar.gz
++     version: 0.8.1
++   ros2/rcl:
++-    hash: 287ccd9ed06ff5bdded4dfb1130920d592a71bb7
++-    shallow_since: 1658776609 -0700
++-    type: git
++-    url: https://github.com/ros2/rcl.git
+++    hash: e0b6f1607104093fc3eced0ccaf9c4c0a91c8a05560596273a767dccc6ccf2f3
+++    strip_prefix: rcl-1.1.14
+++    type: http_archive
+++    url: https://github.com/ros2/rcl/archive/refs/tags/1.1.14.tar.gz
++     version: 1.1.14
++   ros2/rcl_interfaces:
++-    hash: 48cb91129051a494f3b4b097dccd6c921bb50552
++-    shallow_since: 1590522301 +0000
++-    type: git
++-    url: https://github.com/ros2/rcl_interfaces.git
+++    hash: bb603420186394cc4e7a5f6da44d62d530f01e3246a8f78e952d21bf2d41a45b
+++    strip_prefix: rcl_interfaces-1.0.0
+++    type: http_archive
+++    url: https://github.com/ros2/rcl_interfaces/archive/refs/tags/1.0.0.tar.gz
++     version: 1.0.0
++   ros2/rcl_logging:
++-    hash: d22a6630f039bee97c6667394def926a5426a673
++-    shallow_since: 1618435530 -0700
++-    type: git
++-    url: https://github.com/ros2/rcl_logging.git
+++    hash: c7a4a8f22b77269fe99ad43c1e075bf2a3f42513bfb2531fd9e5fe9f146e6e63
+++    strip_prefix: rcl_logging-1.1.0
+++    type: http_archive
+++    url: https://github.com/ros2/rcl_logging/archive/refs/tags/1.1.0.tar.gz
++     version: 1.1.0
++   ros2/rclcpp:
++-    hash: b0c25d5f22237d42e2cedad05dbb2e5cc31a3cf4
++-    shallow_since: 1685154213 +0000
++-    type: git
++-    url: https://github.com/ros2/rclcpp.git
+++    hash: 8c4112c5273c206bb6cc1b765337f1bbd23243d307a40f3b4e667ccef9cd7505
+++    strip_prefix: rclcpp-2.4.3
+++    type: http_archive
+++    url: https://github.com/ros2/rclcpp/archive/refs/tags/2.4.3.tar.gz
++     version: 2.4.3
++   ros2/rclpy:
++-    hash: 8cf7680362cd9f84fbb2f882be004296316b9ddd
++-    shallow_since: 1685154247 +0000
++-    type: git
++-    url: https://github.com/ros2/rclpy.git
+++    hash: 109cd8093ff0207efe7ef71005faed9e7821a6b8d502bccec5211d9ce90ff53b
+++    strip_prefix: rclpy-1.0.13
+++    type: http_archive
+++    url: https://github.com/ros2/rclpy/archive/refs/tags/1.0.13.tar.gz
++     version: 1.0.13
++   ros2/rcpputils:
++-    hash: f4ce24de0b9b6b2c0c3807d6ce43418d4e1db331
++-    shallow_since: 1630457027 -0700
++-    type: git
++-    url: https://github.com/ros2/rcpputils.git
+++    hash: 778b39bb3589c16e3b6ece1ea4c3fb52898099ce712db4113d7d07d2d3e9833d
+++    strip_prefix: rcpputils-1.3.2
+++    type: http_archive
+++    url: https://github.com/ros2/rcpputils/archive/refs/tags/1.3.2.tar.gz
++     version: 1.3.2
++   ros2/rcutils:
++-    hash: 7cc5a47ee5d85d605d2291c1b04ac570a4c0faf6
++-    shallow_since: 1678961835 +0000
++-    type: git
++-    url: https://github.com/ros2/rcutils.git
+++    hash: f772dbace29be191aa83a9ae74a8502b6cba7836df0d311977225efe1699c97d
+++    strip_prefix: rcutils-1.1.5
+++    type: http_archive
+++    url: https://github.com/ros2/rcutils/archive/refs/tags/1.1.5.tar.gz
++     version: 1.1.5
++   ros2/realtime_support:
++-    hash: 934621219b8421f52fdd9a980e3011131a6a2943
++-    shallow_since: 1588277808 +0000
++-    type: git
++-    url: https://github.com/ros2/realtime_support.git
+++    hash: 304918e2eadc8452f45048cec2d7fd1de7caac78a4fc43ac127ea554fb8f768c
+++    strip_prefix: realtime_support-0.9.0
+++    type: http_archive
+++    url: https://github.com/ros2/realtime_support/archive/refs/tags/0.9.0.tar.gz
++     version: 0.9.0
++   ros2/rmw:
++-    hash: 7fa45cb0d86fef00488e707b9ef37914d7ff0369
++-    shallow_since: 1678961864 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw.git
+++    hash: b26eb2e14c456b55a860eaae5345a23f7eed732a4fab0865ebc2ef39ee65dd6d
+++    strip_prefix: rmw-1.0.4
+++    type: http_archive
+++    url: https://github.com/ros2/rmw/archive/refs/tags/1.0.4.tar.gz
++     version: 1.0.4
++   ros2/rmw_connext:
++-    hash: 86ba57ddad8d3a653a49c10b1bd736a226856b94
++-    shallow_since: 1607456760 -0800
++-    type: git
++-    url: https://github.com/ros2/rmw_connext.git
+++    hash: b2508d6a7bd1ba677c1bceec5e349d26aecaa3cd1efc88c63897d3314c04cbf1
+++    strip_prefix: rmw_connext-1.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_connext/archive/refs/tags/1.0.3.tar.gz
++     version: 1.0.3
++   ros2/rmw_cyclonedds:
++-    hash: c12abc56983204f1d91f2d839d394528c7b29b42
++-    shallow_since: 1663705274 -0700
++-    type: git
++-    url: https://github.com/ros2/rmw_cyclonedds.git
+++    hash: 1f2c42000c2e179834060170856be4cb04e6ab6dfbc301086218c49b56dc693f
+++    strip_prefix: rmw_cyclonedds-0.7.11
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_cyclonedds/archive/refs/tags/0.7.11.tar.gz
++     version: 0.7.11
++   ros2/rmw_dds_common:
++-    hash: 39d01cf8b174ffbd09e9601893f82390a770525a
++-    shallow_since: 1618434424 -0700
++-    type: git
++-    url: https://github.com/ros2/rmw_dds_common.git
+++    hash: 34e46de0e2858af57d996b5d17fbfd76b58b1c37b64321d2c6bafaf4198d64db
+++    strip_prefix: rmw_dds_common-1.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_dds_common/archive/refs/tags/1.0.3.tar.gz
++     version: 1.0.3
++   ros2/rmw_fastrtps:
++-    hash: 7da03b330655d0cdad08e60c7536e85526b62b12
++-    shallow_since: 1685154262 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_fastrtps.git
+++    hash: db97bb95c2c22dd07a1baf01af49bbf319b682994f70c5307d4bbc7ba020be1a
+++    strip_prefix: rmw_fastrtps-1.3.2
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_fastrtps/archive/refs/tags/1.3.2.tar.gz
++     version: 1.3.2
++   ros2/rmw_implementation:
++-    hash: a21d275a56140977802a82373c8796d1f7fac636
++-    shallow_since: 1643666512 -0800
++-    type: git
++-    url: https://github.com/ros2/rmw_implementation.git
+++    hash: d22bb94ba7e72f63e06ff80913c77ad95267ad3da31088d27d0d0a6575bfe538
+++    strip_prefix: rmw_implementation-1.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_implementation/archive/refs/tags/1.0.3.tar.gz
++     version: 1.0.3
++   ros2/ros1_bridge:
++-    hash: 689a932499befbd1ec3cb273a1054430e55a43c3
++-    shallow_since: 1685154274 +0000
++-    type: git
++-    url: https://github.com/ros2/ros1_bridge.git
+++    hash: d63b5c92f080fce55ee6986e3f3630d99fd3ffbe7f1e56e56348dd72250da2f6
+++    strip_prefix: ros1_bridge-0.9.7
+++    type: http_archive
+++    url: https://github.com/ros2/ros1_bridge/archive/refs/tags/0.9.7.tar.gz
++     version: 0.9.7
++   ros2/ros2_tracing:
++-    hash: f10fb2c13775fa0220833c5fa4ff82660640362a
++-    shallow_since: 1608651744 -0500
++-    type: git
++-    url: https://github.com/ros2/ros2_tracing.git
+++    hash: 552f35e1dbdc30cdd5ddeeccf278f8fc50811f15f3d2eb98e25a28fadac0ae8f
+++    strip_prefix: ros2_tracing-1.0.5
+++    type: http_archive
+++    url: https://github.com/ros2/ros2_tracing/archive/refs/tags/1.0.5.tar.gz
++     version: 1.0.5
++   ros2/ros2cli:
++-    hash: 26715cbb0948258d6f04b94c909d035c5130456a
++-    shallow_since: 1678961891 +0000
++-    type: git
++-    url: https://github.com/ros2/ros2cli.git
+++    hash: bdba1238c028c0c5102e62754b51126ad35c606905874620fd0718e7372f758d
+++    strip_prefix: ros2cli-0.9.13
+++    type: http_archive
+++    url: https://github.com/ros2/ros2cli/archive/refs/tags/0.9.13.tar.gz
++     version: 0.9.13
++   ros2/ros2cli_common_extensions:
++-    hash: 4f2d47f4417475c5036c9930b5d348a5e0774007
++-    shallow_since: 1616076624 +0000
++-    type: git
++-    url: https://github.com/ros2/ros2cli_common_extensions.git
+++    hash: 5f019ebb88f214c788caedbe33257ae290a5956c5af93332c02d4e0946aaa702
+++    strip_prefix: ros2cli_common_extensions-0.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/ros2cli_common_extensions/archive/refs/tags/0.1.1.tar.gz
++     version: 0.1.1
++   ros2/ros_testing:
++-    hash: 45055af5100f981454f2c4c6f672e0e16fe0d0c3
++-    shallow_since: 1588232802 -0700
++-    type: git
++-    url: https://github.com/ros2/ros_testing.git
+++    hash: 1def68962286e95dcbce54445f5589429d7d6fb44b580183356c3281b3670798
+++    strip_prefix: ros_testing-0.2.1
+++    type: http_archive
+++    url: https://github.com/ros2/ros_testing/archive/refs/tags/0.2.1.tar.gz
++     version: 0.2.1
++   ros2/rosbag2:
++-    hash: 77f5a51b4d5cd70ea6a78d53cffe964e3b9afaf7
++-    shallow_since: 1685547940 -0700
++-    type: git
++-    url: https://github.com/ros2/rosbag2.git
+++    hash: 9856b06c225522fbadf262231b96ba8557bf29688e0cf70d431e1c1ac299ff33
+++    strip_prefix: rosbag2-0.3.11
+++    type: http_archive
+++    url: https://github.com/ros2/rosbag2/archive/refs/tags/0.3.11.tar.gz
++     version: 0.3.11
++   ros2/rosidl:
++-    hash: 62bc7072d9078cfd7c63ebb1d12ca6e9732491b4
++-    shallow_since: 1685154334 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl.git
+++    hash: 7acf68ee029bba805ff48ebf19b6c895ec64378e3676caafab62700aa4797db4
+++    strip_prefix: rosidl-1.3.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl/archive/refs/tags/1.3.1.tar.gz
++     version: 1.3.1
++   ros2/rosidl_dds:
++-    hash: e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc
++-    shallow_since: 1557357026 -0500
++-    type: git
++-    url: https://github.com/ros2/rosidl_dds.git
+++    hash: c158bb43caa1fd9ae0dfb23397e28643c9cdbb4673c9aa6f9fe9e5e2dfad893e
+++    strip_prefix: rosidl_dds-0.7.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_dds/archive/refs/tags/0.7.1.tar.gz
++     version: 0.7.1
++   ros2/rosidl_defaults:
++-    hash: cbc7ffd38d98c5b15823fc62b0891d2264ae4472
++-    shallow_since: 1618433870 -0700
++-    type: git
++-    url: https://github.com/ros2/rosidl_defaults.git
+++    hash: 9b80033b28589e881957a5267d7f6c983f794c360f82c28b8ab36a4547094cc3
+++    strip_prefix: rosidl_defaults-1.0.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_defaults/archive/refs/tags/1.0.1.tar.gz
++     version: 1.0.1
++   ros2/rosidl_python:
++-    hash: 6630bdf134b0d37e466c6d232e57e7de268be1b3
++-    shallow_since: 1678961921 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_python.git
+++    hash: ffbfce6556f36b763fd4ba7bdfdc535cad1990eedabaa88f58c53bc77f0ccf12
+++    strip_prefix: rosidl_python-0.9.7
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_python/archive/refs/tags/0.9.7.tar.gz
++     version: 0.9.7
++   ros2/rosidl_runtime_py:
++-    hash: 63a9c99ad735ef08b9cfda69ba35322b5f8b75f3
++-    shallow_since: 1616078071 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_runtime_py.git
+++    hash: b171a9358ed30df2f702f64c4618872c22802287dbf7b6d27310bd6c8a550dcf
+++    strip_prefix: rosidl_runtime_py-0.9.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_runtime_py/archive/refs/tags/0.9.1.tar.gz
++     version: 0.9.1
++   ros2/rosidl_typesupport:
++-    hash: 08bec09e39f68a29ca15d8177f084118a47eaa92
++-    shallow_since: 1685154344 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport.git
+++    hash: 7e0b46bfdc2040d7dda295641cfb40f9981ca4155c561e164e1c20017a7bc40f
+++    strip_prefix: rosidl_typesupport-1.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_typesupport/archive/refs/tags/1.0.3.tar.gz
++     version: 1.0.3
++   ros2/rosidl_typesupport_connext:
++-    hash: 3cde17b7b5eeaa460e4593ce44f6dbf3ebcbfeef
++-    shallow_since: 1618433168 -0700
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_connext.git
+++    hash: 521f4de1cc22d9f6eaa51774ae88ccc269291d7b4cbee371a27a04aa179018cb
+++    strip_prefix: rosidl_typesupport_connext-1.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_typesupport_connext/archive/refs/tags/1.0.3.tar.gz
++     version: 1.0.3
++   ros2/rosidl_typesupport_fastrtps:
++-    hash: 9741bc17dedbf6a4f3fed86c6d5bc30c1603d0f0
++-    shallow_since: 1630458352 -0700
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+++    hash: 496108424f8bd628901a50f504f9ebee05f284bbc73e244824be6d103e14c0f5
+++    strip_prefix: rosidl_typesupport_fastrtps-1.0.4
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_typesupport_fastrtps/archive/refs/tags/1.0.4.tar.gz
++     version: 1.0.4
++   ros2/rpyutils:
++-    hash: 3e41fe4d71bc16f5a727a010f835fb49376b52b3
++-    shallow_since: 1599856543 -0700
++-    type: git
++-    url: https://github.com/ros2/rpyutils.git
+++    hash: 8b321fd04ffc65b7be2e8d6e4dde6e632bac291021dc5adc67077c9cac601243
+++    strip_prefix: rpyutils-0.2.0
+++    type: http_archive
+++    url: https://github.com/ros2/rpyutils/archive/refs/tags/0.2.0.tar.gz
++     version: 0.2.0
++   ros2/rviz:
++-    hash: 22179fc7a2fed72cd3f38e6712c62e2228a36001
++-    shallow_since: 1678961939 +0000
++-    type: git
++-    url: https://github.com/ros2/rviz.git
+++    hash: 92f2eb70dc085a97e2acc059f1d4446a66ca1551db6b65804b43227eaad2d060
+++    strip_prefix: rviz-8.2.8
+++    type: http_archive
+++    url: https://github.com/ros2/rviz/archive/refs/tags/8.2.8.tar.gz
++     version: 8.2.8
++   ros2/spdlog_vendor:
++-    hash: 8eb6d4f2c64e7166596e4a57f7293b899ece34e0
++-    shallow_since: 1617908033 -0700
++-    type: git
++-    url: https://github.com/ros2/spdlog_vendor.git
+++    hash: d2c9b3ac17788040d8539a4520643f237af97ebded9682c741cd2063b85a0636
+++    strip_prefix: spdlog_vendor-1.1.3
+++    type: http_archive
+++    url: https://github.com/ros2/spdlog_vendor/archive/refs/tags/1.1.3.tar.gz
++     version: 1.1.3
++   ros2/sros2:
++-    hash: f67f66ec39ae4dc35a58493f76558fba36d5d88d
++-    shallow_since: 1643667677 -0800
++-    type: git
++-    url: https://github.com/ros2/sros2.git
+++    hash: 06c405f417216b459dae5cfddd5dec5bf31bf420e9930dccb1f7e94341daf6fe
+++    strip_prefix: sros2-0.9.5
+++    type: http_archive
+++    url: https://github.com/ros2/sros2/archive/refs/tags/0.9.5.tar.gz
++     version: 0.9.5
++   ros2/system_tests:
++-    hash: ac07337c0b26b54b8c13403e7fce417132c1f359
++-    shallow_since: 1643667750 -0800
++-    type: git
++-    url: https://github.com/ros2/system_tests.git
+++    hash: 0d9522a35c2b88df66313e7842bf112410098a6d4fb3476a515069a157121e1c
+++    strip_prefix: system_tests-0.9.2
+++    type: http_archive
+++    url: https://github.com/ros2/system_tests/archive/refs/tags/0.9.2.tar.gz
++     version: 0.9.2
++   ros2/test_interface_files:
++-    hash: d0ee98f449c428fc2afa888b06fea48b87dc6645
++-    shallow_since: 1616075821 +0000
++-    type: git
++-    url: https://github.com/ros2/test_interface_files.git
+++    hash: a48120dbf44ad536f209654e20eda8fe03b826568c2b53fd591937b5718302a3
+++    strip_prefix: test_interface_files-0.8.1
+++    type: http_archive
+++    url: https://github.com/ros2/test_interface_files/archive/refs/tags/0.8.1.tar.gz
++     version: 0.8.1
++   ros2/tinyxml2_vendor:
++-    hash: 2905a56d59f0e1de436d83a7035ab850a5a75c8f
++-    shallow_since: 1616075299 +0000
++-    type: git
++-    url: https://github.com/ros2/tinyxml2_vendor.git
+++    hash: 4ecbfc55d99e4f28d3cc1d8992399812a9e3bb8ba01169d846fba0b54ed1a744
+++    strip_prefix: tinyxml2_vendor-0.7.4
+++    type: http_archive
+++    url: https://github.com/ros2/tinyxml2_vendor/archive/refs/tags/0.7.4.tar.gz
++     version: 0.7.4
++   ros2/tinyxml_vendor:
++-    hash: 8d5ec29ca6ba2716006ad84553016cb03b237716
++-    shallow_since: 1616075138 +0000
++-    type: git
++-    url: https://github.com/ros2/tinyxml_vendor.git
+++    hash: 25db4b255a7fba9a6c8373ff876caba2454378a87031d1cb1502ff1925e4d8b0
+++    strip_prefix: tinyxml_vendor-0.8.2
+++    type: http_archive
+++    url: https://github.com/ros2/tinyxml_vendor/archive/refs/tags/0.8.2.tar.gz
++     version: 0.8.2
++   ros2/tlsf:
++-    hash: 1c4a13c3f76f79ce9f2a049a8b01cafbff775d4d
++-    shallow_since: 1529976968 +0000
++-    type: git
++-    url: https://github.com/ros2/tlsf.git
+++    hash: d62978fa4791d55afb3bcc4920b09c2942f99453c751ed90d42df86861c8b896
+++    strip_prefix: tlsf-0.5.0
+++    type: http_archive
+++    url: https://github.com/ros2/tlsf/archive/refs/tags/0.5.0.tar.gz
++     version: 0.5.0
++   ros2/unique_identifier_msgs:
++-    hash: 099923f53d58aa8eba2e1590523457f9d7f20eed
++-    shallow_since: 1617907574 -0700
++-    type: git
++-    url: https://github.com/ros2/unique_identifier_msgs.git
+++    hash: aa0f5a440cface1dd85cf05d97cadb812b2796973882d02a7e795ae70b64b9a0
+++    strip_prefix: unique_identifier_msgs-2.1.3
+++    type: http_archive
+++    url: https://github.com/ros2/unique_identifier_msgs/archive/refs/tags/2.1.3.tar.gz
++     version: 2.1.3
++   ros2/urdf:
++-    hash: 533de85e9a4611fc42855b1d65d9f32cb42b0d6b
++-    shallow_since: 1590548494 -0700
++-    type: git
++-    url: https://github.com/ros2/urdf.git
+++    hash: 391a1148bb69fffb59264ff2b8030e885899cb4dffc936e7afa08802aead14a2
+++    strip_prefix: urdf-2.4.0
+++    type: http_archive
+++    url: https://github.com/ros2/urdf/archive/refs/tags/2.4.0.tar.gz
++     version: 2.4.0
++   ros2/yaml_cpp_vendor:
++-    hash: 7c80af3b3178d645283bed0817c70af48ca97944
++-    shallow_since: 1663960122 -0700
++-    type: git
++-    url: https://github.com/ros2/yaml_cpp_vendor.git
+++    hash: 4efd8a94b1f29db9992c90a2c6f9acffb0d8938221bfaac6ff094748bdff9ec5
+++    strip_prefix: yaml_cpp_vendor-7.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/yaml_cpp_vendor/archive/refs/tags/7.0.3.tar.gz
++     version: 7.0.3
++diff --git a/repos/config/ros2_humble.lock b/repos/config/ros2_humble.lock
++index 8fa3af3..2d9fe17 100644
++--- a/repos/config/ros2_humble.lock
+++++ b/repos/config/ros2_humble.lock
++@@ -3,620 +3,620 @@
++ #
++ repositories:
++   ament/ament_cmake:
++-    hash: 571379977af23528fb805f812c0e20466e140fb1
++-    shallow_since: 1687452086 -0700
++-    type: git
++-    url: https://github.com/ament/ament_cmake.git
+++    hash: 7f343f90844d47ef225e401e643aa46376aaeeb53d3fdb257be6e98ce75cf36c
+++    strip_prefix: ament_cmake-1.3.5
+++    type: http_archive
+++    url: https://github.com/ament/ament_cmake/archive/refs/tags/1.3.5.tar.gz
++     version: 1.3.5
++   ament/ament_index:
++-    hash: f019d6c40991799a13b18c9c3dcc583e3fde0381
++-    shallow_since: 1646168510 +0000
++-    type: git
++-    url: https://github.com/ament/ament_index.git
+++    hash: e66896e255653508cb2bdecd7789f8dd5a03d7d2b4a1dd37445821a5679c447c
+++    strip_prefix: ament_index-1.4.0
+++    type: http_archive
+++    url: https://github.com/ament/ament_index/archive/refs/tags/1.4.0.tar.gz
++     version: 1.4.0
++   ament/ament_lint:
++-    hash: 03609e90e76d9be745dfdf8846dd8ee1ba92f5ec
++-    shallow_since: 1695129776 +0000
++-    type: git
++-    url: https://github.com/ament/ament_lint.git
+++    hash: 875b3261631d34082eed2f8f07386e3b64d564ba9d494288cb88d4fe09e8402b
+++    strip_prefix: ament_lint-0.12.8
+++    type: http_archive
+++    url: https://github.com/ament/ament_lint/archive/refs/tags/0.12.8.tar.gz
++     version: 0.12.8
++   ament/ament_package:
++-    hash: f8ea958fd02cff6f4192425e28566369c92b5e34
++-    shallow_since: 1642531281 -0800
++-    type: git
++-    url: https://github.com/ament/ament_package.git
+++    hash: 85da59b1d067c8040b378d0bef47e32198defb5edc2e2ba251479cc24992553b
+++    strip_prefix: ament_package-0.14.0
+++    type: http_archive
+++    url: https://github.com/ament/ament_package/archive/refs/tags/0.14.0.tar.gz
++     version: 0.14.0
++   ament/google_benchmark_vendor:
++-    hash: d75f3a8897a8846064e00c3ac3be46db1f98d51e
++-    shallow_since: 1689716271 +0000
++-    type: git
++-    url: https://github.com/ament/google_benchmark_vendor.git
+++    hash: 4efc38011ca059c10323281a915fb57aef368b4b2dd4a2a9f3c72507b8602ef3
+++    strip_prefix: google_benchmark_vendor-0.1.2
+++    type: http_archive
+++    url: https://github.com/ament/google_benchmark_vendor/archive/refs/tags/0.1.2.tar.gz
++     version: 0.1.2
++   ament/googletest:
++-    hash: 6df7425fdcbd368d2d1b99ffd89b9168014abb07
++-    shallow_since: 1642171980 -0800
++-    type: git
++-    url: https://github.com/ament/googletest.git
+++    hash: e3f1f2bb6d0727ed7c8c6971c5e924a7d75fbdc22a08fdcfc0a663264ee5499b
+++    strip_prefix: googletest-1.10.9004
+++    type: http_archive
+++    url: https://github.com/ament/googletest/archive/refs/tags/1.10.9004.tar.gz
++     version: 1.10.9004
++   ament/uncrustify_vendor:
++-    hash: ec8f8b4d03483671e8ea2b3039f1015f92b0ef89
++-    shallow_since: 1648503100 +0000
++-    type: git
++-    url: https://github.com/ament/uncrustify_vendor.git
+++    hash: 94ce058f994f543baae20e8e78e1f12b21b5b14472a3454142329ac002de5359
+++    strip_prefix: uncrustify_vendor-2.0.2
+++    type: http_archive
+++    url: https://github.com/ament/uncrustify_vendor/archive/refs/tags/2.0.2.tar.gz
++     version: 2.0.2
++   eProsima/Fast-CDR:
++-    hash: da2987299ee3104bb0393cf0afc8aad6fb848dc1
++-    shallow_since: 1647345218 +0100
++-    type: git
++-    url: https://github.com/eProsima/Fast-CDR.git
+++    hash: ecd688ab89ff1c03b9031c314891ae60995e2e73d919b93569eb840d6e87dec2
+++    strip_prefix: Fast-CDR-1.0.24
+++    type: http_archive
+++    url: https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.24.tar.gz
++     version: v1.0.24
++   eProsima/Fast-DDS:
++-    hash: cffaa679ec8cd9c84b4d5b3fe1e3c22974d63be0
++-    shallow_since: 1691144938 +0200
++-    type: git
++-    url: https://github.com/eProsima/Fast-DDS.git
+++    hash: 2234b9fb7c34cc642a76bb221483f6e0839c954de8ff1b3854557e85cc8ade60
+++    strip_prefix: Fast-DDS-2.6.6
+++    type: http_archive
+++    url: https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.6.6.tar.gz
++     version: v2.6.6
++   eProsima/foonathan_memory_vendor:
++-    hash: e91681a25711c1811b2eaf2ba1e6996e0d9ecc84
++-    shallow_since: 1683727792 +0200
++-    type: git
++-    url: https://github.com/eProsima/foonathan_memory_vendor.git
+++    hash: 982d11615214497bd7c713f3463af27567c76bed06b9b61021bc24694fd11c4a
+++    strip_prefix: foonathan_memory_vendor-1.3.1
+++    type: http_archive
+++    url: https://github.com/eProsima/foonathan_memory_vendor/archive/refs/tags/v1.3.1.tar.gz
++     version: v1.3.1
++   eclipse-cyclonedds/cyclonedds:
++-    hash: 63b6eab0e0660009eaf5e54d10509ea587ce199e
++-    shallow_since: 1679487279 +0100
++-    type: git
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+++    hash: bc79696209febfe66d97e7af6b11e92f9db663caf608a922b6c201b1d6a5eb62
+++    strip_prefix: cyclonedds-0.10.3
+++    type: http_archive
+++    url: https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.10.3.tar.gz
++     version: 0.10.3
++   eclipse-iceoryx/iceoryx:
++-    hash: 40ef24e9515940564af63987234d51dc7f02f6b3
++-    shallow_since: 1675094707 +0100
++-    type: git
++-    url: https://github.com/eclipse-iceoryx/iceoryx.git
+++    hash: 8f391696daf2e63da9437aab8d7154371df630fc93876479f2e84c693fc1ba5a
+++    strip_prefix: iceoryx-2.0.3
+++    type: http_archive
+++    url: https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.3.tar.gz
++     version: v2.0.3
++   ignition/ignition_cmake2_vendor:
++-    hash: adcee1687a6f77bdc345702d7ce1f518e97a6a66
++-    shallow_since: 1648558265 +0000
++-    type: git
++-    url: https://github.com/ignition-release/ignition_cmake2_vendor.git
+++    hash: 5b13472e33db9c9bb631b037d1c6b0ccedfcf5e38e16157024cc641215a43b32
+++    strip_prefix: ignition_cmake2_vendor-0.0.2
+++    type: http_archive
+++    url: https://github.com/ignition-release/ignition_cmake2_vendor/archive/refs/tags/0.0.2.tar.gz
++     version: 0.0.2
++   ignition/ignition_math6_vendor:
++-    hash: 177e74c31767e60c5bd8167f9ec66017b8e8020b
++-    shallow_since: 1648558450 +0000
++-    type: git
++-    url: https://github.com/ignition-release/ignition_math6_vendor.git
+++    hash: d357a43e8265db9a9e886b01ca53cc9692c81b7e9f7d99abc99df982efd5a1be
+++    strip_prefix: ignition_math6_vendor-0.0.2
+++    type: http_archive
+++    url: https://github.com/ignition-release/ignition_math6_vendor/archive/refs/tags/0.0.2.tar.gz
++     version: 0.0.2
++   osrf/osrf_pycommon:
++-    hash: d70a3bd3c8aa23bc9c2fff267a5b12d674516646
++-    shallow_since: 1649454420 -0700
++-    type: git
++-    url: https://github.com/osrf/osrf_pycommon.git
+++    hash: 1bb4f9a91c6b02fab67be27e63841bf05f49dc32970149562a0c7ea85b3a2b9c
+++    strip_prefix: osrf_pycommon-2.0.2
+++    type: http_archive
+++    url: https://github.com/osrf/osrf_pycommon/archive/refs/tags/2.0.2.tar.gz
++     version: 2.0.2
++   osrf/osrf_testing_tools_cpp:
++-    hash: ccfe94a685884155cb619896df1e71b8507c5c70
++-    shallow_since: 1667830580 -0600
++-    type: git
++-    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+++    hash: ec2bbc8cf59e48acd858006423d0872c0950eda24efccb67a1ad47191fc47ff4
+++    strip_prefix: osrf_testing_tools_cpp-1.5.2
+++    type: http_archive
+++    url: https://github.com/osrf/osrf_testing_tools_cpp/archive/refs/tags/1.5.2.tar.gz
++     version: 1.5.2
++   ros-perception/image_common:
++-    hash: 7ebae2f92257e1746fd9ec7787fb820a6f28d91a
++-    shallow_since: 1692024443 +0200
++-    type: git
++-    url: https://github.com/ros-perception/image_common.git
+++    hash: bf878db599ccca96e239aef428e60e58e02db32d3ddf7a62c4a2cc340aa9540a
+++    strip_prefix: image_common-3.1.7
+++    type: http_archive
+++    url: https://github.com/ros-perception/image_common/archive/refs/tags/3.1.7.tar.gz
++     version: 3.1.7
++   ros-perception/laser_geometry:
++-    hash: ba53212e6908e6f4e022a1ae2fb3b5bb1388d1d0
++-    shallow_since: 1646168108 +0000
++-    type: git
++-    url: https://github.com/ros-perception/laser_geometry.git
+++    hash: fe836029a0e960d8b2095b2cd3ce993b556fc2dd6ce73df5dfe266f90ba62017
+++    strip_prefix: laser_geometry-2.4.0
+++    type: http_archive
+++    url: https://github.com/ros-perception/laser_geometry/archive/refs/tags/2.4.0.tar.gz
++     version: 2.4.0
++   ros-planning/navigation_msgs:
++-    hash: 1d8683359734a2c829b5cdb6b5a4e015bbbcb6a5
++-    shallow_since: 1616703818 +0000
++-    type: git
++-    url: https://github.com/ros-planning/navigation_msgs.git
+++    hash: 4de38585745387d0a6557c28c66cca88dd4cfdf9d2e15871669fa8ecd2657f03
+++    strip_prefix: navigation_msgs-2.1.0
+++    type: http_archive
+++    url: https://github.com/ros-planning/navigation_msgs/archive/refs/tags/2.1.0.tar.gz
++     version: 2.1.0
++   ros-tooling/keyboard_handler:
++-    hash: a80cbfc93be6a545bb0892d1b5a408d2b5ef29b1
++-    shallow_since: 1667916008 -0500
++-    type: git
++-    url: https://github.com/ros-tooling/keyboard_handler.git
+++    hash: 36e64e9e1927a6026e1b45cafc4c8efd32db274bfab5da0edd273a583f3c73f4
+++    strip_prefix: keyboard_handler-0.0.5
+++    type: http_archive
+++    url: https://github.com/ros-tooling/keyboard_handler/archive/refs/tags/0.0.5.tar.gz
++     version: 0.0.5
++   ros-tooling/libstatistics_collector:
++-    hash: 6d473eb7533a3db385512d5721e3a46ceb06f96f
++-    shallow_since: 1677042096 -0800
++-    type: git
++-    url: https://github.com/ros-tooling/libstatistics_collector.git
+++    hash: 12e9e52e2b342e471a31ad41db18e72795ac2b0faf56a54adcb74a24de630fa3
+++    strip_prefix: libstatistics_collector-1.3.1
+++    type: http_archive
+++    url: https://github.com/ros-tooling/libstatistics_collector/archive/refs/tags/1.3.1.tar.gz
++     version: 1.3.1
++   ros-visualization/interactive_markers:
++-    hash: b4e6a0df87cddba49d844f6798387faf8db2dd37
++-    shallow_since: 1649450982 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/interactive_markers.git
+++    hash: 5e532f93f82e88d669d0883911d3f8d21b33f289970abd19a5cd7392a89bf69d
+++    strip_prefix: interactive_markers-2.3.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/interactive_markers/archive/refs/tags/2.3.2.tar.gz
++     version: 2.3.2
++   ros-visualization/python_qt_binding:
++-    hash: 89492df890f390d956b7f829811f29ccc7f1cd87
++-    shallow_since: 1638839032 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/python_qt_binding.git
+++    hash: ec9dabfd91352830b49e4e429d7d3ec63eb733c29375d6f0c54c713af736e2c8
+++    strip_prefix: python_qt_binding-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/python_qt_binding/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/qt_gui_core:
++-    hash: 4a1010a702ea4b922a25b0b1cebc33904de88c0c
++-    shallow_since: 1660584395 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/qt_gui_core.git
+++    hash: f6ac634e5ea5107f190febdc5ed0064a55b27baa201795a58066638ac5ba49e6
+++    strip_prefix: qt_gui_core-2.2.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/qt_gui_core/archive/refs/tags/2.2.2.tar.gz
++     version: 2.2.2
++   ros-visualization/rqt:
++-    hash: d954ac6727f873a2c2e1b7f9e7cb1bd7642fc461
++-    shallow_since: 1682459372 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt.git
+++    hash: 98f199fb868e127257106fc9f292cdc23baa501d9b1e97e365f2494bc706d849
+++    strip_prefix: rqt-1.1.5
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt/archive/refs/tags/1.1.5.tar.gz
++     version: 1.1.5
++   ros-visualization/rqt_action:
++-    hash: 86e5c65a708b562f220cf6bafa7a3f10e075dad8
++-    shallow_since: 1642182537 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_action.git
+++    hash: 51befe0c28ca2a02f304defb3a9c7cb7f7a5a2da9b296dce40271b5643112991
+++    strip_prefix: rqt_action-2.0.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_action/archive/refs/tags/2.0.1.tar.gz
++     version: 2.0.1
++   ros-visualization/rqt_bag:
++-    hash: a860837d1a52459ed5a97674546faf526f175402
++-    shallow_since: 1667831876 -0600
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_bag.git
+++    hash: c3bffc73d88e6cb16939a10903351ac69a819596d4c07f1bb735f42917f88cf6
+++    strip_prefix: rqt_bag-1.1.4
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_bag/archive/refs/tags/1.1.4.tar.gz
++     version: 1.1.4
++   ros-visualization/rqt_console:
++-    hash: 3f2fd4e066562e8a9b630bcba5dee95a20fbdca9
++-    shallow_since: 1635300128 +0900
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_console.git
+++    hash: 4f76b11a1a3d5066282d868eae0d83d288d72ea7352f7749d6ba3286dc0e414f
+++    strip_prefix: rqt_console-2.0.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_console/archive/refs/tags/2.0.2.tar.gz
++     version: 2.0.2
++   ros-visualization/rqt_graph:
++-    hash: e512cd7a246ca1032422c454bb103a5beb3cf4c1
++-    shallow_since: 1663109940 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_graph.git
+++    hash: b0e60900879b785e3ae9100c7749cd67f3ecfcaa6ffd16cc142ba18bfe9a0ede
+++    strip_prefix: rqt_graph-1.3.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_graph/archive/refs/tags/1.3.0.tar.gz
++     version: 1.3.0
++   ros-visualization/rqt_msg:
++-    hash: e73c05e6b4a2601a587231eacafad75e5fa07aa4
++-    shallow_since: 1663096424 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_msg.git
+++    hash: 42c593d6e54fc99bad734e675332d34b1d2cafd5cacea5175a5bdc2aa8455770
+++    strip_prefix: rqt_msg-1.2.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_msg/archive/refs/tags/1.2.0.tar.gz
++     version: 1.2.0
++   ros-visualization/rqt_plot:
++-    hash: d44f4a6b5ddb39d03ddc201dd202f1f8c324a262
++-    shallow_since: 1652231949 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_plot.git
+++    hash: b9e4d23892f26a75081ae999b61f2c92ee99a20f017189c40555a85790a83334
+++    strip_prefix: rqt_plot-1.1.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_plot/archive/refs/tags/1.1.2.tar.gz
++     version: 1.1.2
++   ros-visualization/rqt_publisher:
++-    hash: db902c8dd75527dbc0e9e533b42f650a56dbe03e
++-    shallow_since: 1659477921 -0400
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_publisher.git
+++    hash: 140cdfa21eaf16e78892f56fbb5264ad1849f759b5f7716ef6289157100d2fae
+++    strip_prefix: rqt_publisher-1.5.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_publisher/archive/refs/tags/1.5.0.tar.gz
++     version: 1.5.0
++   ros-visualization/rqt_py_console:
++-    hash: 36ad6e467f7add9279a4cd54d3e02ebcbd936d5b
++-    shallow_since: 1630451545 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_py_console.git
+++    hash: 1cb589b7c2b6bb445eef1cbfdceedd8d517b2f9d1b8cb2f22a767d612cba40b6
+++    strip_prefix: rqt_py_console-1.0.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_py_console/archive/refs/tags/1.0.2.tar.gz
++     version: 1.0.2
++   ros-visualization/rqt_reconfigure:
++-    hash: 3cdeeb3cb6bdf4931b8b49b87b6aa95c24e378ba
++-    shallow_since: 1663106666 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_reconfigure.git
+++    hash: b6717de7819875484319a96a46d4001b71ab9bda5716e6d12343cf2a09843b99
+++    strip_prefix: rqt_reconfigure-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_reconfigure/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/rqt_service_caller:
++-    hash: c9afeb84e9db4807c895e345294f2d521abf3859
++-    shallow_since: 1630451643 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_service_caller.git
+++    hash: 5e3802f444b50594f3a7dc80977286609b88a50f1ad77f9208e45911889ae825
+++    strip_prefix: rqt_service_caller-1.0.5
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_service_caller/archive/refs/tags/1.0.5.tar.gz
++     version: 1.0.5
++   ros-visualization/rqt_shell:
++-    hash: 50639b2252fc0d02bcc3361284b67baa44a87c3b
++-    shallow_since: 1630452741 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_shell.git
+++    hash: 0308be57b7e1ed81d66035c21ce37d37ab00a599c85a7667d7487b8786805987
+++    strip_prefix: rqt_shell-1.0.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_shell/archive/refs/tags/1.0.2.tar.gz
++     version: 1.0.2
++   ros-visualization/rqt_srv:
++-    hash: 46e8e71560008857456525ad7977aa6bd87391d5
++-    shallow_since: 1630452880 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_srv.git
+++    hash: 719a48657574e2abbdf3469773d894d542c5fbe15b2d81784868979c13fbf095
+++    strip_prefix: rqt_srv-1.0.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_srv/archive/refs/tags/1.0.3.tar.gz
++     version: 1.0.3
++   ros-visualization/rqt_topic:
++-    hash: 19141d759cfa35515182677f9d4e60a898e86c74
++-    shallow_since: 1663095690 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_topic.git
+++    hash: 8476832e52311e434b36804cec87f67c7066b17e07f5963b3f3268afabce42ca
+++    strip_prefix: rqt_topic-1.5.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_topic/archive/refs/tags/1.5.0.tar.gz
++     version: 1.5.0
++   ros-visualization/tango_icons_vendor:
++-    hash: 6829ad2201c6b42973edcfc9f5755b8b9f5b67ff
++-    shallow_since: 1649249706 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/tango_icons_vendor.git
+++    hash: 1402e81d5a34916b90b8bb30a9dd7a131b1a98df9f5754f311dfd35d32561971
+++    strip_prefix: tango_icons_vendor-0.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/tango_icons_vendor/archive/refs/tags/0.1.1.tar.gz
++     version: 0.1.1
++   ros/class_loader:
++-    hash: b59bce93380b73ac9061fba28e96bba540e2befe
++-    shallow_since: 1642184223 -0800
++-    type: git
++-    url: https://github.com/ros/class_loader.git
+++    hash: a85a99b93fcad7c8d9686672b8e3793200b1da9d8feab7ab3a9962e34ab1f675
+++    strip_prefix: class_loader-2.2.0
+++    type: http_archive
+++    url: https://github.com/ros/class_loader/archive/refs/tags/2.2.0.tar.gz
++     version: 2.2.0
++   ros/kdl_parser:
++-    hash: a4ad6b3c1dbf3730a579b250be81e4a74e838b94
++-    shallow_since: 1673360125 -0600
++-    type: git
++-    url: https://github.com/ros/kdl_parser.git
+++    hash: f28da9bd7eaa8995f4b67bc9c8321d7467043aa43e01b918aa239b8b9971bf56
+++    strip_prefix: kdl_parser-2.6.4
+++    type: http_archive
+++    url: https://github.com/ros/kdl_parser/archive/refs/tags/2.6.4.tar.gz
++     version: 2.6.4
++   ros/pluginlib:
++-    hash: fc2d015a594bb582c1143a9e2b8b8d9f6f8c75fc
++-    shallow_since: 1642186000 -0800
++-    type: git
++-    url: https://github.com/ros/pluginlib.git
+++    hash: 74188b886f9bbe7e857d21f3bb50b480e7c0e5adab97c10563dc17013600198b
+++    strip_prefix: pluginlib-5.1.0
+++    type: http_archive
+++    url: https://github.com/ros/pluginlib/archive/refs/tags/5.1.0.tar.gz
++     version: 5.1.0
++   ros/resource_retriever:
++-    hash: 6c82181f7c0c893f50dbacdafe51bc83b9a56803
++-    shallow_since: 1673360221 -0600
++-    type: git
++-    url: https://github.com/ros/resource_retriever.git
+++    hash: a7de4f63babcdaafa7c8af69942ce31105c763ae8a4467ed77a69b4ab80d2dc8
+++    strip_prefix: resource_retriever-3.1.1
+++    type: http_archive
+++    url: https://github.com/ros/resource_retriever/archive/refs/tags/3.1.1.tar.gz
++     version: 3.1.1
++   ros/robot_state_publisher:
++-    hash: 6e11ed88d24a63a00472c000075f568f270334ed
++-    shallow_since: 1649194244 -0700
++-    type: git
++-    url: https://github.com/ros/robot_state_publisher.git
+++    hash: f349756d8db6d6fc79dcc869acaa749175f2ad20ea74c738ed72cd1f96cd97b6
+++    strip_prefix: robot_state_publisher-3.0.2
+++    type: http_archive
+++    url: https://github.com/ros/robot_state_publisher/archive/refs/tags/3.0.2.tar.gz
++     version: 3.0.2
++   ros/ros_environment:
++-    hash: cf4d7c2b770fec588e8d35de09e12d5bfd056067
++-    shallow_since: 1667832063 -0600
++-    type: git
++-    url: https://github.com/ros/ros_environment.git
+++    hash: 4f67c3c8b91ad568aa5c02b710678f32aa7e6a01e962d4300fee2311ea31f06f
+++    strip_prefix: ros_environment-3.2.2
+++    type: http_archive
+++    url: https://github.com/ros/ros_environment/archive/refs/tags/3.2.2.tar.gz
++     version: 3.2.2
++   ros/ros_tutorials:
++-    hash: ba29c3f376197e3736f497639299f855cbf73390
++-    shallow_since: 1652796435 -0400
++-    type: git
++-    url: https://github.com/ros/ros_tutorials.git
+++    hash: e87349defac08978cf47c6ae0a743b488a89195b00b1eb73a2f5fd0a74430dca
+++    strip_prefix: ros_tutorials-1.4.2
+++    type: http_archive
+++    url: https://github.com/ros/ros_tutorials/archive/refs/tags/1.4.2.tar.gz
++     version: 1.4.2
++   ros/urdfdom:
++-    hash: dbecca095cf81b755991b4d785f87a8e6b7358d6
++-    shallow_since: 1648511537 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom.git
+++    hash: 1072b2a304295eb299ed70d99914eb2fbf8843c3257e5e51defc5dd457ee6211
+++    strip_prefix: urdfdom-3.0.2
+++    type: http_archive
+++    url: https://github.com/ros/urdfdom/archive/refs/tags/3.0.2.tar.gz
++     version: 3.0.2
++   ros/urdfdom_headers:
++-    hash: d3643d2acd8567c6522ceaf7ded6e3c3755a5244
++-    shallow_since: 1648511357 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom_headers.git
+++    hash: 1acd50b976f642de9dc0fde532eb8d77ea09f4de12ebfbd9d88b0cd2891278fd
+++    strip_prefix: urdfdom_headers-1.0.6
+++    type: http_archive
+++    url: https://github.com/ros/urdfdom_headers/archive/refs/tags/1.0.6.tar.gz
++     version: 1.0.6
++   ros2/ament_cmake_ros:
++-    hash: 60572fa1bec50b9e6fbe64e1b23640d21c15e9d0
++-    shallow_since: 1642109880 -0800
++-    type: git
++-    url: https://github.com/ros2/ament_cmake_ros.git
+++    hash: 01c778f18315ad13efd02e24200ff04f1e72359096c0967dba45e45bc479b3c6
+++    strip_prefix: ament_cmake_ros-0.10.0
+++    type: http_archive
+++    url: https://github.com/ros2/ament_cmake_ros/archive/refs/tags/0.10.0.tar.gz
++     version: 0.10.0
++   ros2/common_interfaces:
++-    hash: f4eac72f0bbd70f7955a5f709d4a6705eb6ca7e8
++-    shallow_since: 1673281597 -0600
++-    type: git
++-    url: https://github.com/ros2/common_interfaces.git
+++    hash: f4be9343a4c028fcf5403d90c120bca78aea1bbe2a04ae9838a7f73c347366c6
+++    strip_prefix: common_interfaces-4.2.3
+++    type: http_archive
+++    url: https://github.com/ros2/common_interfaces/archive/refs/tags/4.2.3.tar.gz
++     version: 4.2.3
++   ros2/console_bridge_vendor:
++-    hash: d445245912786a7a03216e9d47f102e1997320f2
++-    shallow_since: 1673357965 -0600
++-    type: git
++-    url: https://github.com/ros2/console_bridge_vendor.git
+++    hash: 624e5166bc495d2dcfbe1fd3e0b7c8b5ebc20429b3455b1e5673337f66aa83ad
+++    strip_prefix: console_bridge_vendor-1.4.1
+++    type: http_archive
+++    url: https://github.com/ros2/console_bridge_vendor/archive/refs/tags/1.4.1.tar.gz
++     version: 1.4.1
++   ros2/demos:
++-    hash: f258b8182c7ad680c8cceba38eac72e01fdb0a3c
++-    shallow_since: 1673358561 -0600
++-    type: git
++-    url: https://github.com/ros2/demos.git
+++    hash: d8afc21488675cc2ac537969a560064bad5a1d6115d7d631a01c5b3eeada58f8
+++    strip_prefix: demos-0.20.3
+++    type: http_archive
+++    url: https://github.com/ros2/demos/archive/refs/tags/0.20.3.tar.gz
++     version: 0.20.3
++   ros2/eigen3_cmake_module:
++-    hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
++-    shallow_since: 1565307940 -0700
++-    type: git
++-    url: https://github.com/ros2/eigen3_cmake_module.git
+++    hash: 15d85f7c96fc14c48484e3d2e8484581e1077cf64d593b5e1fb4096700824b43
+++    strip_prefix: eigen3_cmake_module-0.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/eigen3_cmake_module/archive/refs/tags/0.1.1.tar.gz
++     version: 0.1.1
++   ros2/example_interfaces:
++-    hash: f8deb566a1facf91bd38b9f00c4cf684c5007d85
++-    shallow_since: 1649249608 +0000
++-    type: git
++-    url: https://github.com/ros2/example_interfaces.git
+++    hash: 7ee9b0223529fddce6cc85ebc981edec35f594d0565399086e773530ea9d6a52
+++    strip_prefix: example_interfaces-0.9.3
+++    type: http_archive
+++    url: https://github.com/ros2/example_interfaces/archive/refs/tags/0.9.3.tar.gz
++     version: 0.9.3
++   ros2/examples:
++-    hash: fac7da74281cbe6912e74aa78db633945b9ed930
++-    shallow_since: 1667832202 -0600
++-    type: git
++-    url: https://github.com/ros2/examples.git
+++    hash: 71c75c775964f2e1f910dac55b3429adcde04f9960afbd651a7f7a7b662c0807
+++    strip_prefix: examples-0.15.1
+++    type: http_archive
+++    url: https://github.com/ros2/examples/archive/refs/tags/0.15.1.tar.gz
++     version: 0.15.1
++   ros2/geometry2:
++-    hash: a73160df358c52d1f506fce21f15f8243e9b87f4
++-    shallow_since: 1695130569 +0000
++-    type: git
++-    url: https://github.com/ros2/geometry2.git
+++    hash: cdcd4596379672cd90548e0f68029d894396e018b9fa95383b09e78c08b8febb
+++    strip_prefix: geometry2-0.25.4
+++    type: http_archive
+++    url: https://github.com/ros2/geometry2/archive/refs/tags/0.25.4.tar.gz
++     version: 0.25.4
++   ros2/launch:
++-    hash: aed025e04e0b143362c69bf29a67b2ffff4c59ee
++-    shallow_since: 1673358862 -0600
++-    type: git
++-    url: https://github.com/ros2/launch.git
+++    hash: 41ba52c876ab4b2301406e442cd7503ae877aaa33c7f5fcf86010bf2a57db606
+++    strip_prefix: launch-1.0.4
+++    type: http_archive
+++    url: https://github.com/ros2/launch/archive/refs/tags/1.0.4.tar.gz
++     version: 1.0.4
++   ros2/launch_ros:
++-    hash: 2bf4e6057dea57669c19395f6f39d390bd420ee7
++-    shallow_since: 1695130640 +0000
++-    type: git
++-    url: https://github.com/ros2/launch_ros.git
+++    hash: bd051a2f92774931714e9bf4abbeba7645f2917e818d93a6e39ec693e474a16f
+++    strip_prefix: launch_ros-0.19.6
+++    type: http_archive
+++    url: https://github.com/ros2/launch_ros/archive/refs/tags/0.19.6.tar.gz
++     version: 0.19.6
++   ros2/libyaml_vendor:
++-    hash: 239f695ceaa0820255f3d0fe02ec8c2bd41b8e78
++-    shallow_since: 1648732255 +0000
++-    type: git
++-    url: https://github.com/ros2/libyaml_vendor.git
+++    hash: fbcd5f2921e68f1fb5eb7d44e9d3449dee3e9dba730648f919bad79aa4855cff
+++    strip_prefix: libyaml_vendor-1.2.2
+++    type: http_archive
+++    url: https://github.com/ros2/libyaml_vendor/archive/refs/tags/1.2.2.tar.gz
++     version: 1.2.2
++   ros2/message_filters:
++-    hash: bb405b0d55646fbcb6acf7c2d42911d0efb11415
++-    shallow_since: 1682458765 +0000
++-    type: git
++-    url: https://github.com/ros2/message_filters.git
+++    hash: bd86a6f099393f10f208a757abc6c2bccf8fc6f684216cffd73f67f5f23b8fd6
+++    strip_prefix: message_filters-4.3.3
+++    type: http_archive
+++    url: https://github.com/ros2/message_filters/archive/refs/tags/4.3.3.tar.gz
++     version: 4.3.3
++   ros2/mimick_vendor:
++-    hash: 39ec45b347721c8c90c0e31450e91c00fb0ec856
++-    shallow_since: 1648188875 +0000
++-    type: git
++-    url: https://github.com/ros2/mimick_vendor.git
+++    hash: 445a326aba0796868ddf65ca4d8c6166dc27208f21f2a65440ffeea9214d195a
+++    strip_prefix: mimick_vendor-0.2.8
+++    type: http_archive
+++    url: https://github.com/ros2/mimick_vendor/archive/refs/tags/0.2.8.tar.gz
++     version: 0.2.8
++   ros2/orocos_kdl_vendor:
++-    hash: d390ba45a77d8d49746a784d10a88cb77e86f703
++-    shallow_since: 1674245380 -0600
++-    type: git
++-    url: https://github.com/ros2/orocos_kdl_vendor.git
+++    hash: a315b3121d3a0761d821c15fa1a8939a65eb99073943795e56d52c08bf75ee0d
+++    strip_prefix: orocos_kdl_vendor-0.2.5
+++    type: http_archive
+++    url: https://github.com/ros2/orocos_kdl_vendor/archive/refs/tags/0.2.5.tar.gz
++     version: 0.2.5
++   ros2/performance_test_fixture:
++-    hash: afb01872d0c03e31cd4fda04e91af8e5548de0a3
++-    shallow_since: 1658776414 -0700
++-    type: git
++-    url: https://github.com/ros2/performance_test_fixture.git
+++    hash: 28d6039ef9fcc9281efce60d42c769d014a6a82f0a228d5bf887868282a2d770
+++    strip_prefix: performance_test_fixture-0.0.9
+++    type: http_archive
+++    url: https://github.com/ros2/performance_test_fixture/archive/refs/tags/0.0.9.tar.gz
++     version: 0.0.9
++   ros2/pybind11_vendor:
++-    hash: 06dff083cdef3381c1d1d16159ac19227f646ad9
++-    shallow_since: 1670369976 -0800
++-    type: git
++-    url: https://github.com/ros2/pybind11_vendor.git
+++    hash: af7ef176068f8043800f2bcc22e97db71f592619ac17252b972dcff9e6b11c0e
+++    strip_prefix: pybind11_vendor-2.4.2
+++    type: http_archive
+++    url: https://github.com/ros2/pybind11_vendor/archive/refs/tags/2.4.2.tar.gz
++     version: 2.4.2
++   ros2/python_cmake_module:
++-    hash: 859115408416e77d37711912d5c36cd3147fe136
++-    shallow_since: 1646164088 +0000
++-    type: git
++-    url: https://github.com/ros2/python_cmake_module.git
+++    hash: ad29e461ee43bfd7fce0b8986abced92ba31970bc2ba8fb45f5276140e5f61f2
+++    strip_prefix: python_cmake_module-0.10.0
+++    type: http_archive
+++    url: https://github.com/ros2/python_cmake_module/archive/refs/tags/0.10.0.tar.gz
++     version: 0.10.0
++   ros2/rcl:
++-    hash: 3804c35f6dd31d5ac54a1acb426bff253cce8272
++-    shallow_since: 1695130701 +0000
++-    type: git
++-    url: https://github.com/ros2/rcl.git
+++    hash: 00de985ff9c5ea5fee1524bccf948c32dbd0610b73297a602cc2a4c7f3a35a4a
+++    strip_prefix: rcl-5.3.5
+++    type: http_archive
+++    url: https://github.com/ros2/rcl/archive/refs/tags/5.3.5.tar.gz
++     version: 5.3.5
++   ros2/rcl_interfaces:
++-    hash: 5e01a28f9866a564491480e12d8659a134678741
++-    shallow_since: 1667833699 -0600
++-    type: git
++-    url: https://github.com/ros2/rcl_interfaces.git
+++    hash: e267048c9f78aabed4b4be11bb028c8488127587e5065c3b3daff3550df25875
+++    strip_prefix: rcl_interfaces-1.2.1
+++    type: http_archive
+++    url: https://github.com/ros2/rcl_interfaces/archive/refs/tags/1.2.1.tar.gz
++     version: 1.2.1
++   ros2/rcl_logging:
++-    hash: 1b7a4e34884005f28eeb04065b5d94565c67b11d
++-    shallow_since: 1667833800 -0600
++-    type: git
++-    url: https://github.com/ros2/rcl_logging.git
+++    hash: f711a7677cb68c927650e5e9f6bbb5d013dd9ae30736209f9b70f9c6485170f6
+++    strip_prefix: rcl_logging-2.3.1
+++    type: http_archive
+++    url: https://github.com/ros2/rcl_logging/archive/refs/tags/2.3.1.tar.gz
++     version: 2.3.1
++   ros2/rclcpp:
++-    hash: 0f6b5449f66f131735a423be4a84d6f14751d3b2
++-    shallow_since: 1695130763 +0000
++-    type: git
++-    url: https://github.com/ros2/rclcpp.git
+++    hash: 3308f806a2e92dbeabdda36edfff3f32e303fdc34b29088adf0d2f53cbc0bd9c
+++    strip_prefix: rclcpp-16.0.6
+++    type: http_archive
+++    url: https://github.com/ros2/rclcpp/archive/refs/tags/16.0.6.tar.gz
++     version: 16.0.6
++   ros2/rclpy:
++-    hash: 242f78a3d856ed1552a56d1e06713553e9d65fdf
++-    shallow_since: 1695130817 +0000
++-    type: git
++-    url: https://github.com/ros2/rclpy.git
+++    hash: deba02252ba279310a34e1b7f100a08c5dc189b1cf1920764547996b9c961b3f
+++    strip_prefix: rclpy-3.3.10
+++    type: http_archive
+++    url: https://github.com/ros2/rclpy/archive/refs/tags/3.3.10.tar.gz
++     version: 3.3.10
++   ros2/rcpputils:
++-    hash: 3eb281afdc891855b5feb367c79ede1e2fbb0acb
++-    shallow_since: 1682457603 +0000
++-    type: git
++-    url: https://github.com/ros2/rcpputils.git
+++    hash: 57524f5f0b95a55add358259b859ad44d4c7cb1ed5188d87be92eab78a765a33
+++    strip_prefix: rcpputils-2.4.1
+++    type: http_archive
+++    url: https://github.com/ros2/rcpputils/archive/refs/tags/2.4.1.tar.gz
++     version: 2.4.1
++   ros2/rcutils:
++-    hash: 2d9d74e72ecd1eea240412be3dacd413dcb5f680
++-    shallow_since: 1682457695 +0000
++-    type: git
++-    url: https://github.com/ros2/rcutils.git
+++    hash: c34d9ba3c9b22810e0f0b94e11b1ae8b3b9c38e970dcc9236884727f68ef7bad
+++    strip_prefix: rcutils-5.1.3
+++    type: http_archive
+++    url: https://github.com/ros2/rcutils/archive/refs/tags/5.1.3.tar.gz
++     version: 5.1.3
++   ros2/realtime_support:
++-    hash: 0e3faef4b7aa7985726dba97c761a6783f62a958
++-    shallow_since: 1646162410 +0000
++-    type: git
++-    url: https://github.com/ros2/realtime_support.git
+++    hash: f607f0eccb647a7b20fb04538c735b09c5ca13f39943575a654fa7fc12e8b39f
+++    strip_prefix: realtime_support-0.13.0
+++    type: http_archive
+++    url: https://github.com/ros2/realtime_support/archive/refs/tags/0.13.0.tar.gz
++     version: 0.13.0
++   ros2/rmw:
++-    hash: 2a4ee718d0da004d5629f50afd2896fbd1f4aedd
++-    shallow_since: 1667834517 -0600
++-    type: git
++-    url: https://github.com/ros2/rmw.git
+++    hash: 3042de743e86ca36997ecd3b3da8319e6d3853dd5366d4ae4055dd6ad38e89b3
+++    strip_prefix: rmw-6.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/rmw/archive/refs/tags/6.1.1.tar.gz
++     version: 6.1.1
++   ros2/rmw_connextdds:
++-    hash: 94bde7556d069bee8f9540171a9b87593c3be51e
++-    shallow_since: 1689700540 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_connextdds.git
+++    hash: 262af67376298c19cb5fc23c0b285c2e21d60190ba3c48e51c4dd9944d514261
+++    strip_prefix: rmw_connextdds-0.11.2
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_connextdds/archive/refs/tags/0.11.2.tar.gz
++     version: 0.11.2
++   ros2/rmw_cyclonedds:
++-    hash: 7cb3b38a21e14fbcc84aadcc460e4d812d0c7a7f
++-    shallow_since: 1667834582 -0600
++-    type: git
++-    url: https://github.com/ros2/rmw_cyclonedds.git
+++    hash: 58ef4fe3fd18eb723906df77eb10df1e69222b451e479c6ec85426ba48e16a8a
+++    strip_prefix: rmw_cyclonedds-1.3.4
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_cyclonedds/archive/refs/tags/1.3.4.tar.gz
++     version: 1.3.4
++   ros2/rmw_dds_common:
++-    hash: e26ba1079886c5598614172db0b27526aa6af07d
++-    shallow_since: 1648761511 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_dds_common.git
+++    hash: 85dd9f586d53b658e5389a388fe3d99a884ba06f567a59f9908ecb96e29132ef
+++    strip_prefix: rmw_dds_common-1.6.0
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_dds_common/archive/refs/tags/1.6.0.tar.gz
++     version: 1.6.0
++   ros2/rmw_fastrtps:
++-    hash: 4b0f30f15fad0e1a9824db0bf54dbbaa5085fa5d
++-    shallow_since: 1695130886 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_fastrtps.git
+++    hash: 7b6976219d129a318c3a28fec50bc463e30603bd31f16208c0ef3c46a7435d09
+++    strip_prefix: rmw_fastrtps-6.2.4
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_fastrtps/archive/refs/tags/6.2.4.tar.gz
++     version: 6.2.4
++   ros2/rmw_implementation:
++-    hash: 413eb313f7e128c6977cd453818e1a39bf70da40
++-    shallow_since: 1673359327 -0600
++-    type: git
++-    url: https://github.com/ros2/rmw_implementation.git
+++    hash: 46067d692a9606c12132980cad8dbf00f9cac7bda358f2ce14a96c877e04aee9
+++    strip_prefix: rmw_implementation-2.8.2
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_implementation/archive/refs/tags/2.8.2.tar.gz
++     version: 2.8.2
++   ros2/ros2_tracing:
++-    hash: 548634dd2837d65c043436c8186614e924be5c6c
++-    shallow_since: 1667834775 -0600
++-    type: git
++-    url: https://github.com/ros2/ros2_tracing.git
+++    hash: 261672e689e583c90b35d97ccea90ffec649ac55a0f045da46cbc3f69b657c5a
+++    strip_prefix: ros2_tracing-4.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/ros2_tracing/archive/refs/tags/4.1.1.tar.gz
++     version: 4.1.1
++   ros2/ros2cli:
++-    hash: 38d4fa97fa8091e211e190d70e9fa0b0e817689d
++-    shallow_since: 1689700836 +0000
++-    type: git
++-    url: https://github.com/ros2/ros2cli.git
+++    hash: dd862da3ff65ef4603377da21f5842d2775d55cbf89f04dfa6d42b70e28473bd
+++    strip_prefix: ros2cli-0.18.7
+++    type: http_archive
+++    url: https://github.com/ros2/ros2cli/archive/refs/tags/0.18.7.tar.gz
++     version: 0.18.7
++   ros2/ros2cli_common_extensions:
++-    hash: 4f2d47f4417475c5036c9930b5d348a5e0774007
++-    shallow_since: 1616076624 +0000
++-    type: git
++-    url: https://github.com/ros2/ros2cli_common_extensions.git
+++    hash: 5f019ebb88f214c788caedbe33257ae290a5956c5af93332c02d4e0946aaa702
+++    strip_prefix: ros2cli_common_extensions-0.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/ros2cli_common_extensions/archive/refs/tags/0.1.1.tar.gz
++     version: 0.1.1
++   ros2/ros_testing:
++-    hash: d258cbca54a5e6fbbf7be38ddd78592273ccee78
++-    shallow_since: 1642109145 -0800
++-    type: git
++-    url: https://github.com/ros2/ros_testing.git
+++    hash: f52dc8d48e3e525597e96e5316e882a03cbed6b2d3024699219c0afc0283a38b
+++    strip_prefix: ros_testing-0.4.0
+++    type: http_archive
+++    url: https://github.com/ros2/ros_testing/archive/refs/tags/0.4.0.tar.gz
++     version: 0.4.0
++   ros2/rosbag2:
++-    hash: 0b4deb3311ed8397410d84b462a86b2d1c9db153
++-    shallow_since: 1695151794 -0500
++-    type: git
++-    url: https://github.com/ros2/rosbag2.git
+++    hash: b8f10a4bb4562651c5df50b3e787ee87e2f6b30d29afe5a9044ba8acf96bc523
+++    strip_prefix: rosbag2-0.15.8
+++    type: http_archive
+++    url: https://github.com/ros2/rosbag2/archive/refs/tags/0.15.8.tar.gz
++     version: 0.15.8
++   ros2/rosidl:
++-    hash: cf3b637605c8c1dc0b1266ca0090963e9186c7dd
++-    shallow_since: 1689702714 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl.git
+++    hash: 5fef4012e2dd5d1ea6921d8bb676a95806c44f1072709b0371d75b261d8139f8
+++    strip_prefix: rosidl-3.1.5
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl/archive/refs/tags/3.1.5.tar.gz
++     version: 3.1.5
++   ros2/rosidl_dds:
++-    hash: ab8497770c652edb40d6b1591118198cbcf14237
++-    shallow_since: 1648665003 -0700
++-    type: git
++-    url: https://github.com/ros2/rosidl_dds.git
+++    hash: 5eaff06098483a0c7a54f8d998e74115e5d70b23e9c7bfff800804dcb0fb9f6a
+++    strip_prefix: rosidl_dds-0.8.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_dds/archive/refs/tags/0.8.1.tar.gz
++     version: 0.8.1
++   ros2/rosidl_defaults:
++-    hash: 1f1ee2a6169837b10302ffb2a52fb2f2a57239b2
++-    shallow_since: 1648762308 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_defaults.git
+++    hash: 3826d8df0402e2580606310fbf57b719ef8e17c460ab4f0367d2c600297fc66a
+++    strip_prefix: rosidl_defaults-1.2.0
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_defaults/archive/refs/tags/1.2.0.tar.gz
++     version: 1.2.0
++   ros2/rosidl_python:
++-    hash: 2507d5dbc1aebe2254d9eac088f007dcaea2ff03
++-    shallow_since: 1667923359 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_python.git
+++    hash: 4bb38b6718a0c23aa6d799548c4cfd021ba320294673e75eaf3137821e1234d1
+++    strip_prefix: rosidl_python-0.14.4
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_python/archive/refs/tags/0.14.4.tar.gz
++     version: 0.14.4
++   ros2/rosidl_runtime_py:
++-    hash: 02b91d6f9acbfe3dbfa4feb34bd7c30e219aa178
++-    shallow_since: 1667835469 -0600
++-    type: git
++-    url: https://github.com/ros2/rosidl_runtime_py.git
+++    hash: 4006ed60e2544eb390a6231c3e7a676d1605601260417b4b207ef94424a38b26
+++    strip_prefix: rosidl_runtime_py-0.9.3
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_runtime_py/archive/refs/tags/0.9.3.tar.gz
++     version: 0.9.3
++   ros2/rosidl_typesupport:
++-    hash: aa522c4bf1a1b6c10766b84ca6625a8c494c0928
++-    shallow_since: 1689702809 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport.git
+++    hash: ab4b5cbe2db3f03b2e91bc999bf618467b696bb316f91fc6002590d00cad23fd
+++    strip_prefix: rosidl_typesupport-2.0.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_typesupport/archive/refs/tags/2.0.1.tar.gz
++     version: 2.0.1
++   ros2/rosidl_typesupport_fastrtps:
++-    hash: c1c132960f466db26020c01913a7827695fc15af
++-    shallow_since: 1689702902 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+++    hash: 41deed571ab95f7d2a191af6e4536536f13266df059b0b11f6469be8e44cf304
+++    strip_prefix: rosidl_typesupport_fastrtps-2.2.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_typesupport_fastrtps/archive/refs/tags/2.2.1.tar.gz
++     version: 2.2.1
++   ros2/rpyutils:
++-    hash: 4cb9e1b5c1c4c585694196377ab918e7e70639f0
++-    shallow_since: 1646159541 +0000
++-    type: git
++-    url: https://github.com/ros2/rpyutils.git
+++    hash: f87d8c0a2b1a5c28b722f168d7170076e6d82e68c5cb31cff74f15a9fa251fb9
+++    strip_prefix: rpyutils-0.2.1
+++    type: http_archive
+++    url: https://github.com/ros2/rpyutils/archive/refs/tags/0.2.1.tar.gz
++     version: 0.2.1
++   ros2/rviz:
++-    hash: 6ecfcecf5bd14ce77e1c3078a65b736c9cac00b6
++-    shallow_since: 1695131351 +0000
++-    type: git
++-    url: https://github.com/ros2/rviz.git
+++    hash: 77b08203c3ea781c1a43b050b3f21193ab5c54bb0179d12bf8e688eee84d8e98
+++    strip_prefix: rviz-11.2.8
+++    type: http_archive
+++    url: https://github.com/ros2/rviz/archive/refs/tags/11.2.8.tar.gz
++     version: 11.2.8
++   ros2/spdlog_vendor:
++-    hash: 2de3e7f6ee157a7e3a2dd24f33046f6d25c099be
++-    shallow_since: 1673359578 -0600
++-    type: git
++-    url: https://github.com/ros2/spdlog_vendor.git
+++    hash: 3f9f0cbce8d6e8dd61c0f2d6462973edb16cb5c27de4f40eb5bf2a94ebb5e48f
+++    strip_prefix: spdlog_vendor-1.3.1
+++    type: http_archive
+++    url: https://github.com/ros2/spdlog_vendor/archive/refs/tags/1.3.1.tar.gz
++     version: 1.3.1
++   ros2/sros2:
++-    hash: bb3859098f123c65f8cfc90f45e21502be521d48
++-    shallow_since: 1649450801 +0000
++-    type: git
++-    url: https://github.com/ros2/sros2.git
+++    hash: b7cc3ab698e1dc4f09c45a6a14053b2c1b4cf30a9d43e1ec1718ce74d80c15cb
+++    strip_prefix: sros2-0.10.4
+++    type: http_archive
+++    url: https://github.com/ros2/sros2/archive/refs/tags/0.10.4.tar.gz
++     version: 0.10.4
++   ros2/system_tests:
++-    hash: 83a4e481624a6d171104fe4c89d2fb56da91ab6d
++-    shallow_since: 1649180453 +0000
++-    type: git
++-    url: https://github.com/ros2/system_tests.git
+++    hash: d17b31af3da15aaab7ccdfd84745b2875f5979645226059acded6aef06b1f8a8
+++    strip_prefix: system_tests-0.12.3
+++    type: http_archive
+++    url: https://github.com/ros2/system_tests/archive/refs/tags/0.12.3.tar.gz
++     version: 0.12.3
++   ros2/test_interface_files:
++-    hash: a0c8f5e338490ddf8b98238dce35c06810115e8b
++-    shallow_since: 1649179981 +0000
++-    type: git
++-    url: https://github.com/ros2/test_interface_files.git
+++    hash: 5f2df28f9b04e9edcef772b4d717222b098890739a49e6e0596afbf0d33ec75f
+++    strip_prefix: test_interface_files-0.9.1
+++    type: http_archive
+++    url: https://github.com/ros2/test_interface_files/archive/refs/tags/0.9.1.tar.gz
++     version: 0.9.1
++   ros2/tinyxml2_vendor:
++-    hash: 4ec721bf7f6adaa604db28e6ef1ae4beb205a773
++-    shallow_since: 1649179758 +0000
++-    type: git
++-    url: https://github.com/ros2/tinyxml2_vendor.git
+++    hash: 748a5e4d31566530e66b80c84e30e882789b9c9944c8777f19d745d184d9e411
+++    strip_prefix: tinyxml2_vendor-0.7.5
+++    type: http_archive
+++    url: https://github.com/ros2/tinyxml2_vendor/archive/refs/tags/0.7.5.tar.gz
++     version: 0.7.5
++   ros2/tinyxml_vendor:
++-    hash: b226bdf9a7dbdcf9ac47961e09f3d730525c1667
++-    shallow_since: 1649179658 +0000
++-    type: git
++-    url: https://github.com/ros2/tinyxml_vendor.git
+++    hash: 082e1168c25d90681a2e6973452aee4822eb6d29bc1e3ee61f31c87c82a28a33
+++    strip_prefix: tinyxml_vendor-0.8.3
+++    type: http_archive
+++    url: https://github.com/ros2/tinyxml_vendor/archive/refs/tags/0.8.3.tar.gz
++     version: 0.8.3
++   ros2/tlsf:
++-    hash: d39351de61894a8b4ce65a682ea3593628a9a179
++-    shallow_since: 1646157096 +0000
++-    type: git
++-    url: https://github.com/ros2/tlsf.git
+++    hash: d4e5b0f2e06d37b7038a17b9423b06d1b63884f930af20786d4ac9d4af5a776c
+++    strip_prefix: tlsf-0.7.0
+++    type: http_archive
+++    url: https://github.com/ros2/tlsf/archive/refs/tags/0.7.0.tar.gz
++     version: 0.7.0
++   ros2/unique_identifier_msgs:
++-    hash: 27767cefcf8a80da44641dc208c57722c28aa11c
++-    shallow_since: 1617715220 +0000
++-    type: git
++-    url: https://github.com/ros2/unique_identifier_msgs.git
+++    hash: ccedcb7c2b6d927fc4f654cceab299a8cb55082953867754795c6ea2ccdd68a9
+++    strip_prefix: unique_identifier_msgs-2.2.1
+++    type: http_archive
+++    url: https://github.com/ros2/unique_identifier_msgs/archive/refs/tags/2.2.1.tar.gz
++     version: 2.2.1
++   ros2/urdf:
++-    hash: 3fa99149d8300dcd90bfc05b58ce0fc0bceaae5d
++-    shallow_since: 1646156722 +0000
++-    type: git
++-    url: https://github.com/ros2/urdf.git
+++    hash: a762eb57dc7f60b9ada0240fd7c609f0dc5028ef0b4b65972daf91e009e52cf6
+++    strip_prefix: urdf-2.6.0
+++    type: http_archive
+++    url: https://github.com/ros2/urdf/archive/refs/tags/2.6.0.tar.gz
++     version: 2.6.0
++   ros2/yaml_cpp_vendor:
++-    hash: 77bebe7a90c0bc26df3137f15bad4a9712f9b74e
++-    shallow_since: 1673359652 -0600
++-    type: git
++-    url: https://github.com/ros2/yaml_cpp_vendor.git
+++    hash: 404880afaf66890f3c3b79e83c5b433cd4be2aa01a2ce024df501f0488570842
+++    strip_prefix: yaml_cpp_vendor-8.0.2
+++    type: http_archive
+++    url: https://github.com/ros2/yaml_cpp_vendor/archive/refs/tags/8.0.2.tar.gz
++     version: 8.0.2
++diff --git a/repos/config/ros2_iron.lock b/repos/config/ros2_iron.lock
++index 7e03cac..9a87afa 100644
++--- a/repos/config/ros2_iron.lock
+++++ b/repos/config/ros2_iron.lock
++@@ -3,638 +3,638 @@
++ #
++ repositories:
++   ament/ament_cmake:
++-    hash: 4248cdfcf0d8d0a462c04e5dce498fee5721da4b
++-    shallow_since: 1687451108 -0700
++-    type: git
++-    url: https://github.com/ament/ament_cmake.git
+++    hash: c2b6c6556fef3a11ada6ed1582aad1e96d0c99f80ce8d44e9fc4b8cceab80295
+++    strip_prefix: ament_cmake-2.0.3
+++    type: http_archive
+++    url: https://github.com/ament/ament_cmake/archive/refs/tags/2.0.3.tar.gz
++     version: 2.0.3
++   ament/ament_index:
++-    hash: ba818db036e82d5f752d17e3e6fe6e3efd583bfb
++-    shallow_since: 1676390119 +0000
++-    type: git
++-    url: https://github.com/ament/ament_index.git
+++    hash: 148bc65f5d12700ada5d76b93ba66a05b99c4fe4221f294bceb292c15f08a38c
+++    strip_prefix: ament_index-1.5.2
+++    type: http_archive
+++    url: https://github.com/ament/ament_index/archive/refs/tags/1.5.2.tar.gz
++     version: 1.5.2
++   ament/ament_lint:
++-    hash: f4f0f7fd061575a22367a5ecfa5fa5e5b8ed0895
++-    shallow_since: 1694147882 +0800
++-    type: git
++-    url: https://github.com/ament/ament_lint.git
+++    hash: 4abea3d56fe234a12db71d2e68a79f046cfe64e27a7bd8603832f239f5a9a176
+++    strip_prefix: ament_lint-0.14.2
+++    type: http_archive
+++    url: https://github.com/ament/ament_lint/archive/refs/tags/0.14.2.tar.gz
++     version: 0.14.2
++   ament/ament_package:
++-    hash: cf415e74bb8faff896bb6915ee3d120cc7b60fc3
++-    shallow_since: 1681221907 +0000
++-    type: git
++-    url: https://github.com/ament/ament_package.git
+++    hash: 0d237006f51dafa32486583696558b178cc2bc114b556fcd13af366f749513f3
+++    strip_prefix: ament_package-0.15.3
+++    type: http_archive
+++    url: https://github.com/ament/ament_package/archive/refs/tags/0.15.3.tar.gz
++     version: 0.15.3
++   ament/google_benchmark_vendor:
++-    hash: 953cee9382bdbdde1b85c0406ce34f71acf0534c
++-    shallow_since: 1676386698 -0600
++-    type: git
++-    url: https://github.com/ament/google_benchmark_vendor.git
+++    hash: 4864c4b43709e17ebda8f08cba66e1bbaa23e22613d22b0febbfb1e3d9f576e9
+++    strip_prefix: google_benchmark_vendor-0.3.0
+++    type: http_archive
+++    url: https://github.com/ament/google_benchmark_vendor/archive/refs/tags/0.3.0.tar.gz
++     version: 0.3.0
++   ament/googletest:
++-    hash: 1c2fdcd80b08fcfe6b70fa2a369ae6bab9d5f78e
++-    shallow_since: 1681222174 +0000
++-    type: git
++-    url: https://github.com/ament/googletest.git
+++    hash: 3ade05c790816b12d88ffed584dc2bf39346fb1bde328d20c5566a1e17b79f30
+++    strip_prefix: googletest-1.10.9005
+++    type: http_archive
+++    url: https://github.com/ament/googletest/archive/refs/tags/1.10.9005.tar.gz
++     version: 1.10.9005
++   ament/uncrustify_vendor:
++-    hash: 94ed3f68d1d2e44e04398c4538509f5e78114dae
++-    shallow_since: 1676390520 +0000
++-    type: git
++-    url: https://github.com/ament/uncrustify_vendor.git
+++    hash: 157addbd01a71468771a53274ba34382ab2717394b5c6bbcbb308e0779cc9f6a
+++    strip_prefix: uncrustify_vendor-2.1.2
+++    type: http_archive
+++    url: https://github.com/ament/uncrustify_vendor/archive/refs/tags/2.1.2.tar.gz
++     version: 2.1.2
++   eProsima/Fast-CDR:
++-    hash: 5d782877435b569e0ed38541f362e212c9123dd4
++-    shallow_since: 1679466588 +0100
++-    type: git
++-    url: https://github.com/eProsima/Fast-CDR.git
+++    hash: a9bc8fd31a2c2b95e6d2fb46e6ce1ad733e86dc4442f733479e33ed9cdc54bf6
+++    strip_prefix: Fast-CDR-1.0.27
+++    type: http_archive
+++    url: https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.27.tar.gz
++     version: v1.0.27
++   eProsima/Fast-DDS:
++-    hash: 2be7879185bfa2b67d5a9777ddee0a7e637776f3
++-    shallow_since: 1692360029 +0200
++-    type: git
++-    url: https://github.com/eProsima/Fast-DDS.git
++-    version: 2.10.2
+++    hash: 68fe3db6bb03823eb0d707eb6c8087049be7a7494571092c16e2489497def022
+++    strip_prefix: Fast-DDS-2.10.2
+++    type: http_archive
+++    url: https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.10.2.tar.gz
+++    version: v2.10.2
++   eProsima/foonathan_memory_vendor:
++-    hash: 8db2afc097db4cebe414ae27cdb3af1480ae46e7
++-    shallow_since: 1676364830 +0100
++-    type: git
++-    url: https://github.com/eProsima/foonathan_memory_vendor.git
+++    hash: bd72f3dd66a2a66c46bc28eff32de618462ddfee8e3e98b8ec3efee4ffbae880
+++    strip_prefix: foonathan_memory_vendor-1.3.0
+++    type: http_archive
+++    url: https://github.com/eProsima/foonathan_memory_vendor/archive/refs/tags/v1.3.0.tar.gz
++     version: v1.3.0
++   eclipse-cyclonedds/cyclonedds:
++-    hash: 63b6eab0e0660009eaf5e54d10509ea587ce199e
++-    shallow_since: 1679487279 +0100
++-    type: git
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
+++    hash: bc79696209febfe66d97e7af6b11e92f9db663caf608a922b6c201b1d6a5eb62
+++    strip_prefix: cyclonedds-0.10.3
+++    type: http_archive
+++    url: https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.10.3.tar.gz
++     version: 0.10.3
++   eclipse-iceoryx/iceoryx:
++-    hash: 40ef24e9515940564af63987234d51dc7f02f6b3
++-    shallow_since: 1675094707 +0100
++-    type: git
++-    url: https://github.com/eclipse-iceoryx/iceoryx.git
+++    hash: 8f391696daf2e63da9437aab8d7154371df630fc93876479f2e84c693fc1ba5a
+++    strip_prefix: iceoryx-2.0.3
+++    type: http_archive
+++    url: https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.3.tar.gz
++     version: v2.0.3
++   gazebo-release/gz_cmake2_vendor:
++-    hash: 01bd9e0a4e49b272645200a782dead88188cdb2e
++-    shallow_since: 1681223004 +0000
++-    type: git
++-    url: https://github.com/gazebo-release/gz_cmake2_vendor.git
+++    hash: 56c578263240deea251e0e288a967db60ea2b56b58ee6d7f86f9fd059189a309
+++    strip_prefix: gz_cmake2_vendor-0.1.0
+++    type: http_archive
+++    url: https://github.com/gazebo-release/gz_cmake2_vendor/archive/refs/tags/0.1.0.tar.gz
++     version: 0.1.0
++   gazebo-release/gz_math6_vendor:
++-    hash: c4784e998bbce003f8db8e87b62c73750cb8be0f
++-    shallow_since: 1682703105 +0000
++-    type: git
++-    url: https://github.com/gazebo-release/gz_math6_vendor.git
+++    hash: f99105bd9ee4290cbed70efea578917fdcc1cf1a5ebf8010e1b7af6daaec2840
+++    strip_prefix: gz_math6_vendor-0.1.0
+++    type: http_archive
+++    url: https://github.com/gazebo-release/gz_math6_vendor/archive/refs/tags/0.1.0.tar.gz
++     version: 0.1.0
++   osrf/osrf_pycommon:
++-    hash: 815073ebe4eb892cf1f5bb5fa064ffb1dd45b170
++-    shallow_since: 1676392123 +0000
++-    type: git
++-    url: https://github.com/osrf/osrf_pycommon.git
+++    hash: a1b00e27f0190b46a5ab92974e8a34ac47537ffd6639428ccb3c0919d4a11537
+++    strip_prefix: osrf_pycommon-2.1.2
+++    type: http_archive
+++    url: https://github.com/osrf/osrf_pycommon/archive/refs/tags/2.1.2.tar.gz
++     version: 2.1.2
++   osrf/osrf_testing_tools_cpp:
++-    hash: 557ce7827b09b22d58de1c726a2caf71fc32e3e7
++-    shallow_since: 1682703503 +0000
++-    type: git
++-    url: https://github.com/osrf/osrf_testing_tools_cpp.git
+++    hash: 30e5cfe7f74e718377430376de13c672f189b3e0fff1ba89ea97122e3064e99e
+++    strip_prefix: osrf_testing_tools_cpp-1.6.0
+++    type: http_archive
+++    url: https://github.com/osrf/osrf_testing_tools_cpp/archive/refs/tags/1.6.0.tar.gz
++     version: 1.6.0
++   ros-perception/image_common:
++-    hash: a32e834234af161c19d9a2b1cc03991dd6af53e7
++-    shallow_since: 1692024961 +0200
++-    type: git
++-    url: https://github.com/ros-perception/image_common.git
+++    hash: be3eee5e6ba899098e395f338fc524aab93744ac1b3a9a58a32f72fc1b469127
+++    strip_prefix: image_common-4.2.2
+++    type: http_archive
+++    url: https://github.com/ros-perception/image_common/archive/refs/tags/4.2.2.tar.gz
++     version: 4.2.2
++   ros-perception/laser_geometry:
++-    hash: de79acf96ecaafcba7a62dba12e644b5747cb19c
++-    shallow_since: 1676387774 -0600
++-    type: git
++-    url: https://github.com/ros-perception/laser_geometry.git
+++    hash: 71fb1b2f1fb08e071efb0e482f140a0d881e95b0433a01c5e5185ca0499b2376
+++    strip_prefix: laser_geometry-2.5.0
+++    type: http_archive
+++    url: https://github.com/ros-perception/laser_geometry/archive/refs/tags/2.5.0.tar.gz
++     version: 2.5.0
++   ros-planning/navigation_msgs:
++-    hash: 6ceaaf521f604c1c9d2cdb2b80f69e7406681978
++-    shallow_since: 1676389678 -0600
++-    type: git
++-    url: https://github.com/ros-planning/navigation_msgs.git
+++    hash: af395b89e190da5ed4818f680e67d5a0cf320e5c21fb5f50d23603d5b945f115
+++    strip_prefix: navigation_msgs-2.2.0
+++    type: http_archive
+++    url: https://github.com/ros-planning/navigation_msgs/archive/refs/tags/2.2.0.tar.gz
++     version: 2.2.0
++   ros-tooling/keyboard_handler:
++-    hash: 93e4743ea2918626b3f441c443abe7533e366bbc
++-    shallow_since: 1667916946 -0500
++-    type: git
++-    url: https://github.com/ros-tooling/keyboard_handler.git
+++    hash: 2bb52d551a09a8c001009e9cce98459e36ac1faf3e8b4d7d47238d2f6451f81f
+++    strip_prefix: keyboard_handler-0.1.0
+++    type: http_archive
+++    url: https://github.com/ros-tooling/keyboard_handler/archive/refs/tags/0.1.0.tar.gz
++     version: 0.1.0
++   ros-tooling/libstatistics_collector:
++-    hash: 00b9371c15fdc9b3f42faee3cb718214b787eb13
++-    shallow_since: 1681306122 +0000
++-    type: git
++-    url: https://github.com/ros-tooling/libstatistics_collector.git
+++    hash: e3cae09351a29eeb3ba10aa2ecfe5fc8a1307de48bc68c4d34b2cacff3fce1b5
+++    strip_prefix: libstatistics_collector-1.5.1
+++    type: http_archive
+++    url: https://github.com/ros-tooling/libstatistics_collector/archive/refs/tags/1.5.1.tar.gz
++     version: 1.5.1
++   ros-visualization/interactive_markers:
++-    hash: ae67485ee39c77c17946c0708af4bb77a39b96b3
++-    shallow_since: 1676389612 -0600
++-    type: git
++-    url: https://github.com/ros-visualization/interactive_markers.git
+++    hash: b739b64496992644939df7f9d36587e944445e0e94dca2c227dd2ef8ebfceaef
+++    strip_prefix: interactive_markers-2.4.0
+++    type: http_archive
+++    url: https://github.com/ros-visualization/interactive_markers/archive/refs/tags/2.4.0.tar.gz
++     version: 2.4.0
++   ros-visualization/python_qt_binding:
++-    hash: ae0c68db584a88b56cffc1485d1dd8b776729602
++-    shallow_since: 1681223869 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/python_qt_binding.git
+++    hash: cad340c5978f97a1d1d209bd0a91b2840bdfe6cc752674e0d845dbb736007f8f
+++    strip_prefix: python_qt_binding-1.2.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/python_qt_binding/archive/refs/tags/1.2.3.tar.gz
++     version: 1.2.3
++   ros-visualization/qt_gui_core:
++-    hash: 4abf0eebc7a0da73f00c1c8432166efb16e244b1
++-    shallow_since: 1684469026 +0800
++-    type: git
++-    url: https://github.com/ros-visualization/qt_gui_core.git
+++    hash: f1e3796581cc342416c9cfbae5b4be19a2ca9415368a3704d37320253238a06a
+++    strip_prefix: qt_gui_core-2.4.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/qt_gui_core/archive/refs/tags/2.4.2.tar.gz
++     version: 2.4.2
++   ros-visualization/rqt:
++-    hash: dba23643d88f3f0f7990aa9d92a4959af7213518
++-    shallow_since: 1684468389 +0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt.git
+++    hash: 5ec59f9e01ded168d7aa65b1ac0193193b35d02f6a960ae588730505a71ebaf1
+++    strip_prefix: rqt-1.3.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt/archive/refs/tags/1.3.3.tar.gz
++     version: 1.3.3
++   ros-visualization/rqt_action:
++-    hash: 485841029f88d93b6cc4d8104786f42f8bb45e1e
++-    shallow_since: 1676391928 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_action.git
+++    hash: 1ae559b72680b0578dbe13ccea3b5221f7e8a2425092c7b822b75bad5a420e2e
+++    strip_prefix: rqt_action-2.1.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_action/archive/refs/tags/2.1.2.tar.gz
++     version: 2.1.2
++   ros-visualization/rqt_bag:
++-    hash: 7130a33b0d22171a27d4f831d0de3729e916b90a
++-    shallow_since: 1694149679 +0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_bag.git
+++    hash: 6ac08b2606d0ffa78f3c58eea611f3c11cbac64ce317f5005a94bbac79cf121c
+++    strip_prefix: rqt_bag-1.3.4
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_bag/archive/refs/tags/1.3.4.tar.gz
++     version: 1.3.4
++   ros-visualization/rqt_console:
++-    hash: 7b4797c29746ea1f39b05beac63d836a5ded8cd3
++-    shallow_since: 1676391823 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_console.git
+++    hash: 7d691a4d6c9d1c9d6fb3da28778cb62618675ac6227be96c0ca505906a59c790
+++    strip_prefix: rqt_console-2.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_console/archive/refs/tags/2.1.1.tar.gz
++     version: 2.1.1
++   ros-visualization/rqt_graph:
++-    hash: 9f8314d91cf0a3b3f525770f62470c33d650629c
++-    shallow_since: 1683795583 +0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_graph.git
+++    hash: e2464d9b4bc261e974d96fcd5255279b653c95108c70a8f951c1aae168dea616
+++    strip_prefix: rqt_graph-1.4.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_graph/archive/refs/tags/1.4.2.tar.gz
++     version: 1.4.2
++   ros-visualization/rqt_msg:
++-    hash: 9eb293818a27bda6a6300637ec497bc778928256
++-    shallow_since: 1676391592 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_msg.git
+++    hash: 3a318bff7c7d85fc86fa052f83de5d8359d7f8477574bd15dd3e2aab7911e4cd
+++    strip_prefix: rqt_msg-1.3.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_msg/archive/refs/tags/1.3.1.tar.gz
++     version: 1.3.1
++   ros-visualization/rqt_plot:
++-    hash: 709dbb8deeb0982b9e1cbf0bda7293132c18a635
++-    shallow_since: 1683797105 +0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_plot.git
+++    hash: d2436d19179806919d124619c7345a515e41c0b350754b1344eb8cdd99691513
+++    strip_prefix: rqt_plot-1.2.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_plot/archive/refs/tags/1.2.3.tar.gz
++     version: 1.2.3
++   ros-visualization/rqt_publisher:
++-    hash: 33dd6e32f74b9b160cbcee519ac46ad937647350
++-    shallow_since: 1681224497 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_publisher.git
+++    hash: bbccdf7be70d0fa6f3d1e9cc71c97c4983bb201af60adc8f9b973dd7e2d168aa
+++    strip_prefix: rqt_publisher-1.6.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_publisher/archive/refs/tags/1.6.3.tar.gz
++     version: 1.6.3
++   ros-visualization/rqt_py_console:
++-    hash: c7570778bbed0e4c3ab564eae2dfceb6d4052e4f
++-    shallow_since: 1676391315 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_py_console.git
+++    hash: 76b5359a366c60b472cd23e02f6a58c0eb54d3ed31f4c427ca8c53c7d5cef320
+++    strip_prefix: rqt_py_console-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_py_console/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/rqt_reconfigure:
++-    hash: a7057ba5642546f5f59cf29893e9f23b3025ac5d
++-    shallow_since: 1681303854 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_reconfigure.git
+++    hash: 4678b4617f17b7919e613af4ce6b7c51398c9727820414c8de5ea6f0792b1264
+++    strip_prefix: rqt_reconfigure-1.3.3
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_reconfigure/archive/refs/tags/1.3.3.tar.gz
++     version: 1.3.3
++   ros-visualization/rqt_service_caller:
++-    hash: 20d2bc0385d37c1a4a7d686b966f7b46b4dda29c
++-    shallow_since: 1676391104 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_service_caller.git
+++    hash: db3bce8077421b1ee55b592c4f5f89f3f7e2aadcba833b1d6fb698319de76d18
+++    strip_prefix: rqt_service_caller-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_service_caller/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/rqt_shell:
++-    hash: 142244b512cf07971de9d53516dad8c335592a15
++-    shallow_since: 1676390997 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_shell.git
+++    hash: 461fd796de437b834a28ec6d33b4ce9fa5fa93cd87aaeefd9a2c5b0fb330e900
+++    strip_prefix: rqt_shell-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_shell/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/rqt_srv:
++-    hash: 55389081d4b830a248d75d6a7dac4418ab8f2926
++-    shallow_since: 1676390915 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_srv.git
+++    hash: c609f12eca2879bb35eef915e78a017e02160c7bf53a989568d2c6b38513b609
+++    strip_prefix: rqt_srv-1.1.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_srv/archive/refs/tags/1.1.1.tar.gz
++     version: 1.1.1
++   ros-visualization/rqt_topic:
++-    hash: b983018ef6722570faf7e8267f8a70ae74d049c6
++-    shallow_since: 1676390816 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_topic.git
+++    hash: 2b564554edf778a928dbc3bd16d9c1ba7e1933118755a9f8b77e74a874e88d53
+++    strip_prefix: rqt_topic-1.6.1
+++    type: http_archive
+++    url: https://github.com/ros-visualization/rqt_topic/archive/refs/tags/1.6.1.tar.gz
++     version: 1.6.1
++   ros-visualization/tango_icons_vendor:
++-    hash: 9b7d001ea4201f113c0876b52de16d528ee6824f
++-    shallow_since: 1676386541 +0000
++-    type: git
++-    url: https://github.com/ros-visualization/tango_icons_vendor.git
+++    hash: 08b40ec1061c355389e57ecbed1bb76c5ced1f348b62b54b469cb3ad863e3788
+++    strip_prefix: tango_icons_vendor-0.2.2
+++    type: http_archive
+++    url: https://github.com/ros-visualization/tango_icons_vendor/archive/refs/tags/0.2.2.tar.gz
++     version: 0.2.2
++   ros/class_loader:
++-    hash: 2f360ba29d094b843f359033b8ece76ee0eb1a1e
++-    shallow_since: 1676325429 +0000
++-    type: git
++-    url: https://github.com/ros/class_loader.git
+++    hash: 474267bf0a4d18cf2ff0d696841a7399047797471e752be818933e4d1eab042c
+++    strip_prefix: class_loader-2.5.0
+++    type: http_archive
+++    url: https://github.com/ros/class_loader/archive/refs/tags/2.5.0.tar.gz
++     version: 2.5.0
++   ros/kdl_parser:
++-    hash: e2d652441561bae71bd33a6b8285f49b97dafa82
++-    shallow_since: 1676323420 +0000
++-    type: git
++-    url: https://github.com/ros/kdl_parser.git
+++    hash: 0a7849d3cc1d30926b1d92fb1182424b0cba450b2bbaa16120c0cf7ec534d02f
+++    strip_prefix: kdl_parser-2.9.0
+++    type: http_archive
+++    url: https://github.com/ros/kdl_parser/archive/refs/tags/2.9.0.tar.gz
++     version: 2.9.0
++   ros/pluginlib:
++-    hash: 30042370880c5a476d0a2817187aab11c1c886f6
++-    shallow_since: 1677682055 +0000
++-    type: git
++-    url: https://github.com/ros/pluginlib.git
+++    hash: fa51490338fcc85ae116c1c992d3d6428270de36983f284523c2bdf732c39556
+++    strip_prefix: pluginlib-5.2.2
+++    type: http_archive
+++    url: https://github.com/ros/pluginlib/archive/refs/tags/5.2.2.tar.gz
++     version: 5.2.2
++   ros/resource_retriever:
++-    hash: 8046f3dc41e9646a035802b53556dd31f13525fe
++-    shallow_since: 1667410648 +0000
++-    type: git
++-    url: https://github.com/ros/resource_retriever.git
+++    hash: d2bf40bcadb820a19c2deccdc6a58a60e22bd9a87b118df9f1ee6be07ceb9eed
+++    strip_prefix: resource_retriever-3.2.2
+++    type: http_archive
+++    url: https://github.com/ros/resource_retriever/archive/refs/tags/3.2.2.tar.gz
++     version: 3.2.2
++   ros/robot_state_publisher:
++-    hash: f52c7ca4c85f0ac7cd11f6d371b64f48da78b562
++-    shallow_since: 1681224612 +0000
++-    type: git
++-    url: https://github.com/ros/robot_state_publisher.git
+++    hash: 4e903b567895e92770e6501866eb87f63290523f8ba07995deeebb3ceda918ab
+++    strip_prefix: robot_state_publisher-3.2.0
+++    type: http_archive
+++    url: https://github.com/ros/robot_state_publisher/archive/refs/tags/3.2.0.tar.gz
++     version: 3.2.0
++   ros/ros_environment:
++-    hash: 9ba0e07e089082051d674df94fd5a78d262765f4
++-    shallow_since: 1682716516 +0000
++-    type: git
++-    url: https://github.com/ros/ros_environment.git
+++    hash: 89a81c5431b6dcb7d6103cebdfff39a8cc75ecbe06cdc9803170a3235c3f4928
+++    strip_prefix: ros_environment-4.1.1
+++    type: http_archive
+++    url: https://github.com/ros/ros_environment/archive/refs/tags/4.1.1.tar.gz
++     version: 4.1.1
++   ros/ros_tutorials:
++-    hash: 441071ee52275a7c6569573d7de10b3db2f602ba
++-    shallow_since: 1683813824 +0000
++-    type: git
++-    url: https://github.com/ros/ros_tutorials.git
+++    hash: 22f66f84c1d6affb51ae1c1a6f47505661a962b8c221a59a4860fcb69b3c6352
+++    strip_prefix: ros_tutorials-1.6.1
+++    type: http_archive
+++    url: https://github.com/ros/ros_tutorials/archive/refs/tags/1.6.1.tar.gz
++     version: 1.6.1
++   ros/urdfdom:
++-    hash: 1ed7ca95b917f38feb4ff7bd1aa033baf2cfce0e
++-    shallow_since: 1681253424 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom.git
+++    hash: dd69b2077b8fc1bd2b67022c1dc861cd896ac882df065aa08cabdf2f945a9ac0
+++    strip_prefix: urdfdom-3.1.1
+++    type: http_archive
+++    url: https://github.com/ros/urdfdom/archive/refs/tags/3.1.1.tar.gz
++     version: 3.1.1
++   ros/urdfdom_headers:
++-    hash: 2981892df9da19d10f58dc84de63820e4f554f63
++-    shallow_since: 1652227372 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom_headers.git
+++    hash: 01b91c2f7cb42b0033cbdf559684a60001f9927e5d0a5a3682a344cc354f1d39
+++    strip_prefix: urdfdom_headers-1.1.0
+++    type: http_archive
+++    url: https://github.com/ros/urdfdom_headers/archive/refs/tags/1.1.0.tar.gz
++     version: 1.1.0
++   ros2/ament_cmake_ros:
++-    hash: ede6248e1f36aaef85eb4eac23c782a134ef2bff
++-    shallow_since: 1676324288 +0000
++-    type: git
++-    url: https://github.com/ros2/ament_cmake_ros.git
+++    hash: 8cff1fbc298920709c7efa92f56fc00902a906ff6bab5c52be9df26971a8a9ca
+++    strip_prefix: ament_cmake_ros-0.11.2
+++    type: http_archive
+++    url: https://github.com/ros2/ament_cmake_ros/archive/refs/tags/0.11.2.tar.gz
++     version: 0.11.2
++   ros2/common_interfaces:
++-    hash: 86801a504b97f25a3b6e1c36e42a445500c98f79
++-    shallow_since: 1681224748 +0000
++-    type: git
++-    url: https://github.com/ros2/common_interfaces.git
+++    hash: fb3c8c4eb9afe15e94ec8e9fb5bd05c6de71782370cfd6d453da416621c55212
+++    strip_prefix: common_interfaces-5.0.0
+++    type: http_archive
+++    url: https://github.com/ros2/common_interfaces/archive/refs/tags/5.0.0.tar.gz
++     version: 5.0.0
++   ros2/console_bridge_vendor:
++-    hash: 2617013ef72fec17877ed25c8deba347fd1a29a7
++-    shallow_since: 1676385245 +0000
++-    type: git
++-    url: https://github.com/ros2/console_bridge_vendor.git
+++    hash: 62aef22f5d30a95415852f5a4c786b18c9df7785ced820d8d5c837218c2c8e8f
+++    strip_prefix: console_bridge_vendor-1.6.0
+++    type: http_archive
+++    url: https://github.com/ros2/console_bridge_vendor/archive/refs/tags/1.6.0.tar.gz
++     version: 1.6.0
++   ros2/demos:
++-    hash: cae576969faf98eb44bfc85090c71be0230da788
++-    shallow_since: 1683799437 +0800
++-    type: git
++-    url: https://github.com/ros2/demos.git
+++    hash: 50fe887912e11e497d78d4bfdf5b44fe4a24bad927e3e36b7976376a1dc5e714
+++    strip_prefix: demos-0.27.1
+++    type: http_archive
+++    url: https://github.com/ros2/demos/archive/refs/tags/0.27.1.tar.gz
++     version: 0.27.1
++   ros2/eigen3_cmake_module:
++-    hash: b7d875ee0628b579060e19874570bcfb30ecca8c
++-    shallow_since: 1676324365 +0000
++-    type: git
++-    url: https://github.com/ros2/eigen3_cmake_module.git
+++    hash: 5d14617e3df89214e19a209110c22e222fdf94332e3814e10aaf19424bc7a999
+++    strip_prefix: eigen3_cmake_module-0.2.2
+++    type: http_archive
+++    url: https://github.com/ros2/eigen3_cmake_module/archive/refs/tags/0.2.2.tar.gz
++     version: 0.2.2
++   ros2/example_interfaces:
++-    hash: 58899de0f85388be333e32bcb78c551a6877db4d
++-    shallow_since: 1676324462 +0000
++-    type: git
++-    url: https://github.com/ros2/example_interfaces.git
+++    hash: 53b82d16975d73d037b5d958d2d9594446c0fb03061639cc0f9f51500146bbad
+++    strip_prefix: example_interfaces-0.10.2
+++    type: http_archive
+++    url: https://github.com/ros2/example_interfaces/archive/refs/tags/0.10.2.tar.gz
++     version: 0.10.2
++   ros2/examples:
++-    hash: cbeb3135f932dc6297d3e8675912b2209270e796
++-    shallow_since: 1681224974 +0000
++-    type: git
++-    url: https://github.com/ros2/examples.git
+++    hash: 324a70655cc7b35ad9665732733e4d59a967d2e4c1a3ad88b83088fc26f4e92f
+++    strip_prefix: examples-0.18.0
+++    type: http_archive
+++    url: https://github.com/ros2/examples/archive/refs/tags/0.18.0.tar.gz
++     version: 0.18.0
++   ros2/geometry2:
++-    hash: 00e0805a581e8fe97d87b6093a5978014295712c
++-    shallow_since: 1694150506 +0800
++-    type: git
++-    url: https://github.com/ros2/geometry2.git
+++    hash: c08308e55dc41e702b08938e651d4bfa7a9b099b20902af737eab8af2b2c2168
+++    strip_prefix: geometry2-0.31.5
+++    type: http_archive
+++    url: https://github.com/ros2/geometry2/archive/refs/tags/0.31.5.tar.gz
++     version: 0.31.5
++   ros2/launch:
++-    hash: f15691c341d32e53970fa18a9a22c9206c2edfbe
++-    shallow_since: 1689268429 +0800
++-    type: git
++-    url: https://github.com/ros2/launch.git
+++    hash: a9460a982564eb3a60e30888e8e11c58a1275f256301583cc6cfef6ea01d5897
+++    strip_prefix: launch-2.0.2
+++    type: http_archive
+++    url: https://github.com/ros2/launch/archive/refs/tags/2.0.2.tar.gz
++     version: 2.0.2
++   ros2/launch_ros:
++-    hash: 03031d629f78115ea7a0b838fb48034b0d7ae92b
++-    shallow_since: 1681227952 +0000
++-    type: git
++-    url: https://github.com/ros2/launch_ros.git
+++    hash: 9f60c4afc250e384cee751fad73846a33d240deda21cbe7116bfe0da9d06bcd8
+++    strip_prefix: launch_ros-0.24.0
+++    type: http_archive
+++    url: https://github.com/ros2/launch_ros/archive/refs/tags/0.24.0.tar.gz
++     version: 0.24.0
++   ros2/libyaml_vendor:
++-    hash: 0c814892fe8c31aeb20688a8b43906aeefda015e
++-    shallow_since: 1676325166 +0000
++-    type: git
++-    url: https://github.com/ros2/libyaml_vendor.git
+++    hash: 857d78b0fd870167b1361f8cab4fb73e5b0453341dc55b6b0aad531807fc608d
+++    strip_prefix: libyaml_vendor-1.5.0
+++    type: http_archive
+++    url: https://github.com/ros2/libyaml_vendor/archive/refs/tags/1.5.0.tar.gz
++     version: 1.5.0
++   ros2/message_filters:
++-    hash: c81a914f16e5852ea3b2fe4bd99d06b4269bd385
++-    shallow_since: 1676324832 +0000
++-    type: git
++-    url: https://github.com/ros2/message_filters.git
+++    hash: 4831217bdd605610d2d3e99e9b0bc08b616b6ba457384ed35754d0dcc99f5a5d
+++    strip_prefix: message_filters-4.7.0
+++    type: http_archive
+++    url: https://github.com/ros2/message_filters/archive/refs/tags/4.7.0.tar.gz
++     version: 4.7.0
++   ros2/mimick_vendor:
++-    hash: 3f2e27e2ca82bf08e7c935461dafc3d526e20ea1
++-    shallow_since: 1676390314 +0000
++-    type: git
++-    url: https://github.com/ros2/mimick_vendor.git
+++    hash: cb7bf9dd7ebb016b930caa0211f272386121af8c6dc821d81d08edcc14c802bf
+++    strip_prefix: mimick_vendor-0.3.2
+++    type: http_archive
+++    url: https://github.com/ros2/mimick_vendor/archive/refs/tags/0.3.2.tar.gz
++     version: 0.3.2
++   ros2/orocos_kdl_vendor:
++-    hash: 60532cef2935bdb03aa0cf197108896773c29e42
++-    shallow_since: 1663101745 +0000
++-    type: git
++-    url: https://github.com/ros2/orocos_kdl_vendor.git
+++    hash: 978fd57cc12b9312d24b7b3af6539146f9cf886dfa540ce437c87759e6ac2aa5
+++    strip_prefix: orocos_kdl_vendor-0.3.4
+++    type: http_archive
+++    url: https://github.com/ros2/orocos_kdl_vendor/archive/refs/tags/0.3.4.tar.gz
++     version: 0.3.4
++   ros2/performance_test_fixture:
++-    hash: a3f2988118cd36bffdf2e027c1d9b3cbdd192c37
++-    shallow_since: 1681228085 +0000
++-    type: git
++-    url: https://github.com/ros2/performance_test_fixture.git
+++    hash: 3fe3c7bd50ffacf4c4a0aaefb9b06be60586bbc2f6c0f61a81994effefb11570
+++    strip_prefix: performance_test_fixture-0.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/performance_test_fixture/archive/refs/tags/0.1.1.tar.gz
++     version: 0.1.1
++   ros2/pybind11_vendor:
++-    hash: b68d6210fbe8dc7ec5b97751dbe278d29834662d
++-    shallow_since: 1681226123 -0700
++-    type: git
++-    url: https://github.com/ros2/pybind11_vendor.git
+++    hash: fc5b2ab7f4e4e0faac2b882d3b8c354eeba0757991e51021cf1fab58ae9df33d
+++    strip_prefix: pybind11_vendor-3.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/pybind11_vendor/archive/refs/tags/3.0.3.tar.gz
++     version: 3.0.3
++   ros2/python_cmake_module:
++-    hash: c961a2671638560295b453b43d9315bbf07ecfe2
++-    shallow_since: 1676324123 +0000
++-    type: git
++-    url: https://github.com/ros2/python_cmake_module.git
+++    hash: 3660a48dc3d70f2a9a37ce56650d6c339102a06b9a5c822a405a93b61f26205f
+++    strip_prefix: python_cmake_module-0.10.2
+++    type: http_archive
+++    url: https://github.com/ros2/python_cmake_module/archive/refs/tags/0.10.2.tar.gz
++     version: 0.10.2
++   ros2/rcl:
++-    hash: 71ecc97db05490981f3e37ced27c66f8905879e8
++-    shallow_since: 1694151357 +0800
++-    type: git
++-    url: https://github.com/ros2/rcl.git
+++    hash: eab9fa9df1b130e390f38d1b2c20111154db710d111f1b5078dd6b6243b48719
+++    strip_prefix: rcl-6.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/rcl/archive/refs/tags/6.0.3.tar.gz
++     version: 6.0.3
++   ros2/rcl_interfaces:
++-    hash: 6d28b16a6f74485af03a2c4f043dd568e576c25e
++-    shallow_since: 1681820432 +0000
++-    type: git
++-    url: https://github.com/ros2/rcl_interfaces.git
+++    hash: f11a84e58231eb8afeb5398ea5705d6896fc7e68b80d111b1a0fa992cc981f9d
+++    strip_prefix: rcl_interfaces-1.6.0
+++    type: http_archive
+++    url: https://github.com/ros2/rcl_interfaces/archive/refs/tags/1.6.0.tar.gz
++     version: 1.6.0
++   ros2/rcl_logging:
++-    hash: 2bc49ab7ff557a45d4fa152e2f400e9ad2bb6a68
++-    shallow_since: 1681252296 -0700
++-    type: git
++-    url: https://github.com/ros2/rcl_logging.git
+++    hash: 1f9286326683270d97420efbf2e552cb0e0afa80e26225dcc058f788a4491af6
+++    strip_prefix: rcl_logging-2.5.1
+++    type: http_archive
+++    url: https://github.com/ros2/rcl_logging/archive/refs/tags/2.5.1.tar.gz
++     version: 2.5.1
++   ros2/rclcpp:
++-    hash: 45df3555d2daee48332f7dad1e6dabc7e4a7fd60
++-    shallow_since: 1694151852 +0800
++-    type: git
++-    url: https://github.com/ros2/rclcpp.git
+++    hash: 2dee67d9d168060341016ff4710879dcda5b16e52e48c7de6afa4463c2b7ea19
+++    strip_prefix: rclcpp-21.0.3
+++    type: http_archive
+++    url: https://github.com/ros2/rclcpp/archive/refs/tags/21.0.3.tar.gz
++     version: 21.0.3
++   ros2/rclpy:
++-    hash: 236f7c9f36588471531802078c40362be8f9b162
++-    shallow_since: 1694152525 +0800
++-    type: git
++-    url: https://github.com/ros2/rclpy.git
+++    hash: d972bbe7e271cc7a0e85830252552cd25c136ace3f132a5acefba2b684e78083
+++    strip_prefix: rclpy-4.1.3
+++    type: http_archive
+++    url: https://github.com/ros2/rclpy/archive/refs/tags/4.1.3.tar.gz
++     version: 4.1.3
++   ros2/rcpputils:
++-    hash: 39b20134e571ba74baa7c77750eab586da90b7a5
++-    shallow_since: 1676322161 +0000
++-    type: git
++-    url: https://github.com/ros2/rcpputils.git
+++    hash: a3379a610840bec655a8a2650df0438812f8ab6d44e6ca5bdc1156c933631017
+++    strip_prefix: rcpputils-2.6.1
+++    type: http_archive
+++    url: https://github.com/ros2/rcpputils/archive/refs/tags/2.6.1.tar.gz
++     version: 2.6.1
++   ros2/rcutils:
++-    hash: 04aa9804feb46403f0058f4b089134a6985e19d3
++-    shallow_since: 1681305660 +0000
++-    type: git
++-    url: https://github.com/ros2/rcutils.git
+++    hash: 6ee6c151c1763b19fb3481db3e55b72e0a65abc35e4c1bf62c4784663e309ca6
+++    strip_prefix: rcutils-6.2.1
+++    type: http_archive
+++    url: https://github.com/ros2/rcutils/archive/refs/tags/6.2.1.tar.gz
++     version: 6.2.1
++   ros2/realtime_support:
++-    hash: 7e2a29adc2ccd4aef425a3e91ffc9ae976147e79
++-    shallow_since: 1676384696 +0000
++-    type: git
++-    url: https://github.com/ros2/realtime_support.git
+++    hash: 4406f870e9ddbe6acb485d1c1c8fb3e18beb593591107f68b0a28848265f4b37
+++    strip_prefix: realtime_support-0.15.0
+++    type: http_archive
+++    url: https://github.com/ros2/realtime_support/archive/refs/tags/0.15.0.tar.gz
++     version: 0.15.0
++   ros2/rmw:
++-    hash: 17e3a94e447cd043dc20aec7dd620b5eb26241c6
++-    shallow_since: 1681312425 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw.git
+++    hash: 8233d20a6d3789cf80cc932bf1718498e324313e6143af5ffa3f408c63ce47b0
+++    strip_prefix: rmw-7.1.0
+++    type: http_archive
+++    url: https://github.com/ros2/rmw/archive/refs/tags/7.1.0.tar.gz
++     version: 7.1.0
++   ros2/rmw_connextdds:
++-    hash: a59d530c39de969ef3ac15d9942ddc481c906e59
++-    shallow_since: 1683804810 +0800
++-    type: git
++-    url: https://github.com/ros2/rmw_connextdds.git
+++    hash: 35da85c543ff296c3e2014f62c560491a1b698fc01fa3727d539837f8999c174
+++    strip_prefix: rmw_connextdds-0.14.1
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_connextdds/archive/refs/tags/0.14.1.tar.gz
++     version: 0.14.1
++   ros2/rmw_cyclonedds:
++-    hash: c9e7001e6bf5373bdf1931535354b52eeddb2053
++-    shallow_since: 1681312572 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_cyclonedds.git
+++    hash: f638e82ed026926133d5f43887b2efb252da4b4783fe2d9db9b56e1fdecaa23f
+++    strip_prefix: rmw_cyclonedds-1.6.0
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_cyclonedds/archive/refs/tags/1.6.0.tar.gz
++     version: 1.6.0
++   ros2/rmw_dds_common:
++-    hash: 5cbab3f3dcc83097d462d6bded8a6a724c6972ad
++-    shallow_since: 1681242861 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_dds_common.git
+++    hash: 4ca5670170f5f0c5564839ee2d9089c86d1a876d9454969153566c6419d75c5c
+++    strip_prefix: rmw_dds_common-2.0.1
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_dds_common/archive/refs/tags/2.0.1.tar.gz
++     version: 2.0.1
++   ros2/rmw_fastrtps:
++-    hash: 120ecb1c028d87b5db5175ec04f16a17a8b79152
++-    shallow_since: 1681333781 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_fastrtps.git
+++    hash: 4a2f240bf09f91cd7acf2b706df3e6536ab0e56edb5a502a43c4948cc2cf8910
+++    strip_prefix: rmw_fastrtps-7.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_fastrtps/archive/refs/tags/7.1.1.tar.gz
++     version: 7.1.1
++   ros2/rmw_implementation:
++-    hash: 124a45b2c65df5e69017dec230740c23d937787e
++-    shallow_since: 1681230516 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw_implementation.git
+++    hash: 7c4013a226654c97648ab59af86520b0f755a12a6d806b46b32335ae2e468bd4
+++    strip_prefix: rmw_implementation-2.12.0
+++    type: http_archive
+++    url: https://github.com/ros2/rmw_implementation/archive/refs/tags/2.12.0.tar.gz
++     version: 2.12.0
++   ros2/ros2_tracing:
++-    hash: fb240709fda0e0cc6c08f12ae8052d3a32221d29
++-    shallow_since: 1683805768 +0800
++-    type: git
++-    url: https://github.com/ros2/ros2_tracing.git
+++    hash: 7b3c16120a58927f43dc083b5b187604d7686c7a61a08baa394e08b5e7b30ead
+++    strip_prefix: ros2_tracing-6.3.1
+++    type: http_archive
+++    url: https://github.com/ros2/ros2_tracing/archive/refs/tags/6.3.1.tar.gz
++     version: 6.3.1
++   ros2/ros2cli:
++-    hash: 4d92fa27ca0d7796c1f792864fd98dd3b7437f8f
++-    shallow_since: 1694153559 +0800
++-    type: git
++-    url: https://github.com/ros2/ros2cli.git
+++    hash: 19b8ef30edd9dc73f1b0d7abcce0f20ce2ae836f29a0c83009e7fb958db2cea4
+++    strip_prefix: ros2cli-0.25.3
+++    type: http_archive
+++    url: https://github.com/ros2/ros2cli/archive/refs/tags/0.25.3.tar.gz
++     version: 0.25.3
++   ros2/ros2cli_common_extensions:
++-    hash: 83e51bbe477d0c9bc1a747d2d2c628ff9cf8b078
++-    shallow_since: 1676385018 +0000
++-    type: git
++-    url: https://github.com/ros2/ros2cli_common_extensions.git
+++    hash: 3bd8e4c049d904db8b2f2fcaa5858598b07d9a55b785f565f03ad65d0ea328a6
+++    strip_prefix: ros2cli_common_extensions-0.2.2
+++    type: http_archive
+++    url: https://github.com/ros2/ros2cli_common_extensions/archive/refs/tags/0.2.2.tar.gz
++     version: 0.2.2
++   ros2/ros_testing:
++-    hash: aede5d75060dcbf30897d1bd9a35bc9b503874ac
++-    shallow_since: 1676325044 +0000
++-    type: git
++-    url: https://github.com/ros2/ros_testing.git
+++    hash: 776c812ae782c805466bdf383e36e9355111f6076a45e1a5982e74edbf00f6f1
+++    strip_prefix: ros_testing-0.5.2
+++    type: http_archive
+++    url: https://github.com/ros2/ros_testing/archive/refs/tags/0.5.2.tar.gz
++     version: 0.5.2
++   ros2/rosbag2:
++-    hash: 8f0aee155c87c6607d4b080bbc1436af330d8729
++-    shallow_since: 1694404507 +0800
++-    type: git
++-    url: https://github.com/ros2/rosbag2.git
+++    hash: 4f56edc8947ecffbdbff26c78ead62c3aaa3237c7e39bca6c6601ad3f215a824
+++    strip_prefix: rosbag2-0.22.3
+++    type: http_archive
+++    url: https://github.com/ros2/rosbag2/archive/refs/tags/0.22.3.tar.gz
++     version: 0.22.3
++   ros2/rosidl:
++-    hash: 995917e9ce14d17821c04bf28d5a092111537842
++-    shallow_since: 1689270954 +0800
++-    type: git
++-    url: https://github.com/ros2/rosidl.git
+++    hash: 8b83d6bb56f290548961f37d9174807b148fbd38921c1eaddb48eb08616b8767
+++    strip_prefix: rosidl-4.0.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl/archive/refs/tags/4.0.1.tar.gz
++     version: 4.0.1
++   ros2/rosidl_core:
++-    hash: 83df4c6574f90a8479d0b0211a463a7806ad6179
++-    shallow_since: 1676323731 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_core.git
+++    hash: 4b217d14438c52e48495044b732b676376311ee75b061dda4524abc9e9f89481
+++    strip_prefix: rosidl_core-0.1.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_core/archive/refs/tags/0.1.1.tar.gz
++     version: 0.1.1
++   ros2/rosidl_dds:
++-    hash: f074b295c316e9bbb9845344cc6ab882339e9305
++-    shallow_since: 1676323645 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_dds.git
+++    hash: 9d206455ec46778f5528828ee4033b1e0c4d85104a7b0de57c993dc79ddf3f74
+++    strip_prefix: rosidl_dds-0.10.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_dds/archive/refs/tags/0.10.1.tar.gz
++     version: 0.10.1
++   ros2/rosidl_defaults:
++-    hash: 34a204f3ce0528c6ec3bb89d33404422eb879995
++-    shallow_since: 1676319666 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_defaults.git
+++    hash: 6393d8106623ccb06baa7492da5d29415faedb74f4d936833928f3d3e277990d
+++    strip_prefix: rosidl_defaults-1.5.0
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_defaults/archive/refs/tags/1.5.0.tar.gz
++     version: 1.5.0
++   ros2/rosidl_dynamic_typesupport:
++-    hash: 9e9264c5718489dea75337657473a183ed5ec19c
++-    shallow_since: 1694154531 +0800
++-    type: git
++-    url: https://github.com/ros2/rosidl_dynamic_typesupport
+++    hash: 18cab4d1c59e84e5d374997a592856f733eaa90b6bc7257f95aa01d337a26e68
+++    strip_prefix: rosidl_dynamic_typesupport-0.0.4
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_dynamic_typesupport/archive/refs/tags/0.0.4.tar.gz
++     version: 0.0.4
++   ros2/rosidl_dynamic_typesupport_fastrtps:
++-    hash: d85e3f6dca4e4e69623cfec754415187bd2ae948
++-    shallow_since: 1681234060 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps
+++    hash: c16a4cfcf10f6ea22047dfc68fa8264357cf402a7f43c291378b633bf7d617a2
+++    strip_prefix: rosidl_dynamic_typesupport_fastrtps-0.0.2
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/archive/refs/tags/0.0.2.tar.gz
++     version: 0.0.2
++   ros2/rosidl_python:
++-    hash: 52eaf342deea5fda49d9589deaad6fbb481a6221
++-    shallow_since: 1681228744 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_python.git
+++    hash: 424539f63d426f79ac5942766fcb04e56d805ce44c7611ba604df04b5088046e
+++    strip_prefix: rosidl_python-0.18.0
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_python/archive/refs/tags/0.18.0.tar.gz
++     version: 0.18.0
++   ros2/rosidl_runtime_py:
++-    hash: 614bf2784350d42acb289966570c8c56f164b0a2
++-    shallow_since: 1681228847 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_runtime_py.git
+++    hash: 0d6a82d5f68a204971c81be94a7c0620a237456f1c41c132929894cebe89a340
+++    strip_prefix: rosidl_runtime_py-0.12.0
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_runtime_py/archive/refs/tags/0.12.0.tar.gz
++     version: 0.12.0
++   ros2/rosidl_typesupport:
++-    hash: 7cadef85a4f4e633d8598210ce99d47a3dde52a9
++-    shallow_since: 1689271321 +0800
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport.git
+++    hash: e711d7eb0f10d5f3522c960407304268abfbcc4282ad700fca43eff30465d8b0
+++    strip_prefix: rosidl_typesupport-3.0.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_typesupport/archive/refs/tags/3.0.1.tar.gz
++     version: 3.0.1
++   ros2/rosidl_typesupport_fastrtps:
++-    hash: 5ce3c2a8586305107ad9af9b014340dd6765524b
++-    shallow_since: 1689271552 +0800
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
+++    hash: 9976b2125b14e811ab91b403971b6bf96c0ef511fb53326fb6cfed75a21c5a05
+++    strip_prefix: rosidl_typesupport_fastrtps-3.0.1
+++    type: http_archive
+++    url: https://github.com/ros2/rosidl_typesupport_fastrtps/archive/refs/tags/3.0.1.tar.gz
++     version: 3.0.1
++   ros2/rpyutils:
++-    hash: b2b2d88e256b471494a38f47cd7f8482465572ae
++-    shallow_since: 1676323000 +0000
++-    type: git
++-    url: https://github.com/ros2/rpyutils.git
+++    hash: 0199f411887d8819d5787b30e0a3a0f806d7d6444be385f02bcd296d00aaa30a
+++    strip_prefix: rpyutils-0.3.2
+++    type: http_archive
+++    url: https://github.com/ros2/rpyutils/archive/refs/tags/0.3.2.tar.gz
++     version: 0.3.2
++   ros2/rviz:
++-    hash: 40325f53622e750dc042afc4fad5040cca3bd864
++-    shallow_since: 1694157278 +0800
++-    type: git
++-    url: https://github.com/ros2/rviz.git
+++    hash: cb0bc1bfe1447469d6a57b85a32da11116d0d8f2b642ddf78e3cd5a9409dcec4
+++    strip_prefix: rviz-12.4.4
+++    type: http_archive
+++    url: https://github.com/ros2/rviz/archive/refs/tags/12.4.4.tar.gz
++     version: 12.4.4
++   ros2/spdlog_vendor:
++-    hash: f467d8a0cc77206df37390db904a717e2175ebb8
++-    shallow_since: 1681225577 -0700
++-    type: git
++-    url: https://github.com/ros2/spdlog_vendor.git
+++    hash: e531a692f181a709c748e228a7ece3ee7efefacfb04e35740abd5657ee62303a
+++    strip_prefix: spdlog_vendor-1.4.4
+++    type: http_archive
+++    url: https://github.com/ros2/spdlog_vendor/archive/refs/tags/1.4.4.tar.gz
++     version: 1.4.4
++   ros2/sros2:
++-    hash: 2a48333bc916246acd2409aa447972326cc93529
++-    shallow_since: 1684467056 +0800
++-    type: git
++-    url: https://github.com/ros2/sros2.git
+++    hash: b5810459526f46d377a07a992becf895f3a18bbd5c22bb7c31c74cad13dd0b6e
+++    strip_prefix: sros2-0.11.3
+++    type: http_archive
+++    url: https://github.com/ros2/sros2/archive/refs/tags/0.11.3.tar.gz
++     version: 0.11.3
++   ros2/system_tests:
++-    hash: 20d99d56a0bdfbcd6a327c03606baba40bcce961
++-    shallow_since: 1689272180 +0800
++-    type: git
++-    url: https://github.com/ros2/system_tests.git
+++    hash: 92b749ba5dd629253df0de91714eafc16b3d72322c3f196d0204b222a2a7d462
+++    strip_prefix: system_tests-0.15.2
+++    type: http_archive
+++    url: https://github.com/ros2/system_tests/archive/refs/tags/0.15.2.tar.gz
++     version: 0.15.2
++   ros2/test_interface_files:
++-    hash: 3abbbf68d939cac86e53992b68ee93f9a37fff41
++-    shallow_since: 1676323227 +0000
++-    type: git
++-    url: https://github.com/ros2/test_interface_files.git
+++    hash: 20bfbc6f5ca5d5ceb4a3bbfea0eebb5d0cde7f95d4893f0acbf1f699ce8b0cca
+++    strip_prefix: test_interface_files-0.10.2
+++    type: http_archive
+++    url: https://github.com/ros2/test_interface_files/archive/refs/tags/0.10.2.tar.gz
++     version: 0.10.2
++   ros2/tinyxml2_vendor:
++-    hash: 5ab72a0066240820f82aaaa350e3faba93b224da
++-    shallow_since: 1694159411 +0800
++-    type: git
++-    url: https://github.com/ros2/tinyxml2_vendor.git
+++    hash: 6b0ee498aee3c91def08a39e15d8ba57910ac0e702aedf5e4e1f3b75a86b06a7
+++    strip_prefix: tinyxml2_vendor-0.8.3
+++    type: http_archive
+++    url: https://github.com/ros2/tinyxml2_vendor/archive/refs/tags/0.8.3.tar.gz
++     version: 0.8.3
++   ros2/tinyxml_vendor:
++-    hash: 82db8fdf7d00e9d2ca8947b631a4c1fe6c2681e3
++-    shallow_since: 1676384403 +0000
++-    type: git
++-    url: https://github.com/ros2/tinyxml_vendor.git
+++    hash: 771eecfd2fd0c37f82f735ea520ddc76817c909ee48192ee63dece2e7c74861a
+++    strip_prefix: tinyxml_vendor-0.9.2
+++    type: http_archive
+++    url: https://github.com/ros2/tinyxml_vendor/archive/refs/tags/0.9.2.tar.gz
++     version: 0.9.2
++   ros2/tlsf:
++-    hash: 87d6056c39a6224d166480148c921552a8455f3c
++-    shallow_since: 1676384319 +0000
++-    type: git
++-    url: https://github.com/ros2/tlsf.git
+++    hash: 272004c0f82334f246904be7d9ea92f2328c0d71d79fe5b27e625a4a265363a7
+++    strip_prefix: tlsf-0.8.2
+++    type: http_archive
+++    url: https://github.com/ros2/tlsf/archive/refs/tags/0.8.2.tar.gz
++     version: 0.8.2
++   ros2/unique_identifier_msgs:
++-    hash: 1ced881f07e5d5744d01867b1caedbc13c856195
++-    shallow_since: 1676323080 +0000
++-    type: git
++-    url: https://github.com/ros2/unique_identifier_msgs.git
+++    hash: d2c6f69de9ee41782aee78dcea6aac16e2cebbed66c4740a756043f749c15b52
+++    strip_prefix: unique_identifier_msgs-2.3.2
+++    type: http_archive
+++    url: https://github.com/ros2/unique_identifier_msgs/archive/refs/tags/2.3.2.tar.gz
++     version: 2.3.2
++   ros2/urdf:
++-    hash: a4e593d04a921d8450006432a4c33843419179a2
++-    shallow_since: 1676324735 +0000
++-    type: git
++-    url: https://github.com/ros2/urdf.git
+++    hash: 87b981685016310eb2de8548c5e4717114634a408207a09c3c6043c7d6876d3a
+++    strip_prefix: urdf-2.8.2
+++    type: http_archive
+++    url: https://github.com/ros2/urdf/archive/refs/tags/2.8.2.tar.gz
++     version: 2.8.2
++   ros2/yaml_cpp_vendor:
++-    hash: 1c54425e7a017498b14840d864a6acb237de2afd
++-    shallow_since: 1676322906 +0000
++-    type: git
++-    url: https://github.com/ros2/yaml_cpp_vendor.git
+++    hash: d63d1a8443b89bbd1c7919ab3ed46527d08e6b242ad7d6b850b490c208c64f12
+++    strip_prefix: yaml_cpp_vendor-8.1.2
+++    type: http_archive
+++    url: https://github.com/ros2/yaml_cpp_vendor/archive/refs/tags/8.1.2.tar.gz
++     version: 8.1.2
++-- 
++2.34.1
++
++
++From 9662888392a5c1f3aaa74583d3d306b34892ef1e Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Wed, 27 Sep 2023 21:16:38 -0700
++Subject: [PATCH 09/27] Shorten file names
++
++---
++ .../ament_index_cpp.BUILD}                    |  0
++ .../ament_index_python.BUILD}                 |  0
++ repos/config/bazel.repos                      | 64 +++++++++----------
++ .../root.BUILD}                               |  0
++ .../std_msgs.BUILD}                           |  0
++ .../rcl.BUILD.bazel => ros2.rcl/rcl.BUILD}    |  0
++ .../rcl_yaml_param_parser.BUILD}              |  0
++ .../builtin_interfaces.BUILD}                 |  0
++ .../rcl_interfaces.BUILD}                     |  0
++ .../rosgraph_msgs.BUILD}                      |  0
++ .../statistics_msgs.BUILD}                    |  0
++ .../rcl_logging_interface.BUILD}              |  0
++ .../build_interfaces.py                       |  0
++ .../rclcpp.BUILD}                             |  0
++ .../rcpputils.BUILD}                          |  0
++ .../build_logging_macros.py                   |  0
++ .../root.BUILD}                               |  0
++ .../rmw.BUILD.bazel => ros2.rmw/rmw.BUILD}    |  0
++ .../tracetools.BUILD}                         |  0
++ .../ros2cli.BUILD}                            |  0
++ .../ros2pkg.BUILD}                            |  0
++ .../ros2run.BUILD}                            |  0
++ .../rosidl_adapter.BUILD}                     |  0
++ .../rosidl_cli.BUILD}                         |  0
++ .../rosidl_cmake.BUILD}                       |  0
++ .../rosidl_generator_c.BUILD}                 |  0
++ .../rosidl_generator_cpp.BUILD}               |  0
++ .../rosidl_parser.BUILD}                      |  0
++ .../rosidl_runtime_c.BUILD}                   |  0
++ .../rosidl_runtime_cpp.BUILD}                 |  0
++ .../rosidl_typesupport_interface.BUILD}       |  0
++ .../rosidl_generator_dds_idl.BUILD}           |  0
++ .../rosidl_typesupport_c.BUILD}               |  0
++ 33 files changed, 32 insertions(+), 32 deletions(-)
++ rename repos/{ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel => ament.ament_index/ament_index_cpp.BUILD} (100%)
++ rename repos/{ament.ament_index.BUILD/ament_index_python.BUILD.bazel => ament.ament_index/ament_index_python.BUILD} (100%)
++ rename repos/{ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel => ros-tooling.libstatistics_collector/root.BUILD} (100%)
++ rename repos/{ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel => ros2.common_interfaces/std_msgs.BUILD} (100%)
++ rename repos/{ros2.rcl.BUILD/rcl.BUILD.bazel => ros2.rcl/rcl.BUILD} (100%)
++ rename repos/{ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel => ros2.rcl/rcl_yaml_param_parser.BUILD} (100%)
++ rename repos/{ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel => ros2.rcl_interfaces/builtin_interfaces.BUILD} (100%)
++ rename repos/{ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel => ros2.rcl_interfaces/rcl_interfaces.BUILD} (100%)
++ rename repos/{ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel => ros2.rcl_interfaces/rosgraph_msgs.BUILD} (100%)
++ rename repos/{ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel => ros2.rcl_interfaces/statistics_msgs.BUILD} (100%)
++ rename repos/{ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel => ros2.rcl_logging/rcl_logging_interface.BUILD} (100%)
++ rename repos/{ros2.rclcpp.BUILD => ros2.rclcpp}/build_interfaces.py (100%)
++ rename repos/{ros2.rclcpp.BUILD/rclcpp.BUILD.bazel => ros2.rclcpp/rclcpp.BUILD} (100%)
++ rename repos/{ros2.rcpputils.BUILD/rcpputils.BUILD.bazel => ros2.rcpputils/rcpputils.BUILD} (100%)
++ rename repos/{ros2.rcutils.BUILD => ros2.rcutils}/build_logging_macros.py (100%)
++ rename repos/{ros2.rcutils.BUILD/root.BUILD.bazel => ros2.rcutils/root.BUILD} (100%)
++ rename repos/{ros2.rmw.BUILD/rmw.BUILD.bazel => ros2.rmw/rmw.BUILD} (100%)
++ rename repos/{ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel => ros2.ros2_tracing/tracetools.BUILD} (100%)
++ rename repos/{ros2.ros2cli.BUILD/ros2cli.BUILD.bazel => ros2.ros2cli/ros2cli.BUILD} (100%)
++ rename repos/{ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel => ros2.ros2cli/ros2pkg.BUILD} (100%)
++ rename repos/{ros2.ros2cli.BUILD/ros2run.BUILD.bazel => ros2.ros2cli/ros2run.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel => ros2.rosidl/rosidl_adapter.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel => ros2.rosidl/rosidl_cli.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel => ros2.rosidl/rosidl_cmake.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel => ros2.rosidl/rosidl_generator_c.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel => ros2.rosidl/rosidl_generator_cpp.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel => ros2.rosidl/rosidl_parser.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel => ros2.rosidl/rosidl_runtime_c.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel => ros2.rosidl/rosidl_runtime_cpp.BUILD} (100%)
++ rename repos/{ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel => ros2.rosidl/rosidl_typesupport_interface.BUILD} (100%)
++ rename repos/{ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel => ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD} (100%)
++ rename repos/{ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel => ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD} (100%)
++
++diff --git a/repos/ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel b/repos/ament.ament_index/ament_index_cpp.BUILD
++similarity index 100%
++rename from repos/ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel
++rename to repos/ament.ament_index/ament_index_cpp.BUILD
++diff --git a/repos/ament.ament_index.BUILD/ament_index_python.BUILD.bazel b/repos/ament.ament_index/ament_index_python.BUILD
++similarity index 100%
++rename from repos/ament.ament_index.BUILD/ament_index_python.BUILD.bazel
++rename to repos/ament.ament_index/ament_index_python.BUILD
++diff --git a/repos/config/bazel.repos b/repos/config/bazel.repos
++index 07350c3..155052b 100644
++--- a/repos/config/bazel.repos
+++++ b/repos/config/bazel.repos
++@@ -3,8 +3,8 @@ repositories:
++ #    bazel: {}
++   ament/ament_index:
++     bazel:
++-      "@rules_ros//repos:ament.ament_index.BUILD/ament_index_cpp.BUILD.bazel": "ament_index_cpp/BUILD.bazel"
++-      "@rules_ros//repos:ament.ament_index.BUILD/ament_index_python.BUILD.bazel": "ament_index_python/BUILD.bazel"
+++      "@rules_ros//repos:ament.ament_index/ament_index_cpp.BUILD": "ament_index_cpp/BUILD.bazel"
+++      "@rules_ros//repos:ament.ament_index/ament_index_python.BUILD": "ament_index_python/BUILD.bazel"
++ #  ament/ament_lint:
++ #    bazel: {}
++ #  ament/ament_package:
++@@ -43,7 +43,7 @@ repositories:
++ #    bazel: {}
++   ros-tooling/libstatistics_collector:
++     bazel:
++-      "@rules_ros//repos:ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel": "BUILD.bazel"
+++      "@rules_ros//repos:ros-tooling.libstatistics_collector/root.BUILD": "BUILD.bazel"
++ #  ros-visualization/interactive_markers:
++ #    bazel: {}
++ #  ros-visualization/python_qt_binding:
++@@ -102,7 +102,7 @@ repositories:
++ #    bazel: {}
++   ros2/common_interfaces:
++     bazel:
++-      "@rules_ros//repos:ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel": "std_msgs/BUILD.bazel"
+++      "@rules_ros//repos:ros2.common_interfaces/std_msgs.BUILD": "std_msgs/BUILD.bazel"
++ #  ros2/console_bridge_vendor:
++ #    bazel: {}
++ #  ros2/demos:
++@@ -135,35 +135,35 @@ repositories:
++ #    bazel: {}
++   ros2/rcl:
++     bazel:
++-      "@rules_ros//repos:ros2.rcl.BUILD/rcl.BUILD.bazel": "rcl/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel": "rcl_yaml_param_parser/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl/rcl.BUILD": "rcl/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl/rcl_yaml_param_parser.BUILD": "rcl_yaml_param_parser/BUILD.bazel"
++   ros2/rcl_interfaces:
++     bazel:
++-      "@rules_ros//repos:ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel": "rcl_interfaces/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel": "rosgraph_msgs/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel": "builtin_interfaces/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel": "statistics_msgs/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl_interfaces/rcl_interfaces.BUILD": "rcl_interfaces/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl_interfaces/rosgraph_msgs.BUILD": "rosgraph_msgs/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl_interfaces/builtin_interfaces.BUILD": "builtin_interfaces/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl_interfaces/statistics_msgs.BUILD": "statistics_msgs/BUILD.bazel"
++   ros2/rcl_logging:
++     bazel:
++-      "@rules_ros//repos:ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel": "rcl_logging_interface/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcl_logging/rcl_logging_interface.BUILD": "rcl_logging_interface/BUILD.bazel"
++   ros2/rclcpp:
++     bazel:
++-      "@rules_ros//repos:ros2.rclcpp.BUILD/build_interfaces.py": "rclcpp/build_interfaces.py"
++-      "@rules_ros//repos:ros2.rclcpp.BUILD/rclcpp.BUILD.bazel": "rclcpp/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rclcpp/build_interfaces.py": "rclcpp/build_interfaces.py"
+++      "@rules_ros//repos:ros2.rclcpp/rclcpp.BUILD": "rclcpp/BUILD.bazel"
++ #  ros2/rclpy:
++ #    bazel: {}
++   ros2/rcpputils:
++     bazel:
++-      "@rules_ros//repos:ros2.rcpputils.BUILD/rcpputils.BUILD.bazel": "BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcpputils/rcpputils.BUILD": "BUILD.bazel"
++   ros2/rcutils:
++     bazel:
++-      "@rules_ros//repos:ros2.rcutils.BUILD/root.BUILD.bazel": "BUILD.bazel"
++-      "@rules_ros//repos:ros2.rcutils.BUILD/build_logging_macros.py": "build_logging_macros.py"
+++      "@rules_ros//repos:ros2.rcutils/root.BUILD": "BUILD.bazel"
+++      "@rules_ros//repos:ros2.rcutils/build_logging_macros.py": "build_logging_macros.py"
++ #  ros2/realtime_support:
++ #    bazel: {}
++   ros2/rmw:
++     bazel:
++-      "@rules_ros//repos:ros2.rmw.BUILD/rmw.BUILD.bazel": "rmw/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rmw/rmw.BUILD": "rmw/BUILD.bazel"
++ #  ros2/rmw_connextdds:
++ #    bazel: {}
++ #  ros2/rmw_cyclonedds:
++@@ -176,12 +176,12 @@ repositories:
++ #    bazel: {}
++   ros2/ros2_tracing:
++     bazel:
++-        "@rules_ros//repos:ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel": "tracetools/BUILD.bazel"
+++        "@rules_ros//repos:ros2.ros2_tracing/tracetools.BUILD": "tracetools/BUILD.bazel"
++   ros2/ros2cli:
++     bazel:
++-        "@rules_ros//repos:ros2.ros2cli.BUILD/ros2cli.BUILD.bazel": "ros2cli/BUILD.bazel"
++-        "@rules_ros//repos:ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel": "ros2pkg/BUILD.bazel"
++-        "@rules_ros//repos:ros2.ros2cli.BUILD/ros2run.BUILD.bazel": "ros2run/BUILD.bazel"
+++        "@rules_ros//repos:ros2.ros2cli/ros2cli.BUILD": "ros2cli/BUILD.bazel"
+++        "@rules_ros//repos:ros2.ros2cli/ros2pkg.BUILD": "ros2pkg/BUILD.bazel"
+++        "@rules_ros//repos:ros2.ros2cli/ros2run.BUILD": "ros2run/BUILD.bazel"
++ #  ros2/ros2cli_common_extensions:
++ #    bazel: {}
++ #  ros2/ros_testing:
++@@ -190,18 +190,18 @@ repositories:
++ #    bazel: {}
++   ros2/rosidl:
++     bazel:
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel": "rosidl_runtime_c/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel": "rosidl_runtime_cpp/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel": "rosidl_adapter/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel": "rosidl_cli/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel": "rosidl_parser/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel": "rosidl_cmake/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel": "rosidl_typesupport_interface/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel": "rosidl_generator_c/BUILD.bazel"
++-      "@rules_ros//repos:ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel": "rosidl_generator_cpp/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_runtime_c.BUILD": "rosidl_runtime_c/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_runtime_cpp.BUILD": "rosidl_runtime_cpp/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_adapter.BUILD": "rosidl_adapter/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_cli.BUILD": "rosidl_cli/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_parser.BUILD": "rosidl_parser/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_cmake.BUILD": "rosidl_cmake/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_typesupport_interface.BUILD": "rosidl_typesupport_interface/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_generator_c.BUILD": "rosidl_generator_c/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl/rosidl_generator_cpp.BUILD": "rosidl_generator_cpp/BUILD.bazel"
++   ros2/rosidl_dds:
++     bazel:
++-      "@rules_ros//repos:ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel": "rosidl_generator_dds_idl/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD": "rosidl_generator_dds_idl/BUILD.bazel"
++ #  ros2/rosidl_defaults:
++ #    bazel: {}
++ #  ros2/rosidl_python:
++@@ -210,7 +210,7 @@ repositories:
++ #    bazel: {}
++   ros2/rosidl_typesupport:
++     bazel:
++-      "@rules_ros//repos:ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel": "rosidl_typesupport_c/BUILD.bazel"
+++      "@rules_ros//repos:ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD": "rosidl_typesupport_c/BUILD.bazel"
++ #  ros2/rosidl_typesupport_fastrtps:
++ #    bazel: {}
++ #  ros2/rpyutils:
++diff --git a/repos/ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel b/repos/ros-tooling.libstatistics_collector/root.BUILD
++similarity index 100%
++rename from repos/ros-tooling.libstatistics_collector.BUILD/root.BUILD.bazel
++rename to repos/ros-tooling.libstatistics_collector/root.BUILD
++diff --git a/repos/ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel b/repos/ros2.common_interfaces/std_msgs.BUILD
++similarity index 100%
++rename from repos/ros2.common_interfaces.BUILD/std_msgs.BUILD.bazel
++rename to repos/ros2.common_interfaces/std_msgs.BUILD
++diff --git a/repos/ros2.rcl.BUILD/rcl.BUILD.bazel b/repos/ros2.rcl/rcl.BUILD
++similarity index 100%
++rename from repos/ros2.rcl.BUILD/rcl.BUILD.bazel
++rename to repos/ros2.rcl/rcl.BUILD
++diff --git a/repos/ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel b/repos/ros2.rcl/rcl_yaml_param_parser.BUILD
++similarity index 100%
++rename from repos/ros2.rcl.BUILD/rcl_yaml_param_parser.BUILD.bazel
++rename to repos/ros2.rcl/rcl_yaml_param_parser.BUILD
++diff --git a/repos/ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel b/repos/ros2.rcl_interfaces/builtin_interfaces.BUILD
++similarity index 100%
++rename from repos/ros2.rcl_interfaces.BUILD/builtin_interfaces.BUILD.bazel
++rename to repos/ros2.rcl_interfaces/builtin_interfaces.BUILD
++diff --git a/repos/ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel b/repos/ros2.rcl_interfaces/rcl_interfaces.BUILD
++similarity index 100%
++rename from repos/ros2.rcl_interfaces.BUILD/rcl_interfaces.BUILD.bazel
++rename to repos/ros2.rcl_interfaces/rcl_interfaces.BUILD
++diff --git a/repos/ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel b/repos/ros2.rcl_interfaces/rosgraph_msgs.BUILD
++similarity index 100%
++rename from repos/ros2.rcl_interfaces.BUILD/rosgraph_msgs.BUILD.bazel
++rename to repos/ros2.rcl_interfaces/rosgraph_msgs.BUILD
++diff --git a/repos/ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel b/repos/ros2.rcl_interfaces/statistics_msgs.BUILD
++similarity index 100%
++rename from repos/ros2.rcl_interfaces.BUILD/statistics_msgs.BUILD.bazel
++rename to repos/ros2.rcl_interfaces/statistics_msgs.BUILD
++diff --git a/repos/ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel b/repos/ros2.rcl_logging/rcl_logging_interface.BUILD
++similarity index 100%
++rename from repos/ros2.rcl_logging.BUILD/rcl_logging_interface.BUILD.bazel
++rename to repos/ros2.rcl_logging/rcl_logging_interface.BUILD
++diff --git a/repos/ros2.rclcpp.BUILD/build_interfaces.py b/repos/ros2.rclcpp/build_interfaces.py
++similarity index 100%
++rename from repos/ros2.rclcpp.BUILD/build_interfaces.py
++rename to repos/ros2.rclcpp/build_interfaces.py
++diff --git a/repos/ros2.rclcpp.BUILD/rclcpp.BUILD.bazel b/repos/ros2.rclcpp/rclcpp.BUILD
++similarity index 100%
++rename from repos/ros2.rclcpp.BUILD/rclcpp.BUILD.bazel
++rename to repos/ros2.rclcpp/rclcpp.BUILD
++diff --git a/repos/ros2.rcpputils.BUILD/rcpputils.BUILD.bazel b/repos/ros2.rcpputils/rcpputils.BUILD
++similarity index 100%
++rename from repos/ros2.rcpputils.BUILD/rcpputils.BUILD.bazel
++rename to repos/ros2.rcpputils/rcpputils.BUILD
++diff --git a/repos/ros2.rcutils.BUILD/build_logging_macros.py b/repos/ros2.rcutils/build_logging_macros.py
++similarity index 100%
++rename from repos/ros2.rcutils.BUILD/build_logging_macros.py
++rename to repos/ros2.rcutils/build_logging_macros.py
++diff --git a/repos/ros2.rcutils.BUILD/root.BUILD.bazel b/repos/ros2.rcutils/root.BUILD
++similarity index 100%
++rename from repos/ros2.rcutils.BUILD/root.BUILD.bazel
++rename to repos/ros2.rcutils/root.BUILD
++diff --git a/repos/ros2.rmw.BUILD/rmw.BUILD.bazel b/repos/ros2.rmw/rmw.BUILD
++similarity index 100%
++rename from repos/ros2.rmw.BUILD/rmw.BUILD.bazel
++rename to repos/ros2.rmw/rmw.BUILD
++diff --git a/repos/ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel b/repos/ros2.ros2_tracing/tracetools.BUILD
++similarity index 100%
++rename from repos/ros2.ros2_tracing.BUILD/tracetools.BUILD.bazel
++rename to repos/ros2.ros2_tracing/tracetools.BUILD
++diff --git a/repos/ros2.ros2cli.BUILD/ros2cli.BUILD.bazel b/repos/ros2.ros2cli/ros2cli.BUILD
++similarity index 100%
++rename from repos/ros2.ros2cli.BUILD/ros2cli.BUILD.bazel
++rename to repos/ros2.ros2cli/ros2cli.BUILD
++diff --git a/repos/ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel b/repos/ros2.ros2cli/ros2pkg.BUILD
++similarity index 100%
++rename from repos/ros2.ros2cli.BUILD/ros2pkg.BUILD.bazel
++rename to repos/ros2.ros2cli/ros2pkg.BUILD
++diff --git a/repos/ros2.ros2cli.BUILD/ros2run.BUILD.bazel b/repos/ros2.ros2cli/ros2run.BUILD
++similarity index 100%
++rename from repos/ros2.ros2cli.BUILD/ros2run.BUILD.bazel
++rename to repos/ros2.ros2cli/ros2run.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel b/repos/ros2.rosidl/rosidl_adapter.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_adapter.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_adapter.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel b/repos/ros2.rosidl/rosidl_cli.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_cli.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_cli.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel b/repos/ros2.rosidl/rosidl_cmake.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_cmake.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_cmake.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel b/repos/ros2.rosidl/rosidl_generator_c.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_generator_c.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_generator_c.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel b/repos/ros2.rosidl/rosidl_generator_cpp.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_generator_cpp.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_generator_cpp.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel b/repos/ros2.rosidl/rosidl_parser.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_parser.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_parser.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel b/repos/ros2.rosidl/rosidl_runtime_c.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_runtime_c.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_runtime_c.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel b/repos/ros2.rosidl/rosidl_runtime_cpp.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_runtime_cpp.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_runtime_cpp.BUILD
++diff --git a/repos/ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel b/repos/ros2.rosidl/rosidl_typesupport_interface.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl.BUILD/rosidl_typesupport_interface.BUILD.bazel
++rename to repos/ros2.rosidl/rosidl_typesupport_interface.BUILD
++diff --git a/repos/ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel b/repos/ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl_dds.BUILD/rosidl_generator_dds_idl.BUILD.bazel
++rename to repos/ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD
++diff --git a/repos/ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel b/repos/ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD
++similarity index 100%
++rename from repos/ros2.rosidl_typesupport.BUILD/rosidl_typesupport_c.BUILD.bazel
++rename to repos/ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD
++-- 
++2.34.1
++
++
++From 3a203e5ab02276352e1737ebda5a4a1ff026b8bb Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Fri, 29 Sep 2023 12:03:16 -0700
++Subject: [PATCH 10/27] Review findings
++
++Review findings
++---
++ repos/config/detail/git_repository.bzl       | 13 +++++++------
++ repos/config/detail/http_archive.bzl         |  8 +++++---
++ repos/config/detail/lock_repos.py            |  4 +++-
++ repos/config/detail/new_local_repository.bzl |  7 ++++---
++ repos/config/distros.bzl                     |  9 ---------
++ repos/config/ros2_humble.lock                |  4 ++--
++ 6 files changed, 21 insertions(+), 24 deletions(-)
++
++diff --git a/repos/config/detail/git_repository.bzl b/repos/config/detail/git_repository.bzl
++index 2eb1e84..62adc7a 100644
++--- a/repos/config/detail/git_repository.bzl
+++++ b/repos/config/detail/git_repository.bzl
++@@ -28,11 +28,13 @@ _archive_attrs = {
++     ),
++     "shallow_since": attr.string(
++         doc =
++-            "Time of required commit."
+++            "Time of required commit.",
++     ),
++     "build_files": attr.label_keyed_string_dict(
++-        doc =
++-            "Same as in native rule.",
+++        doc = """
+++            Dict with a file as key and the path where to place the file in the repository as value.
+++            This allows to place multiple (BUILD) files in a repo.
+++        """,
++     ),
++ }
++ 
++@@ -50,9 +52,9 @@ def _git_clone(ctx):
++         ".",
++         "--branch",
++         ctx.attr.branch,
++-        "--shallow-since="+ctx.attr.shallow_since,
+++        "--shallow-since=" + ctx.attr.shallow_since,
++     ])
++-    _execute_or_fail( ctx, [
+++    _execute_or_fail(ctx, [
++         "git",
++         "checkout",
++         ctx.attr.commit,
++@@ -94,4 +96,3 @@ git_repository = repository_rule(
++         It allows to inject multiple BUILD files.
++         """,
++ )
++-
++diff --git a/repos/config/detail/http_archive.bzl b/repos/config/detail/http_archive.bzl
++index e34d594..78daa85 100644
++--- a/repos/config/detail/http_archive.bzl
+++++ b/repos/config/detail/http_archive.bzl
++@@ -27,8 +27,10 @@ _archive_attrs = {
++             "Hash of the commit to be checked out.",
++     ),
++     "build_files": attr.label_keyed_string_dict(
++-        doc =
++-            "Same as in native rule.",
+++        doc = """
+++            Dict with a file as key and the path where to place the file in the repository as value.
+++            This allows to place multiple (BUILD) files in a repo.
+++        """,
++     ),
++ }
++ 
++@@ -74,7 +76,7 @@ http_archive = repository_rule(
++     implementation = _http_archve_impl,
++     attrs = _archive_attrs,
++     doc =
++-        """Custom rule to clone a git repo as external dependency.
+++        """Custom rule to use a compressed tarball for creating an external workspace.
++         It allows to inject multiple BUILD files.
++         """,
++ )
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index b2804ff..70b6c60 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -42,9 +42,11 @@ def main():
++     for repo, spec in repos["repositories"].items():
++         if not spec["type"] in REPO_TYPES:
++             raise ValueError(f"Repo type {spec['type']} not supported. Need one of {REPO_TYPES} instead.")
++-        if args.tar == True:
+++        if args.tar:
+++            # use tarballs
++             additional_attributes = fetch_archive_details(spec['url'], spec['version'])
++         else:
+++            # default: use git repositories
++             additional_attributes = fetch_repo_details(spec['url'], spec['version'])
++         add_attributes(repos["repositories"][repo], additional_attributes)
++         print("{}: {}".format(repo, [*additional_attributes.values()]))
++diff --git a/repos/config/detail/new_local_repository.bzl b/repos/config/detail/new_local_repository.bzl
++index 3ccb254..164bf6f 100644
++--- a/repos/config/detail/new_local_repository.bzl
+++++ b/repos/config/detail/new_local_repository.bzl
++@@ -19,8 +19,10 @@ _archive_attrs = {
++         doc = "Path to the repository.",
++     ),
++     "build_files": attr.label_keyed_string_dict(
++-        doc =
++-            "Same as in native rule.",
+++        doc = """
+++            Dict with a file as key and the path where to place the file in the repository as value.
+++            This allows to place multiple (BUILD) files in a repo.
+++        """,
++     ),
++ }
++ 
++@@ -74,4 +76,3 @@ new_local_repository = repository_rule(
++         It allows to inject multiple BUILD files.
++         """,
++ )
++-
++diff --git a/repos/config/distros.bzl b/repos/config/distros.bzl
++index 78084e4..0ae4260 100644
++--- a/repos/config/distros.bzl
+++++ b/repos/config/distros.bzl
++@@ -24,13 +24,4 @@ DISTROS = {
++         repo_index = "@rules_ros//repos/config:ros2_{}.lock".format(distro),
++     )
++     for distro, date, sha in _VERSIONS
++-} | {
++-    "rolling": dict(
++-        repo_rule = new_git_repository,
++-        remote = ROS_PROJECT,
++-        build_file_content = 'exports_files(["ros2.repos"])',
++-        commit = "1f5bd8ed43beea199dabe48bc8023af3aba9806c",
++-        #shallow_since = "1660330451 -0400",
++-        repo_index = "@rules_ros//repos/config:ros2_iron.lock",
++-    ),
++ }
++diff --git a/repos/config/ros2_humble.lock b/repos/config/ros2_humble.lock
++index 2d9fe17..673ad8e 100644
++--- a/repos/config/ros2_humble.lock
+++++ b/repos/config/ros2_humble.lock
++@@ -76,13 +76,13 @@ repositories:
++     version: v2.0.3
++   ignition/ignition_cmake2_vendor:
++     hash: 5b13472e33db9c9bb631b037d1c6b0ccedfcf5e38e16157024cc641215a43b32
++-    strip_prefix: ignition_cmake2_vendor-0.0.2
+++    strip_prefix: gz_cmake2_vendor-0.0.2
++     type: http_archive
++     url: https://github.com/ignition-release/ignition_cmake2_vendor/archive/refs/tags/0.0.2.tar.gz
++     version: 0.0.2
++   ignition/ignition_math6_vendor:
++     hash: d357a43e8265db9a9e886b01ca53cc9692c81b7e9f7d99abc99df982efd5a1be
++-    strip_prefix: ignition_math6_vendor-0.0.2
+++    strip_prefix: gz_math6_vendor-0.0.2
++     type: http_archive
++     url: https://github.com/ignition-release/ignition_math6_vendor/archive/refs/tags/0.0.2.tar.gz
++     version: 0.0.2
++-- 
++2.34.1
++
++
++From e3c5a87ede97b609db977530738c871bea186005 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Mon, 2 Oct 2023 21:07:31 -0700
++Subject: [PATCH 11/27] Add basic Bazel build/test CI matrix for Ubuntu
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ .github/workflows/build_test.yml | 40 ++++++++++++++++++++++++++++++++
++ 1 file changed, 40 insertions(+)
++ create mode 100644 .github/workflows/build_test.yml
++
++diff --git a/.github/workflows/build_test.yml b/.github/workflows/build_test.yml
++new file mode 100644
++index 0000000..94f93b2
++--- /dev/null
+++++ b/.github/workflows/build_test.yml
++@@ -0,0 +1,40 @@
+++name: Build/Test
+++
+++on:
+++  push:
+++    branches:
+++      - main
+++    tags:
+++      - "**"
+++  pull_request:
+++    branches:
+++      - main
+++  workflow_dispatch:
+++
+++# only run one build doc workflow at a time, cancel any running ones
+++concurrency: 
+++  group: ${{ github.workflow }}-${{ github.ref }}
+++  cancel-in-progress: true
+++
+++jobs:
+++  build_test:
+++    strategy:
+++      matrix:
+++        os:
+++          - ubuntu
+++        version:
+++          - 18.04
+++          - 20.04
+++          - 22.04
+++    runs-on: ${{ matrix.os }}-${{ matrix.version }}
+++    steps:
+++      - uses: actions/checkout@v3
+++      - name: Specify the Bazel cache
+++        uses: actions/cache@v3
+++        with:
+++          path: "/home/runner/.cache/bazel"
+++          key: ${{ hashFiles('.bazelrc', '.bazelversion', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
+++      - name: Build
+++        run: bazel build //...
+++      - name: Test
+++        run: bazel test //...
++-- 
++2.34.1
++
++
++From e392c65769b3eee304d2312d84cf95ffc05523eb Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Tue, 3 Oct 2023 13:47:18 -0700
++Subject: [PATCH 12/27] Use default BUILD files
++
++---
++ repos/config/bazel.repos | 15 ++++++++++-----
++ repos/default.BUILD      |  1 +
++ 2 files changed, 11 insertions(+), 5 deletions(-)
++ create mode 100644 repos/default.BUILD
++
++diff --git a/repos/config/bazel.repos b/repos/config/bazel.repos
++index 155052b..a0ac079 100644
++--- a/repos/config/bazel.repos
+++++ b/repos/config/bazel.repos
++@@ -16,15 +16,20 @@ repositories:
++ #  ament/uncrustify_vendor:
++ #    bazel: {}
++   eProsima/Fast-CDR:
++-    bazel: {}
+++    bazel:
+++      "@rules_ros//repos:default.BUILD": "BUILD.bazel"
++   eProsima/Fast-DDS:
++-    bazel: {}
+++    bazel:
+++      "@rules_ros//repos:default.BUILD": "BUILD.bazel"
++   eProsima/foonathan_memory_vendor:
++-    bazel: {}
+++    bazel:
+++      "@rules_ros//repos:default.BUILD": "BUILD.bazel"
++   eclipse-cyclonedds/cyclonedds:
++-    bazel: {}
+++    bazel:
+++      "@rules_ros//repos:default.BUILD": "BUILD.bazel"
++   eclipse-iceoryx/iceoryx:
++-    bazel: {}
+++    bazel:
+++      "@rules_ros//repos:default.BUILD": "BUILD.bazel"
++ #  ignition/ignition_cmake2_vendor:
++ #    bazel: {}
++ #  ignition/ignition_math6_vendor:
++diff --git a/repos/default.BUILD b/repos/default.BUILD
++new file mode 100644
++index 0000000..ccc23ed
++--- /dev/null
+++++ b/repos/default.BUILD
++@@ -0,0 +1 @@
+++exports_files(glob(["**/*"]))
++-- 
++2.34.1
++
++
++From f95d35be4d5f330d6c4be0e06f497e7adf7955c9 Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Tue, 3 Oct 2023 13:47:35 -0700
++Subject: [PATCH 13/27] Fix ament_index dependencies
++
++---
++ .../ament.ament_index/ament_index_python.BUILD  | 17 ++++++++++-------
++ 1 file changed, 10 insertions(+), 7 deletions(-)
++
++diff --git a/repos/ament.ament_index/ament_index_python.BUILD b/repos/ament.ament_index/ament_index_python.BUILD
++index e0f23cf..fb92bd9 100644
++--- a/repos/ament.ament_index/ament_index_python.BUILD
+++++ b/repos/ament.ament_index/ament_index_python.BUILD
++@@ -15,6 +15,7 @@
++ load("@rules_python//python:packaging.bzl", "py_wheel")
++ load("@rules_python//python:python.bzl", "py_test")
++ load("@rules_ros//pkg:defs.bzl", "ros_pkg")
+++load("@python_deps//:requirements.bzl", "requirement")
++ 
++ py_library(
++     name = "ament_index_python_py",
++@@ -28,6 +29,8 @@ py_test(
++     main = "test/test_ament_index_python.py",
++     deps = [
++         ":ament_index_python_py",
+++        requirement("attrs"),
+++        requirement("pluggy"),
++     ],
++ )
++ 
++@@ -49,21 +52,21 @@ py_wheel(
++     # download_url='https://github.com/ros2/ros2cli/releases',
++     # keywords=[],
++     classifiers = [
++-        'Intended Audience :: Developers',
++-        'License :: OSI Approved :: Apache Software License',
++-        'Programming Language :: Python',
++-        'Topic :: Software Development',
+++        "Intended Audience :: Developers",
+++        "License :: OSI Approved :: Apache Software License",
+++        "Programming Language :: Python",
+++        "Topic :: Software Development",
++     ],
++     #description_file = "README.md",
++     distribution = "ament_index_python",
++     #tests_require=['pytest'],
++     license = "Apache License, Version 2.0",
++     strip_path_prefixes = ["ament_index_python"],
++-    version = '0.8.6',
+++    version = "0.8.6",
++     deps = [":ament_index_python_py"],
++     entry_points = {
++-        'console_scripts': [
++-            'ament_index = ament_index_python.cli:main',
+++        "console_scripts": [
+++            "ament_index = ament_index_python.cli:main",
++         ],
++     },
++ )
++-- 
++2.34.1
++
++
++From 1be92a19ee4d493fa3bc3c8a89aff5ddefbb6278 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Tue, 3 Oct 2023 13:58:27 -0700
++Subject: [PATCH 14/27] Temp build command for CI job until rosidl logic is
++ fixed
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ .github/workflows/build_test.yml | 14 +++++++++++---
++ 1 file changed, 11 insertions(+), 3 deletions(-)
++
++diff --git a/.github/workflows/build_test.yml b/.github/workflows/build_test.yml
++index 94f93b2..0e5327d 100644
++--- a/.github/workflows/build_test.yml
+++++ b/.github/workflows/build_test.yml
++@@ -23,7 +23,6 @@ jobs:
++         os:
++           - ubuntu
++         version:
++-          - 18.04
++           - 20.04
++           - 22.04
++     runs-on: ${{ matrix.os }}-${{ matrix.version }}
++@@ -35,6 +34,15 @@ jobs:
++           path: "/home/runner/.cache/bazel"
++           key: ${{ hashFiles('.bazelrc', '.bazelversion', 'WORKSPACE', 'WORKSPACE.bazel', 'MODULE.bazel') }}
++       - name: Build
++-        run: bazel build //...
+++        # TODO(evan.flynn): uncomment once the rules are properly fixed
+++        # run: bazel build //...
+++        run: bazel build -- $(cat repos/config/bazel.repos | sed -e '/^[#r]/d' -e '/^    /d' -e 's%/%.%' -e 's%  \(.*\):%@\1//...%' -e '/@ros2.rosidl/d' -e '/@ros2.rcl_interfaces/d' -e '/@ros2.common_interfaces/d')
++       - name: Test
++-        run: bazel test //...
+++        run: bazel test -- $(cat repos/config/bazel.repos | sed -e '/^[#r]/d' -e '/^    /d' -e 's%/%.%' -e 's%  \(.*\):%@\1//...%' -e '/@ros2.rosidl/d' -e '/@ros2.rcl_interfaces/d' -e '/@ros2.common_interfaces/d')
+++      - name: Store the bazel-testlogs
+++        uses: actions/upload-artifact@v3
+++        if: always()
+++        with:
+++          name: bazel-testlogs
+++          path: bazel-testlogs
+++          retention-days: 5
++\ No newline at end of file
++-- 
++2.34.1
++
++
++From 2a2e7265ceb0b818b4d11ee0dfe835399f7a2367 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Tue, 3 Oct 2023 16:37:01 -0700
++Subject: [PATCH 15/27] Add pytest as requirement for ament_index_python test
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ repos/ament.ament_index/ament_index_python.BUILD | 1 +
++ 1 file changed, 1 insertion(+)
++
++diff --git a/repos/ament.ament_index/ament_index_python.BUILD b/repos/ament.ament_index/ament_index_python.BUILD
++index fb92bd9..f18e018 100644
++--- a/repos/ament.ament_index/ament_index_python.BUILD
+++++ b/repos/ament.ament_index/ament_index_python.BUILD
++@@ -31,6 +31,7 @@ py_test(
++         ":ament_index_python_py",
++         requirement("attrs"),
++         requirement("pluggy"),
+++        requirement("pytest"),
++     ],
++ )
++ 
++-- 
++2.34.1
++
++
++From 077d57958fac7a4cb7c60580965717d1dc5944c6 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Tue, 3 Oct 2023 16:42:07 -0700
++Subject: [PATCH 16/27] Use os and version variables in artifact names
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ .github/workflows/build_test.yml | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/.github/workflows/build_test.yml b/.github/workflows/build_test.yml
++index 0e5327d..b562933 100644
++--- a/.github/workflows/build_test.yml
+++++ b/.github/workflows/build_test.yml
++@@ -43,6 +43,6 @@ jobs:
++         uses: actions/upload-artifact@v3
++         if: always()
++         with:
++-          name: bazel-testlogs
+++          name: ${{ matrix.os }}-${{ matrix.version }}-bazel-testlogs
++           path: bazel-testlogs
++           retention-days: 5
++\ No newline at end of file
++-- 
++2.34.1
++
++
++From d6d083cdd09c46127ff45cc312c8cfbd17fc1480 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Mon, 15 Jul 2024 12:44:59 -0700
++Subject: [PATCH 17/27] Update copyright year to this year 24
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ WORKSPACE                                                  | 2 +-
++ examples/BUILD.bazel                                       | 2 +-
++ examples/bazel_simple_example/BUILD                        | 2 +-
++ examples/bazel_simple_example/publisher.cpp                | 2 +-
++ examples/bazel_simple_example/subscriber.cpp               | 2 +-
++ examples/hello_world/BUILD.bazel                           | 2 +-
++ pkg/defs.bzl                                               | 2 +-
++ pkg/detail/BUILD                                           | 2 +-
++ pkg/detail/executable_wrapper_generator.py                 | 2 +-
++ pkg/detail/package_xml_generator.py                        | 2 +-
++ pkg/detail/ros_archive.bzl                                 | 2 +-
++ pkg/detail/ros_pkg.bzl                                     | 2 +-
++ pkg/detail/setup_bash_generator.py                         | 2 +-
++ pkg/detail/templates/install.template                      | 2 +-
++ pkg/detail/utils.bzl                                       | 2 +-
++ pkg/providers.bzl                                          | 2 +-
++ repos/ament.ament_index/ament_index_cpp.BUILD              | 2 +-
++ repos/ament.ament_index/ament_index_python.BUILD           | 2 +-
++ repos/config/BUILD.bazel                                   | 2 +-
++ repos/config/defs.bzl                                      | 2 +-
++ repos/config/detail/BUILD.bazel                            | 2 +-
++ repos/config/detail/generate_ros2_config.py                | 2 +-
++ repos/config/detail/git_repository.bzl                     | 2 +-
++ repos/config/detail/http_archive.bzl                       | 2 +-
++ repos/config/detail/lock_repos.py                          | 2 +-
++ repos/config/detail/new_local_repository.bzl               | 2 +-
++ repos/config/detail/ros2_config.bzl                        | 2 +-
++ repos/ros-tooling.libstatistics_collector/root.BUILD       | 2 +-
++ repos/ros2.common_interfaces/std_msgs.BUILD                | 2 +-
++ repos/ros2.rcl/rcl.BUILD                                   | 2 +-
++ repos/ros2.rcl/rcl_yaml_param_parser.BUILD                 | 2 +-
++ repos/ros2.rcl_interfaces/builtin_interfaces.BUILD         | 2 +-
++ repos/ros2.rcl_interfaces/rcl_interfaces.BUILD             | 2 +-
++ repos/ros2.rcl_interfaces/rosgraph_msgs.BUILD              | 2 +-
++ repos/ros2.rcl_interfaces/statistics_msgs.BUILD            | 2 +-
++ repos/ros2.rcl_logging/rcl_logging_interface.BUILD         | 2 +-
++ repos/ros2.rclcpp/build_interfaces.py                      | 2 +-
++ repos/ros2.rclcpp/rclcpp.BUILD                             | 2 +-
++ repos/ros2.rcpputils/rcpputils.BUILD                       | 2 +-
++ repos/ros2.rcutils/build_logging_macros.py                 | 2 +-
++ repos/ros2.rcutils/root.BUILD                              | 2 +-
++ repos/ros2.rmw/rmw.BUILD                                   | 2 +-
++ repos/ros2.ros2_tracing/tracetools.BUILD                   | 2 +-
++ repos/ros2.ros2cli/ros2cli.BUILD                           | 2 +-
++ repos/ros2.ros2cli/ros2pkg.BUILD                           | 2 +-
++ repos/ros2.ros2cli/ros2run.BUILD                           | 2 +-
++ repos/ros2.rosidl/rosidl_adapter.BUILD                     | 2 +-
++ repos/ros2.rosidl/rosidl_cli.BUILD                         | 2 +-
++ repos/ros2.rosidl/rosidl_cmake.BUILD                       | 2 +-
++ repos/ros2.rosidl/rosidl_generator_c.BUILD                 | 2 +-
++ repos/ros2.rosidl/rosidl_generator_cpp.BUILD               | 2 +-
++ repos/ros2.rosidl/rosidl_parser.BUILD                      | 2 +-
++ repos/ros2.rosidl/rosidl_runtime_c.BUILD                   | 2 +-
++ repos/ros2.rosidl/rosidl_runtime_cpp.BUILD                 | 2 +-
++ repos/ros2.rosidl/rosidl_typesupport_interface.BUILD       | 2 +-
++ repos/ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD       | 2 +-
++ repos/ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD   | 2 +-
++ rosidl/defs.bzl                                            | 2 +-
++ rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl | 2 +-
++ rosidl/detail/cc_library_with_msgs_provider.bzl            | 2 +-
++ rosidl/detail/common_config.bzl                            | 2 +-
++ rosidl/detail/misc_support.bzl                             | 2 +-
++ rosidl/detail/rosidl_adapter.bzl                           | 2 +-
++ rosidl/detail/rosidl_generator_c.bzl                       | 2 +-
++ rosidl/detail/rosidl_generator_cpp.bzl                     | 2 +-
++ rosidl/detail/rosidl_generator_dds_idl.bzl                 | 2 +-
++ rosidl/detail/rosidl_typesupport_c.bzl                     | 2 +-
++ rosidl/detail/visiability_control.bzl                      | 2 +-
++ rosidl/providers.bzl                                       | 2 +-
++ thirdparty/bazel_skylib/repositories.bzl                   | 2 +-
++ thirdparty/bazel_skylib/setup.bzl                          | 2 +-
++ thirdparty/libyaml/libyaml.BUILD.bazel                     | 2 +-
++ thirdparty/libyaml/repositories.bzl                        | 2 +-
++ thirdparty/python/repositories.bzl                         | 2 +-
++ thirdparty/setup_01.bzl                                    | 2 +-
++ thirdparty/setup_02.bzl                                    | 2 +-
++ thirdparty/setup_03.bzl                                    | 2 +-
++ thirdparty/setup_04.bzl                                    | 2 +-
++ utils/template_expansion.bzl                               | 2 +-
++ 79 files changed, 79 insertions(+), 79 deletions(-)
++
++diff --git a/WORKSPACE b/WORKSPACE
++index a9159b5..61747a4 100644
++--- a/WORKSPACE
+++++ b/WORKSPACE
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/examples/BUILD.bazel b/examples/BUILD.bazel
++index d633e88..fae64ea 100644
++--- a/examples/BUILD.bazel
+++++ b/examples/BUILD.bazel
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/examples/bazel_simple_example/BUILD b/examples/bazel_simple_example/BUILD
++index ddf0dd1..4446965 100644
++--- a/examples/bazel_simple_example/BUILD
+++++ b/examples/bazel_simple_example/BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/examples/bazel_simple_example/publisher.cpp b/examples/bazel_simple_example/publisher.cpp
++index 5973bcf..0542bc7 100644
++--- a/examples/bazel_simple_example/publisher.cpp
+++++ b/examples/bazel_simple_example/publisher.cpp
++@@ -1,4 +1,4 @@
++-// Copyright 2022 Apex.AI, Inc.
+++// Copyright 2024 Apex.AI, Inc.
++ //
++ // Licensed under the Apache License, Version 2.0 (the "License");
++ // you may not use this file except in compliance with the License.
++diff --git a/examples/bazel_simple_example/subscriber.cpp b/examples/bazel_simple_example/subscriber.cpp
++index 916725e..b965a98 100644
++--- a/examples/bazel_simple_example/subscriber.cpp
+++++ b/examples/bazel_simple_example/subscriber.cpp
++@@ -1,4 +1,4 @@
++-// Copyright 2022 Apex.AI, Inc.
+++// Copyright 2024 Apex.AI, Inc.
++ //
++ // Licensed under the Apache License, Version 2.0 (the "License");
++ // you may not use this file except in compliance with the License.
++diff --git a/examples/hello_world/BUILD.bazel b/examples/hello_world/BUILD.bazel
++index 7e57ee6..23f4011 100644
++--- a/examples/hello_world/BUILD.bazel
+++++ b/examples/hello_world/BUILD.bazel
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/defs.bzl b/pkg/defs.bzl
++index 3cdf278..e94254d 100644
++--- a/pkg/defs.bzl
+++++ b/pkg/defs.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/BUILD b/pkg/detail/BUILD
++index 6eae5f9..ee4c2f0 100644
++--- a/pkg/detail/BUILD
+++++ b/pkg/detail/BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/executable_wrapper_generator.py b/pkg/detail/executable_wrapper_generator.py
++index fb8da57..5f61b6c 100644
++--- a/pkg/detail/executable_wrapper_generator.py
+++++ b/pkg/detail/executable_wrapper_generator.py
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/package_xml_generator.py b/pkg/detail/package_xml_generator.py
++index 582811a..e9eb831 100644
++--- a/pkg/detail/package_xml_generator.py
+++++ b/pkg/detail/package_xml_generator.py
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/ros_archive.bzl b/pkg/detail/ros_archive.bzl
++index a233b61..dec10ab 100644
++--- a/pkg/detail/ros_archive.bzl
+++++ b/pkg/detail/ros_archive.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/ros_pkg.bzl b/pkg/detail/ros_pkg.bzl
++index b9fd094..e85f8fe 100644
++--- a/pkg/detail/ros_pkg.bzl
+++++ b/pkg/detail/ros_pkg.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/setup_bash_generator.py b/pkg/detail/setup_bash_generator.py
++index c307426..8798cbf 100644
++--- a/pkg/detail/setup_bash_generator.py
+++++ b/pkg/detail/setup_bash_generator.py
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/templates/install.template b/pkg/detail/templates/install.template
++index e221047..c480d15 100644
++--- a/pkg/detail/templates/install.template
+++++ b/pkg/detail/templates/install.template
++@@ -1,5 +1,5 @@
++ #! /bin/bash
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/detail/utils.bzl b/pkg/detail/utils.bzl
++index 6b91573..2eaf245 100644
++--- a/pkg/detail/utils.bzl
+++++ b/pkg/detail/utils.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/pkg/providers.bzl b/pkg/providers.bzl
++index 63b54e7..130cd60 100644
++--- a/pkg/providers.bzl
+++++ b/pkg/providers.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ament.ament_index/ament_index_cpp.BUILD b/repos/ament.ament_index/ament_index_cpp.BUILD
++index ac752eb..1604a1f 100644
++--- a/repos/ament.ament_index/ament_index_cpp.BUILD
+++++ b/repos/ament.ament_index/ament_index_cpp.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ament.ament_index/ament_index_python.BUILD b/repos/ament.ament_index/ament_index_python.BUILD
++index f18e018..b2ca224 100644
++--- a/repos/ament.ament_index/ament_index_python.BUILD
+++++ b/repos/ament.ament_index/ament_index_python.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/BUILD.bazel b/repos/config/BUILD.bazel
++index 83497d2..a459d77 100644
++--- a/repos/config/BUILD.bazel
+++++ b/repos/config/BUILD.bazel
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
++index aea43a9..bfcf114 100644
++--- a/repos/config/defs.bzl
+++++ b/repos/config/defs.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/detail/BUILD.bazel b/repos/config/detail/BUILD.bazel
++index 9519eaf..12caae2 100644
++--- a/repos/config/detail/BUILD.bazel
+++++ b/repos/config/detail/BUILD.bazel
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 399ab2e..83ca06a 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -1,5 +1,5 @@
++ #! /usr/bin/env python3
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/detail/git_repository.bzl b/repos/config/detail/git_repository.bzl
++index 62adc7a..2a6121c 100644
++--- a/repos/config/detail/git_repository.bzl
+++++ b/repos/config/detail/git_repository.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/detail/http_archive.bzl b/repos/config/detail/http_archive.bzl
++index 78daa85..b1bcdc6 100644
++--- a/repos/config/detail/http_archive.bzl
+++++ b/repos/config/detail/http_archive.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index 70b6c60..c1dac47 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -1,5 +1,5 @@
++ #! /usr/bin/env python3
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/detail/new_local_repository.bzl b/repos/config/detail/new_local_repository.bzl
++index 164bf6f..d856cab 100644
++--- a/repos/config/detail/new_local_repository.bzl
+++++ b/repos/config/detail/new_local_repository.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
++index 3faa5e4..d514131 100644
++--- a/repos/config/detail/ros2_config.bzl
+++++ b/repos/config/detail/ros2_config.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros-tooling.libstatistics_collector/root.BUILD b/repos/ros-tooling.libstatistics_collector/root.BUILD
++index f0fded9..1832f06 100644
++--- a/repos/ros-tooling.libstatistics_collector/root.BUILD
+++++ b/repos/ros-tooling.libstatistics_collector/root.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.common_interfaces/std_msgs.BUILD b/repos/ros2.common_interfaces/std_msgs.BUILD
++index ad53120..e544ef8 100644
++--- a/repos/ros2.common_interfaces/std_msgs.BUILD
+++++ b/repos/ros2.common_interfaces/std_msgs.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcl/rcl.BUILD b/repos/ros2.rcl/rcl.BUILD
++index 1f26109..bb6c7aa 100644
++--- a/repos/ros2.rcl/rcl.BUILD
+++++ b/repos/ros2.rcl/rcl.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcl/rcl_yaml_param_parser.BUILD b/repos/ros2.rcl/rcl_yaml_param_parser.BUILD
++index 9af8973..dbdf44b 100644
++--- a/repos/ros2.rcl/rcl_yaml_param_parser.BUILD
+++++ b/repos/ros2.rcl/rcl_yaml_param_parser.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcl_interfaces/builtin_interfaces.BUILD b/repos/ros2.rcl_interfaces/builtin_interfaces.BUILD
++index 262cf35..da1afde 100644
++--- a/repos/ros2.rcl_interfaces/builtin_interfaces.BUILD
+++++ b/repos/ros2.rcl_interfaces/builtin_interfaces.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcl_interfaces/rcl_interfaces.BUILD b/repos/ros2.rcl_interfaces/rcl_interfaces.BUILD
++index f50a7fd..173d0d2 100644
++--- a/repos/ros2.rcl_interfaces/rcl_interfaces.BUILD
+++++ b/repos/ros2.rcl_interfaces/rcl_interfaces.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcl_interfaces/rosgraph_msgs.BUILD b/repos/ros2.rcl_interfaces/rosgraph_msgs.BUILD
++index 45dfb89..d163ab3 100644
++--- a/repos/ros2.rcl_interfaces/rosgraph_msgs.BUILD
+++++ b/repos/ros2.rcl_interfaces/rosgraph_msgs.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcl_interfaces/statistics_msgs.BUILD b/repos/ros2.rcl_interfaces/statistics_msgs.BUILD
++index ac4a660..9d8deae 100644
++--- a/repos/ros2.rcl_interfaces/statistics_msgs.BUILD
+++++ b/repos/ros2.rcl_interfaces/statistics_msgs.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcl_logging/rcl_logging_interface.BUILD b/repos/ros2.rcl_logging/rcl_logging_interface.BUILD
++index 598fcbc..eeb970b 100644
++--- a/repos/ros2.rcl_logging/rcl_logging_interface.BUILD
+++++ b/repos/ros2.rcl_logging/rcl_logging_interface.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rclcpp/build_interfaces.py b/repos/ros2.rclcpp/build_interfaces.py
++index f84ec87..c6af59d 100644
++--- a/repos/ros2.rclcpp/build_interfaces.py
+++++ b/repos/ros2.rclcpp/build_interfaces.py
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rclcpp/rclcpp.BUILD b/repos/ros2.rclcpp/rclcpp.BUILD
++index 3ff99d2..2d916cf 100644
++--- a/repos/ros2.rclcpp/rclcpp.BUILD
+++++ b/repos/ros2.rclcpp/rclcpp.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcpputils/rcpputils.BUILD b/repos/ros2.rcpputils/rcpputils.BUILD
++index 6f5d3fe..90b3c5e 100644
++--- a/repos/ros2.rcpputils/rcpputils.BUILD
+++++ b/repos/ros2.rcpputils/rcpputils.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcutils/build_logging_macros.py b/repos/ros2.rcutils/build_logging_macros.py
++index 76e3e1b..14c2356 100644
++--- a/repos/ros2.rcutils/build_logging_macros.py
+++++ b/repos/ros2.rcutils/build_logging_macros.py
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rcutils/root.BUILD b/repos/ros2.rcutils/root.BUILD
++index 02122b2..2997ad3 100644
++--- a/repos/ros2.rcutils/root.BUILD
+++++ b/repos/ros2.rcutils/root.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rmw/rmw.BUILD b/repos/ros2.rmw/rmw.BUILD
++index 07bf9c2..5807695 100644
++--- a/repos/ros2.rmw/rmw.BUILD
+++++ b/repos/ros2.rmw/rmw.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.ros2_tracing/tracetools.BUILD b/repos/ros2.ros2_tracing/tracetools.BUILD
++index ea240e4..788df34 100644
++--- a/repos/ros2.ros2_tracing/tracetools.BUILD
+++++ b/repos/ros2.ros2_tracing/tracetools.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.ros2cli/ros2cli.BUILD b/repos/ros2.ros2cli/ros2cli.BUILD
++index 19a537c..9152164 100644
++--- a/repos/ros2.ros2cli/ros2cli.BUILD
+++++ b/repos/ros2.ros2cli/ros2cli.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.ros2cli/ros2pkg.BUILD b/repos/ros2.ros2cli/ros2pkg.BUILD
++index c88b5dc..1a9b209 100644
++--- a/repos/ros2.ros2cli/ros2pkg.BUILD
+++++ b/repos/ros2.ros2cli/ros2pkg.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.ros2cli/ros2run.BUILD b/repos/ros2.ros2cli/ros2run.BUILD
++index 3ce461c..10dccf7 100644
++--- a/repos/ros2.ros2cli/ros2run.BUILD
+++++ b/repos/ros2.ros2cli/ros2run.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_adapter.BUILD b/repos/ros2.rosidl/rosidl_adapter.BUILD
++index 08be8d2..483bf7a 100644
++--- a/repos/ros2.rosidl/rosidl_adapter.BUILD
+++++ b/repos/ros2.rosidl/rosidl_adapter.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_cli.BUILD b/repos/ros2.rosidl/rosidl_cli.BUILD
++index 1106f03..b967c3c 100644
++--- a/repos/ros2.rosidl/rosidl_cli.BUILD
+++++ b/repos/ros2.rosidl/rosidl_cli.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_cmake.BUILD b/repos/ros2.rosidl/rosidl_cmake.BUILD
++index 91550dc..2f99aa4 100644
++--- a/repos/ros2.rosidl/rosidl_cmake.BUILD
+++++ b/repos/ros2.rosidl/rosidl_cmake.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_generator_c.BUILD b/repos/ros2.rosidl/rosidl_generator_c.BUILD
++index 61e9c7c..d3993ea 100644
++--- a/repos/ros2.rosidl/rosidl_generator_c.BUILD
+++++ b/repos/ros2.rosidl/rosidl_generator_c.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_generator_cpp.BUILD b/repos/ros2.rosidl/rosidl_generator_cpp.BUILD
++index 3e227dd..8cd6965 100644
++--- a/repos/ros2.rosidl/rosidl_generator_cpp.BUILD
+++++ b/repos/ros2.rosidl/rosidl_generator_cpp.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_parser.BUILD b/repos/ros2.rosidl/rosidl_parser.BUILD
++index 4be3ab8..8c6a74d 100644
++--- a/repos/ros2.rosidl/rosidl_parser.BUILD
+++++ b/repos/ros2.rosidl/rosidl_parser.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_runtime_c.BUILD b/repos/ros2.rosidl/rosidl_runtime_c.BUILD
++index 976b574..bcf1808 100644
++--- a/repos/ros2.rosidl/rosidl_runtime_c.BUILD
+++++ b/repos/ros2.rosidl/rosidl_runtime_c.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_runtime_cpp.BUILD b/repos/ros2.rosidl/rosidl_runtime_cpp.BUILD
++index f233bfb..b1d659d 100644
++--- a/repos/ros2.rosidl/rosidl_runtime_cpp.BUILD
+++++ b/repos/ros2.rosidl/rosidl_runtime_cpp.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl/rosidl_typesupport_interface.BUILD b/repos/ros2.rosidl/rosidl_typesupport_interface.BUILD
++index ebd7e75..f96572c 100644
++--- a/repos/ros2.rosidl/rosidl_typesupport_interface.BUILD
+++++ b/repos/ros2.rosidl/rosidl_typesupport_interface.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD b/repos/ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD
++index 2bccd36..0fc5bbc 100644
++--- a/repos/ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD
+++++ b/repos/ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/repos/ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD b/repos/ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD
++index 064b80c..ead5b2f 100644
++--- a/repos/ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD
+++++ b/repos/ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/defs.bzl b/rosidl/defs.bzl
++index e5645f4..3e5e6de 100644
++--- a/rosidl/defs.bzl
+++++ b/rosidl/defs.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl b/rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl
++index 163ff39..f5a7cf3 100644
++--- a/rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl
+++++ b/rosidl/detail/cc_library_with_hdrs_extracted_from_srcs.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/cc_library_with_msgs_provider.bzl b/rosidl/detail/cc_library_with_msgs_provider.bzl
++index b59873c..39a5c0d 100644
++--- a/rosidl/detail/cc_library_with_msgs_provider.bzl
+++++ b/rosidl/detail/cc_library_with_msgs_provider.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/common_config.bzl b/rosidl/detail/common_config.bzl
++index e665917..347798a 100644
++--- a/rosidl/detail/common_config.bzl
+++++ b/rosidl/detail/common_config.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/misc_support.bzl b/rosidl/detail/misc_support.bzl
++index 6c93ec3..1e8cfed 100644
++--- a/rosidl/detail/misc_support.bzl
+++++ b/rosidl/detail/misc_support.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/rosidl_adapter.bzl b/rosidl/detail/rosidl_adapter.bzl
++index da98275..dcfa2ab 100644
++--- a/rosidl/detail/rosidl_adapter.bzl
+++++ b/rosidl/detail/rosidl_adapter.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/rosidl_generator_c.bzl b/rosidl/detail/rosidl_generator_c.bzl
++index b2c0e73..34686e3 100644
++--- a/rosidl/detail/rosidl_generator_c.bzl
+++++ b/rosidl/detail/rosidl_generator_c.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/rosidl_generator_cpp.bzl b/rosidl/detail/rosidl_generator_cpp.bzl
++index de68fe9..80d5bed 100644
++--- a/rosidl/detail/rosidl_generator_cpp.bzl
+++++ b/rosidl/detail/rosidl_generator_cpp.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/rosidl_generator_dds_idl.bzl b/rosidl/detail/rosidl_generator_dds_idl.bzl
++index c0ec998..c8e9bf8 100644
++--- a/rosidl/detail/rosidl_generator_dds_idl.bzl
+++++ b/rosidl/detail/rosidl_generator_dds_idl.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/rosidl_typesupport_c.bzl b/rosidl/detail/rosidl_typesupport_c.bzl
++index 2954991..6d4ab04 100644
++--- a/rosidl/detail/rosidl_typesupport_c.bzl
+++++ b/rosidl/detail/rosidl_typesupport_c.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/detail/visiability_control.bzl b/rosidl/detail/visiability_control.bzl
++index e7faf4b..ae6d9fe 100644
++--- a/rosidl/detail/visiability_control.bzl
+++++ b/rosidl/detail/visiability_control.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/rosidl/providers.bzl b/rosidl/providers.bzl
++index fc27a73..5c3fb42 100644
++--- a/rosidl/providers.bzl
+++++ b/rosidl/providers.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/bazel_skylib/repositories.bzl b/thirdparty/bazel_skylib/repositories.bzl
++index 39f7b81..7d77994 100644
++--- a/thirdparty/bazel_skylib/repositories.bzl
+++++ b/thirdparty/bazel_skylib/repositories.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/bazel_skylib/setup.bzl b/thirdparty/bazel_skylib/setup.bzl
++index 25e35e5..cf31676 100644
++--- a/thirdparty/bazel_skylib/setup.bzl
+++++ b/thirdparty/bazel_skylib/setup.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/libyaml/libyaml.BUILD.bazel b/thirdparty/libyaml/libyaml.BUILD.bazel
++index bde944a..c78b4ef 100644
++--- a/thirdparty/libyaml/libyaml.BUILD.bazel
+++++ b/thirdparty/libyaml/libyaml.BUILD.bazel
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/libyaml/repositories.bzl b/thirdparty/libyaml/repositories.bzl
++index de6efd8..65bdcf0 100644
++--- a/thirdparty/libyaml/repositories.bzl
+++++ b/thirdparty/libyaml/repositories.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/python/repositories.bzl b/thirdparty/python/repositories.bzl
++index 4c90aa9..e191cc0 100644
++--- a/thirdparty/python/repositories.bzl
+++++ b/thirdparty/python/repositories.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/setup_01.bzl b/thirdparty/setup_01.bzl
++index 458e160..d25cde4 100644
++--- a/thirdparty/setup_01.bzl
+++++ b/thirdparty/setup_01.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/setup_02.bzl b/thirdparty/setup_02.bzl
++index 9fb358f..81223a7 100644
++--- a/thirdparty/setup_02.bzl
+++++ b/thirdparty/setup_02.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/setup_03.bzl b/thirdparty/setup_03.bzl
++index bec5e62..e7cb69a 100644
++--- a/thirdparty/setup_03.bzl
+++++ b/thirdparty/setup_03.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/thirdparty/setup_04.bzl b/thirdparty/setup_04.bzl
++index 2134bc6..c54ac21 100644
++--- a/thirdparty/setup_04.bzl
+++++ b/thirdparty/setup_04.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++diff --git a/utils/template_expansion.bzl b/utils/template_expansion.bzl
++index bc37374..4657a5e 100644
++--- a/utils/template_expansion.bzl
+++++ b/utils/template_expansion.bzl
++@@ -1,4 +1,4 @@
++-# Copyright 2022 Apex.AI, Inc.
+++# Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++ # you may not use this file except in compliance with the License.
++-- 
++2.34.1
++
++
++From f5efaff31ffc1f15544e2bd830bd8b3837429489 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Mon, 15 Jul 2024 12:52:32 -0700
++Subject: [PATCH 18/27] Bump bazel version to 6.5.0, update docs accordingly
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ .bazelrc      |  2 +-
++ .bazelversion |  2 +-
++ README.md     | 17 +++++++++++++----
++ 3 files changed, 15 insertions(+), 6 deletions(-)
++
++diff --git a/.bazelrc b/.bazelrc
++index e6717c0..33101eb 100644
++--- a/.bazelrc
+++++ b/.bazelrc
++@@ -4,7 +4,7 @@ build --incompatible_default_to_explicit_init_py
++ # enable implementation_deps on cc_library targets
++ build --experimental_cc_implementation_deps
++ 
++-# set c++14 for all builds
+++# set c++17 for all builds
++ build --cxxopt="-std=c++17"
++ build --host_cxxopt="-std=c++17"
++ 
++diff --git a/.bazelversion b/.bazelversion
++index f9da12e..4be2c72 100644
++--- a/.bazelversion
+++++ b/.bazelversion
++@@ -1 +1 @@
++-6.3.2
++\ No newline at end of file
+++6.5.0
++\ No newline at end of file
++diff --git a/README.md b/README.md
++index be183a2..a6ff840 100644
++--- a/README.md
+++++ b/README.md
++@@ -42,6 +42,7 @@ as a launch tool for Bazel.
++ 
++ Create an empty folder and add the following files to it:
++ * `WORKSPACE` file:
+++
++   ```python
++   workspace(name = "my_first_bazel_ros_workspace") # choose your workspace name here
++   # load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++@@ -83,7 +84,9 @@ Create an empty folder and add the following files to it:
++   load("@rules_ros//thirdparty:setup_04.bzl", "setup_04")
++   setup_04()
++   ```
+++
++ * `.bazelrc` file:
+++
++   ```bash
++   # enable incompatible Python init mode
++   build --incompatible_default_to_explicit_init_py
++@@ -91,39 +94,45 @@ Create an empty folder and add the following files to it:
++   # enable implementation_deps on cc_library targets
++   build --experimental_cc_implementation_deps
++ 
++-  # set C++14 for all builds
+++  # set C++17 for all builds
++   build --cxxopt="-std=c++17"
++   build --host_cxxopt="-std=c++17"
++   ```
++   
++ * `.bazelversion` file (in case you are using bazelisk):
++-  ```text
++-  5.3.1
++-  ```
+++
+++```text
+++6.5.0
+++```
++ 
++ ### Run Bazel example
++ 
++ To **build** an example delivered in the `rules_ros` repository run, e.g.
+++
++ ```bash
++ bazel build @rules_ros//examples/hello_world
++ ```
++ from anywhere within your workspace.
++ 
++ **Executing** the example can be done by calling
+++
++ ```bash
++ bazel run @rules_ros//examples/hello_world
++ ```
++ Note that no sourcing is necessary. Bazel will take care of all the dependencies. 
++ 
++ **Deploying** a package archive to an install folder can be done by
+++
++ ```bash
++ bazel run @rules_ros//examples:rules_ros_examples.install <install_folder>
++ ```
++ Now we are back to working with ROS as usual. Source the package as usual:
+++
++ ```bash
++ source <install_folder>/setup.bash
++ ```
++ and run an executable with
+++
++ ```bash
++ ros2 run hello_world hello_world
++ ```
++-- 
++2.34.1
++
++
++From d0d9bd6546a659c489a6383c1e4a0545eafd85b9 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Mon, 15 Jul 2024 12:53:03 -0700
++Subject: [PATCH 19/27] Bump rules_pkg to 0.10.1, fix issues after bump
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ pkg/detail/ros_archive.bzl            |  2 +-
++ pkg/detail/ros_pkg.bzl                |  2 +-
++ pkg/detail/utils.bzl                  |  2 +-
++ thirdparty/rules_pkg/repositories.bzl | 13 ++++++++-----
++ 4 files changed, 11 insertions(+), 8 deletions(-)
++
++diff --git a/pkg/detail/ros_archive.bzl b/pkg/detail/ros_archive.bzl
++index dec10ab..2b2525c 100644
++--- a/pkg/detail/ros_archive.bzl
+++++ b/pkg/detail/ros_archive.bzl
++@@ -12,7 +12,7 @@
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++ 
++-load("@rules_pkg//:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
+++load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
++ load(
++     ":utils.bzl",
++     _add_filegroup = "add_filegroup",
++diff --git a/pkg/detail/ros_pkg.bzl b/pkg/detail/ros_pkg.bzl
++index e85f8fe..7ccda91 100644
++--- a/pkg/detail/ros_pkg.bzl
+++++ b/pkg/detail/ros_pkg.bzl
++@@ -12,7 +12,7 @@
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++ 
++-load("@rules_pkg//:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
+++load("@rules_pkg//pkg:providers.bzl", "PackageFilegroupInfo", "PackageFilesInfo")
++ load("@rules_python//python:packaging.bzl", "PyWheelInfo")
++ load(
++     ":utils.bzl",
++diff --git a/pkg/detail/utils.bzl b/pkg/detail/utils.bzl
++index 2eaf245..20670d8 100644
++--- a/pkg/detail/utils.bzl
+++++ b/pkg/detail/utils.bzl
++@@ -12,7 +12,7 @@
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++ 
++-load("@rules_pkg//:providers.bzl", _PackageFilegroupInfo = "PackageFilegroupInfo")
+++load("@rules_pkg//pkg:providers.bzl", _PackageFilegroupInfo = "PackageFilegroupInfo")
++ load("@rules_ros//pkg:providers.bzl", _RosPkgInfo = "RosPkgInfo")
++ 
++ def add_files_to_filegroup_info(filegroup_info, pkg_files_info, label):
++diff --git a/thirdparty/rules_pkg/repositories.bzl b/thirdparty/rules_pkg/repositories.bzl
++index 7028523..fa1de76 100644
++--- a/thirdparty/rules_pkg/repositories.bzl
+++++ b/thirdparty/rules_pkg/repositories.bzl
++@@ -1,16 +1,19 @@
++ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
++ 
++-RULES_PKG_VERSION = "0.7.0"
++-RULES_PKG_SHA = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2"
+++RULES_PKG_VERSION = struct(
+++    version = "0.10.1",
+++    sha256 = "d250924a2ecc5176808fc4c25d5cf5e9e79e6346d79d5ab1c493e289e722d1d0",
+++)
++ 
++ def load_rules_pkg_repositories():
++     maybe(
++         name = "rules_pkg",
++         repo_rule = http_archive,
++         urls = [
++-            "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/{version}/rules_pkg-{version}.tar.gz".format(version = RULES_PKG_VERSION),
++-            "https://github.com/bazelbuild/rules_pkg/releases/download/{version}/rules_pkg-{version}.tar.gz".format(version = RULES_PKG_VERSION),
+++            "https://github.com/bazelbuild/rules_pkg/releases/download/{version}/rules_pkg-{version}.tar.gz".format(
+++                version = RULES_PKG_VERSION.version,
+++            ),
++         ],
++-        sha256 = RULES_PKG_SHA,
+++        sha256 = RULES_PKG_VERSION.sha256,
++     )
++-- 
++2.34.1
++
++
++From f3b522b91ff99db43dbf79c64ca650c2eaf436eb Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Wed, 17 Jul 2024 07:09:02 -0700
++Subject: [PATCH 20/27] Add workspace name to update command hint
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ repos/config/detail/lock_repos.py | 2 +-
++ 1 file changed, 1 insertion(+), 1 deletion(-)
++
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index c1dac47..6df8145 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -53,7 +53,7 @@ def main():
++ 
++     with open(args.lock, "w", encoding='utf8') as lock_file:
++         print(
++-            "#\n#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE\n#",
+++            "#\n#   To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE\n#",
++             file = lock_file
++         )
++         yaml.dump(repos, lock_file, default_flow_style=False, allow_unicode=True)
++-- 
++2.34.1
++
++
++From c29e8c9357c720fd919cb86bceda6285712a504e Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Fri, 26 Jul 2024 12:30:40 -0700
++Subject: [PATCH 21/27] Add missing pyyaml dep to repos_lock.update
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ repos/config/detail/BUILD.bazel | 3 ++-
++ 1 file changed, 2 insertions(+), 1 deletion(-)
++
++diff --git a/repos/config/detail/BUILD.bazel b/repos/config/detail/BUILD.bazel
++index 12caae2..21d32d0 100644
++--- a/repos/config/detail/BUILD.bazel
+++++ b/repos/config/detail/BUILD.bazel
++@@ -11,7 +11,7 @@
++ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++-
+++load("@python_deps//:requirements.bzl", "requirement")
++ load("@ros2_config//:repos_lock_file.bzl", "REPOS_LOCK_FILE")
++ 
++ py_binary(
++@@ -20,5 +20,6 @@ py_binary(
++     main = "lock_repos.py",
++     data = ["@ros2//:ros2.repos", REPOS_LOCK_FILE],
++     args = ["$(execpath @ros2//:ros2.repos)", "$(execpath {})".format(REPOS_LOCK_FILE)],
+++    deps = [requirement("pyyaml")],
++     visibility = ["//visibility:public"],
++ )
++-- 
++2.34.1
++
++
++From 65ae96c62583b7aa651c58a1bb20d4ff4da25690 Mon Sep 17 00:00:00 2001
++From: Evan Flynn <evan.flynn@apex.ai>
++Date: Tue, 30 Jul 2024 08:58:34 -0700
++Subject: [PATCH 22/27] Pass repo index overlays to configure_ros2
++
++Signed-off-by: Evan Flynn <evan.flynn@apex.ai>
++---
++ repos/config/defs.bzl | 10 ++++++----
++ 1 file changed, 6 insertions(+), 4 deletions(-)
++
++diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
++index bfcf114..7ac331b 100644
++--- a/repos/config/defs.bzl
+++++ b/repos/config/defs.bzl
++@@ -16,7 +16,7 @@ load("@rules_ros//repos/config/detail:ros2_config.bzl", "ros2_config")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
++ load("@rules_ros//repos/config:distros.bzl", "DISTROS")
++ 
++-def _configure_ros2(*, name, distro_src):
+++def _configure_ros2(*, name, distro_src, repo_index_overlays):
++     distro_src_wo_index = {k: v for k, v in distro_src.items() if k != "repo_index"}
++     distro_src_wo_index["build_file_content"] = 'exports_files(["ros2.repos"])'
++ 
++@@ -27,10 +27,10 @@ def _configure_ros2(*, name, distro_src):
++         repo_index = distro_src["repo_index"],
++         repo_index_overlays = [
++             "@rules_ros//repos/config:bazel.repos",
++-        ],
+++        ] + repo_index_overlays,
++     )
++ 
++-def configure_ros2(*, name = "ros2_config", distro):
+++def configure_ros2(*, name = "ros2_config", repo_index_overlays = [], distro):
++     """
++     """
++     if type(distro) == type(""):
++@@ -41,4 +41,6 @@ def configure_ros2(*, name = "ros2_config", distro):
++         if not type(distro) == type({}) or not "repo_rule" in distro:
++             fail("Distro either needs to be a string (e.g. 'iron') or a dict with arguments for the maybe repo rule")
++         distro_src = distro
++-    _configure_ros2(name = name, distro_src = distro_src)
+++    if not type(repo_index_overlays) == type([]):
+++        fail("repo_index_overlays needs to be a list of *.repos files")
+++    _configure_ros2(name = name, distro_src = distro_src, repo_index_overlays = repo_index_overlays)
++-- 
++2.34.1
++
++
++From 766f2e3323d81d5a71ca9f1b596e80e6062165e1 Mon Sep 17 00:00:00 2001
++From: Andrii Kaznadiei <andrii.kaznadiei@apex.ai>
++Date: Fri, 2 Aug 2024 18:40:29 +0200
++Subject: [PATCH 23/27] Remove unnecessary debug logs
++
++---
++ repos/config/detail/generate_ros2_config.py | 5 +----
++ 1 file changed, 1 insertion(+), 4 deletions(-)
++
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 83ca06a..7ba3fcf 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -51,7 +51,6 @@ def build_load_command(repo, spec):
++ def build_http_archive_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""
++-    print("Loading: @{repo.replace('/','.')}")
++     _maybe(
++         name = "{repo.replace('/','.')}",
++         build_files = {{
++@@ -67,7 +66,6 @@ def build_http_archive_load_command(repo, spec):
++ def build_local_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""
++-    print("Loading: @{repo.replace('/','.')}")
++     _maybe(
++         name = "{repo.replace('/','.')}",
++         build_files = {{
++@@ -82,7 +80,6 @@ def build_local_load_command(repo, spec):
++ def build_git_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""
++-    print("Loading: @{repo.replace('/','.')}")
++     _maybe(
++         name = "{repo.replace('/','.')}",
++         branch = "{spec['version']}",
++@@ -118,4 +115,4 @@ def main():
++ 
++ 
++ if __name__ == "__main__":
++-    main()
++\ No newline at end of file
+++    main()
++-- 
++2.34.1
++
++
++From 4528389203c4cd22276a0fd72638cd6ce84be59e Mon Sep 17 00:00:00 2001
++From: Andrii Kaznadiei <andrii.kaznadiei@apex.ai>
++Date: Tue, 27 Aug 2024 14:06:57 +0200
++Subject: [PATCH 24/27] Do not run Python during 'configure_ros2'
++
++- Add possibility to provide user-defined `setup.bzl`
++- Generate 'setup.bzl' as part of `repos_lock.update`
++---
++ .gitignore                                  |   3 +
++ repos/config/BUILD.bazel                    |   2 +-
++ repos/config/defs.bzl                       |  39 +-
++ repos/config/detail/BUILD.bazel             |  14 +-
++ repos/config/detail/generate_ros2_config.py |  30 +-
++ repos/config/detail/lock_repos.py           |  25 +-
++ repos/config/detail/ros2_config.bzl         |  29 +-
++ repos/config/distros.bzl                    |   2 +-
++ repos/config/ros2_dashing.lock              | 520 ----------------
++ repos/config/ros2_eloquent.lock             | 574 ------------------
++ repos/config/ros2_foxy.lock                 | 598 ------------------
++ repos/config/ros2_humble.lock               | 622 -------------------
++ repos/config/ros2_iron.lock                 | 640 --------------------
++ repos/config/setup_dashing.lock.bzl         | 241 ++++++++
++ repos/config/setup_eloquent.lock.bzl        | 261 ++++++++
++ repos/config/setup_foxy.lock.bzl            | 281 +++++++++
++ repos/config/setup_humble.lock.bzl          | 291 +++++++++
++ repos/config/setup_iron.lock.bzl            | 291 +++++++++
++ 18 files changed, 1445 insertions(+), 3018 deletions(-)
++ delete mode 100644 repos/config/ros2_dashing.lock
++ delete mode 100644 repos/config/ros2_eloquent.lock
++ delete mode 100644 repos/config/ros2_foxy.lock
++ delete mode 100644 repos/config/ros2_humble.lock
++ delete mode 100644 repos/config/ros2_iron.lock
++ create mode 100644 repos/config/setup_dashing.lock.bzl
++ create mode 100644 repos/config/setup_eloquent.lock.bzl
++ create mode 100644 repos/config/setup_foxy.lock.bzl
++ create mode 100644 repos/config/setup_humble.lock.bzl
++ create mode 100644 repos/config/setup_iron.lock.bzl
++
++diff --git a/.gitignore b/.gitignore
++index 424a461..8253c61 100644
++--- a/.gitignore
+++++ b/.gitignore
++@@ -1,2 +1,5 @@
++ .clwb/*
++ bazel-*
+++
+++# Python caches
+++/**/__pycache__/
++diff --git a/repos/config/BUILD.bazel b/repos/config/BUILD.bazel
++index a459d77..c716378 100644
++--- a/repos/config/BUILD.bazel
+++++ b/repos/config/BUILD.bazel
++@@ -12,7 +12,7 @@
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++ 
++-exports_files(glob(["*.lock"]))
+++exports_files(["bazel.repos"] + glob(["*.lock.bzl"]))
++ 
++ alias(
++     name = "repos_lock.update",
++diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
++index 7ac331b..ed10d70 100644
++--- a/repos/config/defs.bzl
+++++ b/repos/config/defs.bzl
++@@ -16,23 +16,24 @@ load("@rules_ros//repos/config/detail:ros2_config.bzl", "ros2_config")
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
++ load("@rules_ros//repos/config:distros.bzl", "DISTROS")
++ 
++-def _configure_ros2(*, name, distro_src, repo_index_overlays):
++-    distro_src_wo_index = {k: v for k, v in distro_src.items() if k != "repo_index"}
++-    distro_src_wo_index["build_file_content"] = 'exports_files(["ros2.repos"])'
+++def _configure_ros2(*, name, distro_src, repos_index_overlays):
+++    distro_src_wo_setup_file = {k: v for k, v in distro_src.items() if k != "setup_file"}
+++    distro_src_wo_setup_file["build_file_content"] = 'exports_files(["ros2.repos"])'
++ 
++-    maybe(name = "ros2", **distro_src_wo_index)
+++    maybe(name = "ros2", **distro_src_wo_setup_file)
++ 
++     ros2_config(
++         name = name,
++-        repo_index = distro_src["repo_index"],
++-        repo_index_overlays = [
+++        repos_index = "@ros2//:ros2.repos",
+++        repos_index_overlays = [
++             "@rules_ros//repos/config:bazel.repos",
++-        ] + repo_index_overlays,
+++        ] + repos_index_overlays,
+++        setup_file = distro_src["setup_file"],
++     )
++ 
++-def configure_ros2(*, name = "ros2_config", repo_index_overlays = [], distro):
++-    """
++-    """
+++def configure_ros2(*, name = "ros2_config", repos_index_overlays = [], distro):
+++    """Configure ROS 2 repositories based on the given distro name."""
+++
++     if type(distro) == type(""):
++         if not distro in DISTROS:
++             fail("Distro {} is not supported. Choose one of {}".format(distro, DISTROS.keys()))
++@@ -41,6 +42,18 @@ def configure_ros2(*, name = "ros2_config", repo_index_overlays = [], distro):
++         if not type(distro) == type({}) or not "repo_rule" in distro:
++             fail("Distro either needs to be a string (e.g. 'iron') or a dict with arguments for the maybe repo rule")
++         distro_src = distro
++-    if not type(repo_index_overlays) == type([]):
++-        fail("repo_index_overlays needs to be a list of *.repos files")
++-    _configure_ros2(name = name, distro_src = distro_src, repo_index_overlays = repo_index_overlays)
+++    if not type(repos_index_overlays) == type([]):
+++        fail("repos_index_overlays needs to be a list of *.repos files")
+++    _configure_ros2(name = name, distro_src = distro_src, repos_index_overlays = repos_index_overlays)
+++
+++def configure_repos(*, name = "ros2_config", repos_index, repos_index_overlays = [], setup_file):
+++    """Configure ROS 2 repositories based on the custom *.repos file."""
+++
+++    if not type(repos_index_overlays) == type([]):
+++        fail("repos_index_overlays needs to be a list of *.repos files")
+++    ros2_config(
+++        name = name,
+++        repos_index = repos_index,
+++        repos_index_overlays = repos_index_overlays,
+++        setup_file = setup_file,
+++    )
++diff --git a/repos/config/detail/BUILD.bazel b/repos/config/detail/BUILD.bazel
++index 21d32d0..927b7ea 100644
++--- a/repos/config/detail/BUILD.bazel
+++++ b/repos/config/detail/BUILD.bazel
++@@ -11,15 +11,21 @@
++ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
+++
++ load("@python_deps//:requirements.bzl", "requirement")
++-load("@ros2_config//:repos_lock_file.bzl", "REPOS_LOCK_FILE")
+++load("@ros2_config//:repos_index_file.bzl", "REPOS_INDEX_FILE")
+++load("@ros2_config//:repos_overlay_files.bzl", "REPOS_OVERLAY_FILES")
+++load("@ros2_config//:repos_setup_file.bzl", "REPOS_SETUP_FILE")
++ 
++ py_binary(
++     name = "repos_lock.update",
++-    srcs = ["lock_repos.py"],
+++    srcs = ["lock_repos.py", "generate_ros2_config.py"],
++     main = "lock_repos.py",
++-    data = ["@ros2//:ros2.repos", REPOS_LOCK_FILE],
++-    args = ["$(execpath @ros2//:ros2.repos)", "$(execpath {})".format(REPOS_LOCK_FILE)],
+++    data = [REPOS_INDEX_FILE, REPOS_SETUP_FILE] + REPOS_OVERLAY_FILES,
+++    args = [
+++        "$(execpath {})".format(REPOS_INDEX_FILE),
+++        "$(execpath {})".format(REPOS_SETUP_FILE),
+++    ] + ["$(execpath {})".format(f) for f in REPOS_OVERLAY_FILES],
++     deps = [requirement("pyyaml")],
++     visibility = ["//visibility:public"],
++ )
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 7ba3fcf..62c9011 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -1,4 +1,3 @@
++-#! /usr/bin/env python3
++ # Copyright 2024 Apex.AI, Inc.
++ #
++ # Licensed under the Apache License, Version 2.0 (the "License");
++@@ -17,22 +16,27 @@ import sys
++ import yaml
++ 
++ 
++-HEADER = """
+++HEADER = """#
+++# DO NOT EDIT THIS FILE MANUALLY!
+++#
+++# To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++ load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
++ load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
++ load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
++-load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++ 
++ def setup():
++     pass
++ """
++ 
++ 
++-def print_setup(repos):
++-    print(HEADER)
+++def print_setup(repos, output_file):
+++    print(HEADER, file=output_file)
++     for repo, spec in repos.items():
++         if spec.get("bazel") is not None:
++-            print(build_load_command(repo, spec))
+++            print(build_load_command(repo, spec), file=output_file)
++ 
++ 
++ def build_load_command(repo, spec):
++@@ -102,17 +106,13 @@ def merge_dict(origin, to_add):
++             origin[key]=value
++ 
++ 
++-def main():
++-    if len(sys.argv) < 2:
++-        raise ValueError("At least one YAML file required as input.")
+++def print_setup_file(yaml_files, output_file):
+++    if len(yaml_files) < 1:
+++        raise ValueError("At least one YAML file is required as input.")
++ 
++     repos = {}
++-    for input_path in sys.argv[1:]:
+++    for input_path in yaml_files:
++         with (open(input_path,"r")) as repo_file:
++             merge_dict(repos, yaml.safe_load(repo_file)["repositories"])
++ 
++-    print_setup(repos)
++-
++-
++-if __name__ == "__main__":
++-    main()
+++    print_setup(repos, output_file)
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index 6df8145..1bd8d0a 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -21,17 +21,21 @@ import subprocess
++ import os
++ import hashlib
++ from pathlib import Path
+++from generate_ros2_config import print_setup_file
++ 
++ REPO_TYPES = ["git", "tar"]
++ 
++ def main():
++-    parser = argparse.ArgumentParser(description="Generate a lock file for a given repos file.")
++-    parser.add_argument('repos', type=str, help='Input YAML file')
++-    parser.add_argument('lock', type=str, help='Output YAML file with pinned repos')
++-    parser.add_argument('--tar', action='store_true', help='Use the Github archive download.')
+++    parser = argparse.ArgumentParser(description='Generate a Bazel setup file containing repo '
+++        'rules to load every repository for a given repos file.')
+++    parser.add_argument('repos', type=str, help='Input YAML *.repos file')
+++    parser.add_argument('setup_bzl', type=str, help='Output Bazel setup file with repo rules.')
+++    parser.add_argument('overlays', type=str, nargs='*', help='Additional YAML files are used as '
+++        'overlays for *.repos file, e.g., to declare BUILD files for a repo.')
+++    parser.add_argument('--tar', action='store_true', help='Use the GitHub archive download.')
++ 
++     args = parser.parse_args()
++-    print(f"Calling {args.repos} {args.lock}")
+++    print(f"Using {args.repos} to generate {args.setup_bzl}")
++ 
++     with open(args.repos, "r") as repos_file:
++         repos = yaml.safe_load(repos_file)
++@@ -51,13 +55,12 @@ def main():
++         add_attributes(repos["repositories"][repo], additional_attributes)
++         print("{}: {}".format(repo, [*additional_attributes.values()]))
++ 
++-    with open(args.lock, "w", encoding='utf8') as lock_file:
++-        print(
++-            "#\n#   To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE\n#",
++-            file = lock_file
++-        )
+++    with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf8') as lock_file:
++         yaml.dump(repos, lock_file, default_flow_style=False, allow_unicode=True)
++ 
+++        with open(args.setup_bzl, mode='w', encoding='utf8') as setup_bzl:
+++            print_setup_file(yaml_files=[lock_file.name] + args.overlays, output_file=setup_bzl)
+++
++ def add_attributes(dictionary, additional_attributes):
++     for k,v in additional_attributes.items():
++         dictionary[k] = v
++@@ -126,4 +129,4 @@ def fetch_repo_details(url, branch):
++ 
++ 
++ if __name__ == "__main__":
++-    main()
++\ No newline at end of file
+++    main()
++diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
++index d514131..0e9102c 100644
++--- a/repos/config/detail/ros2_config.bzl
+++++ b/repos/config/detail/ros2_config.bzl
++@@ -15,37 +15,28 @@
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "update_attrs")
++ 
++ _archive_attrs = {
++-    "repo_index": attr.label(
+++    "repos_index": attr.label(
++         doc = "YAML file containing the details of every ros2 repository.",
++     ),
++-    "repo_index_overlays": attr.label_list(
+++    "repos_index_overlays": attr.label_list(
++         default = [],
++         doc = """
++             Additional YAML files used as overlays for `repo_index` e.g. to declare BUILD files
++             for a repo.
++         """,
++     ),
++-    "_generate_ros2_config": attr.label(
++-        default = "generate_ros2_config.py",
++-    ),
++-    "verbose": attr.bool(
++-        default = False,
++-        doc = "Prints the calling sequence to stdout.",
+++    "setup_file": attr.label(
+++        doc = "Resulting .bzl file containing repo rules to load every ros2 repository.",
++     ),
++ }
++ 
++ def _ros2_config_impl(ctx):
++-    result = ctx.execute(
++-        [ctx.attr._generate_ros2_config, ctx.attr.repo_index] +
++-        ctx.attr.repo_index_overlays,
++-    )
++-    if result.return_code != 0:
++-        fail(result.stderr)
++-
++-    ctx.file("setup.bzl", content = result.stdout)
++-    ctx.file("repos_lock_file.bzl", content = "REPOS_LOCK_FILE = '{}'".format(ctx.attr.repo_index))
++-    ctx.file("WORKSPACE", content = "workspace(name = {}".format(ctx.name), executable = False)
++-    ctx.file("BUILD", executable = False)
+++    ctx.file("repos_index_file.bzl", content = "REPOS_INDEX_FILE = '{}'".format(ctx.attr.repos_index))
+++    ctx.file("repos_overlay_files.bzl", content = "REPOS_OVERLAY_FILES = {}".format(["{}".format(l) for l in ctx.attr.repos_index_overlays]))
+++    ctx.file("repos_setup_file.bzl", content = "REPOS_SETUP_FILE = '{}'".format(ctx.attr.setup_file))
+++    ctx.symlink(ctx.attr.setup_file, "setup.bzl")
+++    ctx.file("WORKSPACE", content = "workspace(name = {})".format(ctx.name), executable = False)
+++    ctx.file("BUILD.bazel", content = "exports_files(glob(['**/*']))", executable = False)
++ 
++     return update_attrs(ctx.attr, _archive_attrs.keys(), {})
++ 
++diff --git a/repos/config/distros.bzl b/repos/config/distros.bzl
++index 0ae4260..77be98c 100644
++--- a/repos/config/distros.bzl
+++++ b/repos/config/distros.bzl
++@@ -21,7 +21,7 @@ DISTROS = {
++         url = _URL_TEMPLATE.format(distro, date),
++         strip_prefix = _STRIP_PREFIX_TEMPLATE.format(distro, date),
++         sha256 = sha,
++-        repo_index = "@rules_ros//repos/config:ros2_{}.lock".format(distro),
+++        setup_file = "@rules_ros//repos/config:setup_{}.lock.bzl".format(distro),
++     )
++     for distro, date, sha in _VERSIONS
++ }
++diff --git a/repos/config/ros2_dashing.lock b/repos/config/ros2_dashing.lock
++deleted file mode 100644
++index 893fb41..0000000
++--- a/repos/config/ros2_dashing.lock
+++++ /dev/null
++@@ -1,520 +0,0 @@
++-#
++-#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
++-#
++-repositories:
++-  ament/ament_cmake:
++-    hash: d75c029777ea4146728eba1947d390710020ee16
++-    shallow_since: 1606242243 -0800
++-    type: git
++-    url: https://github.com/ament/ament_cmake.git
++-    version: 0.7.6
++-  ament/ament_index:
++-    hash: 9d42ba13d7694ad8da5b1622e433e691996c4502
++-    shallow_since: 1571244457 -0700
++-    type: git
++-    url: https://github.com/ament/ament_index.git
++-    version: 0.7.2
++-  ament/ament_lint:
++-    hash: 0e725355914d44bb23ef0c34c045334b008a32dd
++-    shallow_since: 1594438323 -0400
++-    type: git
++-    url: https://github.com/ament/ament_lint.git
++-    version: 0.7.12
++-  ament/ament_package:
++-    hash: 68cb3ea4ad5009c2594eb835c34592e610cef975
++-    shallow_since: 1570825093 -0400
++-    type: git
++-    url: https://github.com/ament/ament_package.git
++-    version: 0.7.3
++-  ament/googletest:
++-    hash: 7e47d9759e8cd03322e5e19b451f44121dde98e2
++-    shallow_since: 1557357092 -0700
++-    type: git
++-    url: https://github.com/ament/googletest.git
++-    version: 1.8.9000
++-  ament/uncrustify_vendor:
++-    hash: 1d03dbdd78548289036d5c46d2a18b4c5a186456
++-    shallow_since: 1554990000 -0700
++-    type: git
++-    url: https://github.com/ament/uncrustify_vendor.git
++-    version: 1.2.0
++-  eProsima/Fast-CDR:
++-    hash: 174f6ff1d3a227c5c900a4587ee32fa888267f5e
++-    shallow_since: 1585310200 +0100
++-    type: git
++-    url: https://github.com/eProsima/Fast-CDR.git
++-    version: v1.0.13
++-  eProsima/Fast-RTPS:
++-    hash: 155087f6a3d445892e05d25a2e360513537457d6
++-    shallow_since: 1585322312 +0100
++-    type: git
++-    url: https://github.com/eProsima/Fast-DDS.git
++-    version: v1.8.4
++-  eclipse-cyclonedds/cyclonedds:
++-    hash: c261053186c455abc63ca5ac7d56c0808a59c364
++-    shallow_since: 1596471565 +0200
++-    type: git
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
++-    version: 0.7.0
++-  osrf/osrf_pycommon:
++-    hash: 0511d7b120048b826ff60465ba7532d332654b8c
++-    shallow_since: 1570737268 -0700
++-    type: git
++-    url: https://github.com/osrf/osrf_pycommon.git
++-    version: 0.1.9
++-  osrf/osrf_testing_tools_cpp:
++-    hash: a34bcc9e5bccc789f94933f9d2f967baf60d5e58
++-    shallow_since: 1606246952 -0800
++-    type: git
++-    url: https://github.com/osrf/osrf_testing_tools_cpp.git
++-    version: 1.2.3
++-  ros-perception/laser_geometry:
++-    hash: ed2c9b548c77c7c373ef139ac0b40b0645a749fc
++-    shallow_since: 1530153917 -0700
++-    type: git
++-    url: https://github.com/ros-perception/laser_geometry.git
++-    version: 2.0.0
++-  ros-planning/navigation_msgs:
++-    hash: fe880e99d993e9d4dfbf37f00d839d32994610e1
++-    shallow_since: 1569867654 -0500
++-    type: git
++-    url: https://github.com/ros-planning/navigation_msgs.git
++-    version: 2.0.2
++-  ros-visualization/python_qt_binding:
++-    hash: a64b4929b3b5620c9785e9505c19e4e00a66c813
++-    shallow_since: 1569879255 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/python_qt_binding.git
++-    version: 1.0.2
++-  ros-visualization/qt_gui_core:
++-    hash: 004e25a5a118e9695d8fe4694b61200cc1e14b06
++-    shallow_since: 1590536933 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/qt_gui_core.git
++-    version: 1.0.9
++-  ros-visualization/rqt:
++-    hash: d06bacf1b5d7c356189a5f35e3dc0e20bd30643c
++-    shallow_since: 1612568901 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt.git
++-    version: 1.0.7
++-  ros-visualization/rqt_console:
++-    hash: addd6b251018aa66b4e5cc53d9c8e66d27f3eb06
++-    shallow_since: 1579042396 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_console.git
++-    version: 1.1.1
++-  ros-visualization/rqt_graph:
++-    hash: 874d7927cea0bfe721511ec403edd572e4363452
++-    shallow_since: 1600463827 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_graph.git
++-    version: 1.0.5
++-  ros-visualization/rqt_msg:
++-    hash: 5e9a8b02dc02039761bc5558adff130bdfb4e495
++-    shallow_since: 1557445337 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_msg.git
++-    version: 1.0.2
++-  ros-visualization/rqt_plot:
++-    hash: 986a95854601f2f1774a5d14c5de22a37f7e64ba
++-    shallow_since: 1570132866 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_plot.git
++-    version: 1.0.7
++-  ros-visualization/rqt_publisher:
++-    hash: 565ffc81069fe1ab53e5230d98be20cb95c6bea3
++-    shallow_since: 1570130261 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_publisher.git
++-    version: 1.1.0
++-  ros-visualization/rqt_py_console:
++-    hash: 359e33589e9c0dbe9861120250a0a67d43e92503
++-    shallow_since: 1544572306 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_py_console.git
++-    version: 1.0.0
++-  ros-visualization/rqt_service_caller:
++-    hash: 23a8213d750a25a555d8a4a18179063323188eb5
++-    shallow_since: 1559173297 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_service_caller.git
++-    version: 1.0.3
++-  ros-visualization/rqt_shell:
++-    hash: 56d240dddecadcd546d2638362533ef99f7c4e6b
++-    shallow_since: 1544582027 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_shell.git
++-    version: 1.0.0
++-  ros-visualization/rqt_srv:
++-    hash: 0126ee3040f94392ed626b489c44a25a694fc7e9
++-    shallow_since: 1544645384 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_srv.git
++-    version: 1.0.1
++-  ros-visualization/rqt_top:
++-    hash: af56baacaa26c23b13d3fc9713cb269199d9b557
++-    shallow_since: 1544596207 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_top.git
++-    version: 1.0.0
++-  ros/class_loader:
++-    hash: 88f52836487bcedb3013b983668116f17f6b2ed5
++-    shallow_since: 1584105098 -0400
++-    type: git
++-    url: https://github.com/ros/class_loader.git
++-    version: 1.3.3
++-  ros/pluginlib:
++-    hash: 2bdfd294699dc1a71116a3789a9843c9ea388560
++-    shallow_since: 1571344601 -0400
++-    type: git
++-    url: https://github.com/ros/pluginlib.git
++-    version: 2.3.3
++-  ros/resource_retriever:
++-    hash: 77f122028870de8f1470f690618c349840998b44
++-    shallow_since: 1594440619 -0400
++-    type: git
++-    url: https://github.com/ros/resource_retriever.git
++-    version: 2.1.3
++-  ros/ros_environment:
++-    hash: ba03418988d8af35019573a5e58c44afb2de76a2
++-    shallow_since: 1554993149 -0700
++-    type: git
++-    url: https://github.com/ros/ros_environment.git
++-    version: 2.3.0
++-  ros/ros_tutorials:
++-    hash: e85388de40a53a22f5056d878b525b06fc173a1e
++-    shallow_since: 1596642207 -0700
++-    type: git
++-    url: https://github.com/ros/ros_tutorials.git
++-    version: 1.0.3
++-  ros/urdfdom_headers:
++-    hash: 00c1c9c231e46b2300d04073ad696521758fa45c
++-    shallow_since: 1558394923 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom_headers.git
++-    version: 1.0.4
++-  ros2/ament_cmake_ros:
++-    hash: 070c7265354dc11ab04faac3b5ec7bb175b9e5d6
++-    shallow_since: 1555010761 -0700
++-    type: git
++-    url: https://github.com/ros2/ament_cmake_ros.git
++-    version: 0.7.0
++-  ros2/common_interfaces:
++-    hash: 30dbc60b45e22f2c88a4c46493388fdad3916845
++-    shallow_since: 1621610616 -0700
++-    type: git
++-    url: https://github.com/ros2/common_interfaces.git
++-    version: 0.7.1
++-  ros2/console_bridge_vendor:
++-    hash: d3be808a1b77028a152a8ee5aa56346ce32db987
++-    shallow_since: 1555013045 -0700
++-    type: git
++-    url: https://github.com/ros2/console_bridge_vendor.git
++-    version: 1.2.0
++-  ros2/demos:
++-    hash: c9e55acba6eaf377ccacce844853fd9eb20d1113
++-    shallow_since: 1570830190 -0700
++-    type: git
++-    url: https://github.com/ros2/demos.git
++-    version: 0.7.9
++-  ros2/eigen3_cmake_module:
++-    hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
++-    shallow_since: 1565307940 -0700
++-    type: git
++-    url: https://github.com/ros2/eigen3_cmake_module.git
++-    version: 0.1.1
++-  ros2/example_interfaces:
++-    hash: 5b118347114931620533aba142939b6a1db200bc
++-    shallow_since: 1559174767 -0700
++-    type: git
++-    url: https://github.com/ros2/example_interfaces.git
++-    version: 0.7.1
++-  ros2/examples:
++-    hash: 166c8294ab99417efde85c96783ff46ac2ac41af
++-    shallow_since: 1606266810 -0800
++-    type: git
++-    url: https://github.com/ros2/examples.git
++-    version: 0.7.5
++-  ros2/geometry2:
++-    hash: 2b639fa57c802386a40b0449cdb5c7ce1e5a62bb
++-    shallow_since: 1576000145 -0600
++-    type: git
++-    url: https://github.com/ros2/geometry2.git
++-    version: 0.11.6
++-  ros2/kdl_parser:
++-    hash: b3e9446f4af182fb499a07798a8b85de53677da7
++-    shallow_since: 1595362350 -0500
++-    type: git
++-    url: https://github.com/ros/kdl_parser.git
++-    version: 2.2.1
++-  ros2/launch:
++-    hash: 36a381026aacb586eaee2d0ba465414fd05a4cba
++-    shallow_since: 1570831179 -0700
++-    type: git
++-    url: https://github.com/ros2/launch.git
++-    version: 0.8.7
++-  ros2/launch_ros:
++-    hash: ab5db2fba3adc279d632c601ce7772aa78232852
++-    shallow_since: 1621611868 -0700
++-    type: git
++-    url: https://github.com/ros2/launch_ros.git
++-    version: 0.8.10
++-  ros2/libyaml_vendor:
++-    hash: c69f385ebb8c971b9bdd2a87fc983c5a12b12811
++-    shallow_since: 1529963667 -0700
++-    type: git
++-    url: https://github.com/ros2/libyaml_vendor.git
++-    version: 1.0.0
++-  ros2/message_filters:
++-    hash: 3d83c63fdcaf9263a5048a36e0573cc1cae11ed0
++-    shallow_since: 1575565019 -0500
++-    type: git
++-    url: https://github.com/ros2/message_filters.git
++-    version: 3.1.3
++-  ros2/orocos_kinematics_dynamics:
++-    hash: 65a38d304bc1d820160b263fe831aa17e0067a37
++-    shallow_since: 1594440803 -0400
++-    type: git
++-    url: https://github.com/ros2/orocos_kinematics_dynamics.git
++-    version: 3.2.2
++-  ros2/poco_vendor:
++-    hash: 6610e1fb283f566047077e25f34d55040f592900
++-    shallow_since: 1606249257 -0800
++-    type: git
++-    url: https://github.com/ros2/poco_vendor.git
++-    version: 1.2.1
++-  ros2/rcl:
++-    hash: f28fd0d5ee8e13a4955dbe84bd336eeee7e2be5d
++-    shallow_since: 1621608437 -0700
++-    type: git
++-    url: https://github.com/ros2/rcl.git
++-    version: 0.7.10
++-  ros2/rcl_interfaces:
++-    hash: bfa9c43dd7d8cfc5c6fcba8a164d8ef317a386d7
++-    shallow_since: 1559174983 -0700
++-    type: git
++-    url: https://github.com/ros2/rcl_interfaces.git
++-    version: 0.7.4
++-  ros2/rcl_logging:
++-    hash: 6b1880038fed2893557c931a202c16b974637e42
++-    shallow_since: 1557360130 -0500
++-    type: git
++-    url: https://github.com/ros2/rcl_logging.git
++-    version: 0.2.1
++-  ros2/rclcpp:
++-    hash: 403aac966271132feadffca93dcfb24f6ab90efb
++-    shallow_since: 1621608557 -0700
++-    type: git
++-    url: https://github.com/ros2/rclcpp.git
++-    version: 0.7.16
++-  ros2/rclpy:
++-    hash: 17576a7cc760bb3a0d04aa31832263766938a943
++-    shallow_since: 1594440478 -0400
++-    type: git
++-    url: https://github.com/ros2/rclpy.git
++-    version: 0.7.11
++-  ros2/rcpputils:
++-    hash: f8e638eb72bfbacea18ca1cf67c4f7d48561d9b2
++-    shallow_since: 1564532092 -0700
++-    type: git
++-    url: https://github.com/ros2/rcpputils.git
++-    version: 0.1.1
++-  ros2/rcutils:
++-    hash: f868e5cb0eaeb9ae9fc984f6783922f375411007
++-    shallow_since: 1606260966 -0800
++-    type: git
++-    url: https://github.com/ros2/rcutils.git
++-    version: 0.7.6
++-  ros2/realtime_support:
++-    hash: d9c7f16613d1a5a848df1beff71531d61269fd19
++-    shallow_since: 1557363033 -0700
++-    type: git
++-    url: https://github.com/ros2/realtime_support.git
++-    version: 0.7.1
++-  ros2/rmw:
++-    hash: 8652949435267cdf0fd65368f621146dea9a85eb
++-    shallow_since: 1560370615 +0000
++-    type: git
++-    url: https://github.com/ros2/rmw.git
++-    version: 0.7.2
++-  ros2/rmw_connext:
++-    hash: ecb25fd543140f91e05d92720c34db1e3cb16b72
++-    shallow_since: 1606260513 -0800
++-    type: git
++-    url: https://github.com/ros2/rmw_connext.git
++-    version: 0.7.6
++-  ros2/rmw_cyclonedds:
++-    hash: 10b042d490e13ce0faf4971f92862c687cbe28f5
++-    shallow_since: 1600186908 -0500
++-    type: git
++-    url: https://github.com/ros2/rmw_cyclonedds.git
++-    version: de-0.7.0
++-  ros2/rmw_fastrtps:
++-    hash: 32a121a8c8d28cfe811d5179dd8bb1a75c48446b
++-    shallow_since: 1606260572 -0800
++-    type: git
++-    url: https://github.com/ros2/rmw_fastrtps.git
++-    version: 0.7.8
++-  ros2/rmw_implementation:
++-    hash: 9e3db8cf64e001a7ca8d20384ec32196f0a4d3cb
++-    shallow_since: 1576015315 -0500
++-    type: git
++-    url: https://github.com/ros2/rmw_implementation.git
++-    version: 0.7.2
++-  ros2/rmw_opensplice:
++-    hash: 824cfa4eec27be2d3fe14607e33d3b879cf7361c
++-    shallow_since: 1564620663 -0700
++-    type: git
++-    url: https://github.com/ros2/rmw_opensplice.git
++-    version: 0.7.3
++-  ros2/robot_state_publisher:
++-    hash: 64b5186fa6cbb694881ffe095f20fdb2cf324893
++-    shallow_since: 1575470809 -0800
++-    type: git
++-    url: https://github.com/ros/robot_state_publisher.git
++-    version: 2.2.5
++-  ros2/ros1_bridge:
++-    hash: 4677180c266bacb42dae6d606696efcf884928fd
++-    shallow_since: 1621613690 -0700
++-    type: git
++-    url: https://github.com/ros2/ros1_bridge.git
++-    version: 0.7.9
++-  ros2/ros2cli:
++-    hash: 8ff79e6cfc88a8d973c854a6709404eed6db47e0
++-    shallow_since: 1594441053 -0400
++-    type: git
++-    url: https://github.com/ros2/ros2cli.git
++-    version: 0.7.11
++-  ros2/ros_testing:
++-    hash: 87bef75b05c5e63e55e469e9560ad40f02c5bf2f
++-    shallow_since: 1571099941 -0400
++-    type: git
++-    url: https://github.com/ros2/ros_testing.git
++-    version: 0.1.1
++-  ros2/rosbag2:
++-    hash: 17581ca8430fb4e5d1611dde5e5ab161608b876b
++-    shallow_since: 1571244036 -0700
++-    type: git
++-    url: https://github.com/ros2/rosbag2.git
++-    version: 0.1.8
++-  ros2/rosidl:
++-    hash: 407b652ac8ca23beea2f1f24575dd57f0c9b4401
++-    shallow_since: 1606259638 -0800
++-    type: git
++-    url: https://github.com/ros2/rosidl.git
++-    version: 0.7.10
++-  ros2/rosidl_dds:
++-    hash: e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc
++-    shallow_since: 1557357026 -0500
++-    type: git
++-    url: https://github.com/ros2/rosidl_dds.git
++-    version: 0.7.1
++-  ros2/rosidl_defaults:
++-    hash: 926ce4d8f460fd8d7bb8c25544c2ebe294e691c1
++-    shallow_since: 1555243629 -0700
++-    type: git
++-    url: https://github.com/ros2/rosidl_defaults.git
++-    version: 0.7.0
++-  ros2/rosidl_python:
++-    hash: cbeb677f0afe54d2b5215ded894a27a80b6f7111
++-    shallow_since: 1606260003 -0800
++-    type: git
++-    url: https://github.com/ros2/rosidl_python.git
++-    version: 0.7.11
++-  ros2/rosidl_typesupport:
++-    hash: 38eb801f1f856a503676bb79875786b3a3b6d92d
++-    shallow_since: 1557357026 -0700
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport.git
++-    version: 0.7.1
++-  ros2/rosidl_typesupport_connext:
++-    hash: 852ac9a3da81e07befc4718414ca220930c39b93
++-    shallow_since: 1575569008 -0800
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_connext.git
++-    version: 0.7.3
++-  ros2/rosidl_typesupport_fastrtps:
++-    hash: 1482ec5a129d0a28a882df9335b85ec10a961c98
++-    shallow_since: 1606249600 -0800
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
++-    version: 0.7.2
++-  ros2/rosidl_typesupport_opensplice:
++-    hash: 4ad5520055199ed3b011834575db16a08c599070
++-    shallow_since: 1567520741 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
++-    version: 0.7.3
++-  ros2/rviz:
++-    hash: 693da2000dce463e4ddfc95caf9a30e2d4f24790
++-    shallow_since: 1621612242 -0700
++-    type: git
++-    url: https://github.com/ros2/rviz.git
++-    version: 6.1.8
++-  ros2/sros2:
++-    hash: f2ef72ad51cbe6c1254a7cf21ab12dc6b021356d
++-    shallow_since: 1592379751 +0200
++-    type: git
++-    url: https://github.com/ros2/sros2.git
++-    version: 0.7.2
++-  ros2/system_tests:
++-    hash: 0481d6bef4474b69afa45cc7ad3bd999e7fe6441
++-    shallow_since: 1564619935 -0700
++-    type: git
++-    url: https://github.com/ros2/system_tests.git
++-    version: 0.7.2
++-  ros2/test_interface_files:
++-    hash: a5dc898842fa23f3635298f140e97081a086d3e4
++-    shallow_since: 1559172037 -0700
++-    type: git
++-    url: https://github.com/ros2/test_interface_files.git
++-    version: 0.7.1
++-  ros2/tinydir_vendor:
++-    hash: 607fa785024557a756e60eae21b4dc9706136f81
++-    shallow_since: 1555254620 -0700
++-    type: git
++-    url: https://github.com/ros2/tinydir_vendor.git
++-    version: 1.1.0
++-  ros2/tinyxml2_vendor:
++-    hash: d0097aa9a8c2aa5990773dd81eb8b20d13d9fcf0
++-    shallow_since: 1547593812 -0800
++-    type: git
++-    url: https://github.com/ros2/tinyxml2_vendor.git
++-    version: 0.6.1
++-  ros2/tinyxml_vendor:
++-    hash: 3caa00bc33a5462e91eb5d44486ca3be4feaf62d
++-    shallow_since: 1554995391 -0700
++-    type: git
++-    url: https://github.com/ros2/tinyxml_vendor.git
++-    version: 0.7.0
++-  ros2/tlsf:
++-    hash: 1c4a13c3f76f79ce9f2a049a8b01cafbff775d4d
++-    shallow_since: 1529976968 +0000
++-    type: git
++-    url: https://github.com/ros2/tlsf.git
++-    version: 0.5.0
++-  ros2/unique_identifier_msgs:
++-    hash: 56c6f47aec363d47c66add1bb597db6cdaffc5d0
++-    shallow_since: 1587859523 -0700
++-    type: git
++-    url: https://github.com/ros2/unique_identifier_msgs.git
++-    version: 2.1.1
++-  ros2/urdf:
++-    hash: 9704679cf21e5b233df420f0cfb6dffab1741c42
++-    shallow_since: 1542738402 -0800
++-    type: git
++-    url: https://github.com/ros2/urdf.git
++-    version: 2.2.0
++-  ros2/urdfdom:
++-    hash: c7564771beb260fa7adaa7d584029811c40def1d
++-    shallow_since: 1555252035 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom.git
++-    version: 2.2.0
++-  ros2/yaml_cpp_vendor:
++-    hash: de4aa5e463e0549f688164b2bce8a4258766c614
++-    shallow_since: 1557352789 -0500
++-    type: git
++-    url: https://github.com/ros2/yaml_cpp_vendor.git
++-    version: 6.0.1
++diff --git a/repos/config/ros2_eloquent.lock b/repos/config/ros2_eloquent.lock
++deleted file mode 100644
++index 22a160e..0000000
++--- a/repos/config/ros2_eloquent.lock
+++++ /dev/null
++@@ -1,574 +0,0 @@
++-#
++-#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
++-#
++-repositories:
++-  ament/ament_cmake:
++-    hash: df62bb6bff09e39898bae0ddee2389d5b3524370
++-    shallow_since: 1606757242 +0000
++-    type: git
++-    url: https://github.com/ament/ament_cmake.git
++-    version: 0.8.3
++-  ament/ament_index:
++-    hash: 9d42ba13d7694ad8da5b1622e433e691996c4502
++-    shallow_since: 1571244457 -0700
++-    type: git
++-    url: https://github.com/ament/ament_index.git
++-    version: 0.7.2
++-  ament/ament_lint:
++-    hash: bc096819e71ae57c6740da02d1d74865ee009bb3
++-    shallow_since: 1607115033 -0600
++-    type: git
++-    url: https://github.com/ament/ament_lint.git
++-    version: 0.8.2
++-  ament/ament_package:
++-    hash: 9d245a3b2209fee71683973f1ba5e575acbf6e5a
++-    shallow_since: 1591381489 -0700
++-    type: git
++-    url: https://github.com/ament/ament_package.git
++-    version: 0.8.9
++-  ament/googletest:
++-    hash: 7e47d9759e8cd03322e5e19b451f44121dde98e2
++-    shallow_since: 1557357092 -0700
++-    type: git
++-    url: https://github.com/ament/googletest.git
++-    version: 1.8.9000
++-  ament/uncrustify_vendor:
++-    hash: 8d4f07a4bdf1c0d8a5aab3eb450d0a15de3e6f1e
++-    shallow_since: 1568741617 -0400
++-    type: git
++-    url: https://github.com/ament/uncrustify_vendor.git
++-    version: 1.3.0
++-  eProsima/Fast-CDR:
++-    hash: cc27c2490b694e97ca1bbcc169172fd63209bb90
++-    shallow_since: 1566903518 +0200
++-    type: git
++-    url: https://github.com/eProsima/Fast-CDR.git
++-    version: v1.0.11
++-  eProsima/Fast-DDS:
++-    hash: b5ae9e9c9ea7ce49c64c0ef3f6c96a3dc563b16f
++-    shallow_since: 1573725955 +0100
++-    type: git
++-    url: https://github.com/eProsima/Fast-DDS.git
++-    version: v1.9.3
++-  eProsima/foonathan_memory_vendor:
++-    hash: 017ff0bdfd2c93930bf525a01f8663a032337a14
++-    shallow_since: 1569302929 +0200
++-    type: git
++-    url: https://github.com/eProsima/foonathan_memory_vendor.git
++-    version: v0.3.0
++-  eclipse-cyclonedds/cyclonedds:
++-    hash: c261053186c455abc63ca5ac7d56c0808a59c364
++-    shallow_since: 1596471565 +0200
++-    type: git
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds.git
++-    version: 0.7.0
++-  osrf/osrf_pycommon:
++-    hash: 0511d7b120048b826ff60465ba7532d332654b8c
++-    shallow_since: 1570737268 -0700
++-    type: git
++-    url: https://github.com/osrf/osrf_pycommon.git
++-    version: 0.1.9
++-  osrf/osrf_testing_tools_cpp:
++-    hash: ec743ff827473493d1437fdb0b477c6aa2fe7f17
++-    shallow_since: 1584498799 -0400
++-    type: git
++-    url: https://github.com/osrf/osrf_testing_tools_cpp.git
++-    version: 1.2.2
++-  ros-perception/laser_geometry:
++-    hash: a615644c770006e66e4a78e4ed9107be5911790f
++-    shallow_since: 1580948914 -0800
++-    type: git
++-    url: https://github.com/ros-perception/laser_geometry.git
++-    version: 2.1.1
++-  ros-planning/navigation_msgs:
++-    hash: fe880e99d993e9d4dfbf37f00d839d32994610e1
++-    shallow_since: 1569867654 -0500
++-    type: git
++-    url: https://github.com/ros-planning/navigation_msgs.git
++-    version: 2.0.2
++-  ros-tracing/ros2_tracing:
++-    hash: 5cd2298545f9c1333126db0aaefd516eae17b141
++-    shallow_since: 1575926311 -0800
++-    type: git
++-    url: https://gitlab.com/ros-tracing/ros2_tracing.git
++-    version: 0.2.12
++-  ros-visualization/interactive_markers:
++-    hash: 674d15927caf41684833ec1f843cbb03781f148a
++-    shallow_since: 1571889026 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/interactive_markers.git
++-    version: 2.0.1
++-  ros-visualization/python_qt_binding:
++-    hash: 4ea84276fca25ef625e71bf1541716b17de10c71
++-    shallow_since: 1573609579 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/python_qt_binding.git
++-    version: 1.0.3
++-  ros-visualization/qt_gui_core:
++-    hash: 5de77352b48ff5724e521cac19bfdfad0b7a1aa8
++-    shallow_since: 1569880852 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/qt_gui_core.git
++-    version: 1.0.7
++-  ros-visualization/rqt:
++-    hash: f549803a6b3129b58e133e7fd19de7a4c1b9357f
++-    shallow_since: 1569885985 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt.git
++-    version: 1.0.5
++-  ros-visualization/rqt_action:
++-    hash: d6842bea658ecbcb83115c9bffe89bcf16a4b566
++-    shallow_since: 1551809854 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_action.git
++-    version: 1.0.1
++-  ros-visualization/rqt_console:
++-    hash: addd6b251018aa66b4e5cc53d9c8e66d27f3eb06
++-    shallow_since: 1579042396 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_console.git
++-    version: 1.1.1
++-  ros-visualization/rqt_graph:
++-    hash: 22952ef7604ed76f573cfae896c96c435203339a
++-    shallow_since: 1578336197 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_graph.git
++-    version: 1.0.4
++-  ros-visualization/rqt_msg:
++-    hash: 5e9a8b02dc02039761bc5558adff130bdfb4e495
++-    shallow_since: 1557445337 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_msg.git
++-    version: 1.0.2
++-  ros-visualization/rqt_plot:
++-    hash: 986a95854601f2f1774a5d14c5de22a37f7e64ba
++-    shallow_since: 1570132866 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_plot.git
++-    version: 1.0.7
++-  ros-visualization/rqt_publisher:
++-    hash: 565ffc81069fe1ab53e5230d98be20cb95c6bea3
++-    shallow_since: 1570130261 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_publisher.git
++-    version: 1.1.0
++-  ros-visualization/rqt_py_console:
++-    hash: 359e33589e9c0dbe9861120250a0a67d43e92503
++-    shallow_since: 1544572306 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_py_console.git
++-    version: 1.0.0
++-  ros-visualization/rqt_reconfigure:
++-    hash: b5a9516b1fc365f7d2ca07991b69ea7d4585a553
++-    shallow_since: 1570742618 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_reconfigure.git
++-    version: 1.0.4
++-  ros-visualization/rqt_service_caller:
++-    hash: 23a8213d750a25a555d8a4a18179063323188eb5
++-    shallow_since: 1559173297 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_service_caller.git
++-    version: 1.0.3
++-  ros-visualization/rqt_shell:
++-    hash: 56d240dddecadcd546d2638362533ef99f7c4e6b
++-    shallow_since: 1544582027 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_shell.git
++-    version: 1.0.0
++-  ros-visualization/rqt_srv:
++-    hash: 0126ee3040f94392ed626b489c44a25a694fc7e9
++-    shallow_since: 1544645384 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_srv.git
++-    version: 1.0.1
++-  ros-visualization/rqt_top:
++-    hash: af56baacaa26c23b13d3fc9713cb269199d9b557
++-    shallow_since: 1544596207 -0700
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_top.git
++-    version: 1.0.0
++-  ros-visualization/rqt_topic:
++-    hash: 2c83d5ad83322644495fc58d614dd2f07516a153
++-    shallow_since: 1573673433 -0800
++-    type: git
++-    url: https://github.com/ros-visualization/rqt_topic.git
++-    version: 1.1.0
++-  ros/class_loader:
++-    hash: a7d2aadb4be603f54ded1d4f2fcd6e7c3622a16b
++-    shallow_since: 1579291969 +0000
++-    type: git
++-    url: https://github.com/ros/class_loader.git
++-    version: 1.4.1
++-  ros/kdl_parser:
++-    hash: b3e9446f4af182fb499a07798a8b85de53677da7
++-    shallow_since: 1595362350 -0500
++-    type: git
++-    url: https://github.com/ros/kdl_parser.git
++-    version: 2.2.1
++-  ros/pluginlib:
++-    hash: 6eca7691d046a060f24bb61ab380fa30d86fe621
++-    shallow_since: 1607115839 -0600
++-    type: git
++-    url: https://github.com/ros/pluginlib.git
++-    version: 2.4.2
++-  ros/resource_retriever:
++-    hash: 6cebdc0214a71662e9e5618515ed9dea94cd91fc
++-    shallow_since: 1575563397 -0500
++-    type: git
++-    url: https://github.com/ros/resource_retriever.git
++-    version: 2.2.1
++-  ros/robot_state_publisher:
++-    hash: 772a88a4c8cf973bf4bcf36276db32b2c75a8113
++-    shallow_since: 1571873830 -0700
++-    type: git
++-    url: https://github.com/ros/robot_state_publisher.git
++-    version: 2.3.1
++-  ros/ros_environment:
++-    hash: a0f400cfdf148298431cdc0323abc0908f310c09
++-    shallow_since: 1571870538 -0700
++-    type: git
++-    url: https://github.com/ros/ros_environment.git
++-    version: 2.4.1
++-  ros/ros_tutorials:
++-    hash: 519752af99a54a466d30cb31509c346e68f54c01
++-    shallow_since: 1573609159 -0800
++-    type: git
++-    url: https://github.com/ros/ros_tutorials.git
++-    version: 1.1.0
++-  ros/urdfdom:
++-    hash: c7564771beb260fa7adaa7d584029811c40def1d
++-    shallow_since: 1555252035 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom.git
++-    version: 2.2.0
++-  ros/urdfdom_headers:
++-    hash: 00c1c9c231e46b2300d04073ad696521758fa45c
++-    shallow_since: 1558394923 -0700
++-    type: git
++-    url: https://github.com/ros/urdfdom_headers.git
++-    version: 1.0.4
++-  ros2/ament_cmake_ros:
++-    hash: e7c18f52a32e42f8847e65661d0521e5c29238c4
++-    shallow_since: 1569344550 -0500
++-    type: git
++-    url: https://github.com/ros2/ament_cmake_ros.git
++-    version: 0.8.0
++-  ros2/common_interfaces:
++-    hash: 81663c07b93889c3d0afda9b99cd5f1c7c98c1f2
++-    shallow_since: 1571867898 -0700
++-    type: git
++-    url: https://github.com/ros2/common_interfaces.git
++-    version: 0.8.1
++-  ros2/console_bridge_vendor:
++-    hash: d3be808a1b77028a152a8ee5aa56346ce32db987
++-    shallow_since: 1555013045 -0700
++-    type: git
++-    url: https://github.com/ros2/console_bridge_vendor.git
++-    version: 1.2.0
++-  ros2/demos:
++-    hash: e1453fc25f0af51abe5aa6d75f5601f4ab69395c
++-    shallow_since: 1574228657 -0600
++-    type: git
++-    url: https://github.com/ros2/demos.git
++-    version: 0.8.4
++-  ros2/eigen3_cmake_module:
++-    hash: 526c6c745da360fe78fb727aa8a1f6daa8199abd
++-    shallow_since: 1565307940 -0700
++-    type: git
++-    url: https://github.com/ros2/eigen3_cmake_module.git
++-    version: 0.1.1
++-  ros2/example_interfaces:
++-    hash: 5b118347114931620533aba142939b6a1db200bc
++-    shallow_since: 1559174767 -0700
++-    type: git
++-    url: https://github.com/ros2/example_interfaces.git
++-    version: 0.7.1
++-  ros2/examples:
++-    hash: fbab64492748a462f9850db06a905c7b3ca957be
++-    shallow_since: 1607118777 -0600
++-    type: git
++-    url: https://github.com/ros2/examples.git
++-    version: 0.8.3
++-  ros2/geometry2:
++-    hash: a5e46e55e94ffe6420fc9a586c5bf6fb6cdad900
++-    shallow_since: 1607116536 -0600
++-    type: git
++-    url: https://github.com/ros2/geometry2.git
++-    version: 0.12.6
++-  ros2/launch:
++-    hash: 50763edc072b14be1af3d44256fa5b8f2b3eab7a
++-    shallow_since: 1607116772 -0600
++-    type: git
++-    url: https://github.com/ros2/launch.git
++-    version: 0.9.7
++-  ros2/launch_ros:
++-    hash: 07497cd1f6576b7d3aff79a490016d583f9f3dcb
++-    shallow_since: 1607116920 -0600
++-    type: git
++-    url: https://github.com/ros2/launch_ros.git
++-    version: 0.9.6
++-  ros2/libyaml_vendor:
++-    hash: c69f385ebb8c971b9bdd2a87fc983c5a12b12811
++-    shallow_since: 1529963667 -0700
++-    type: git
++-    url: https://github.com/ros2/libyaml_vendor.git
++-    version: 1.0.0
++-  ros2/message_filters:
++-    hash: 0b98d58e175ad93116aedb5782ce7c88f8846f3a
++-    shallow_since: 1574115205 -0800
++-    type: git
++-    url: https://github.com/ros2/message_filters.git
++-    version: 3.2.3
++-  ros2/orocos_kinematics_dynamics:
++-    hash: 1bc436e486c489ef71ff19ef31b807306c29f3bb
++-    shallow_since: 1573658255 -0500
++-    type: git
++-    url: https://github.com/ros2/orocos_kinematics_dynamics.git
++-    version: 3.2.1
++-  ros2/poco_vendor:
++-    hash: 6610e1fb283f566047077e25f34d55040f592900
++-    shallow_since: 1606249257 -0800
++-    type: git
++-    url: https://github.com/ros2/poco_vendor.git
++-    version: 1.2.1
++-  ros2/python_cmake_module:
++-    hash: c212c5e12b7c70baacc58684bb378c0fc8e1be86
++-    shallow_since: 1569264636 +0000
++-    type: git
++-    url: https://github.com/ros2/python_cmake_module.git
++-    version: 0.8.0
++-  ros2/rcl:
++-    hash: f5c01e4e2eb5d8f7fb16321f81815cd4b6b200bd
++-    shallow_since: 1607116198 -0600
++-    type: git
++-    url: https://github.com/ros2/rcl.git
++-    version: 0.8.5
++-  ros2/rcl_interfaces:
++-    hash: 93cedce2dacd25fa4f2969d022ccbe3f2903e3fe
++-    shallow_since: 1569518728 -0500
++-    type: git
++-    url: https://github.com/ros2/rcl_interfaces.git
++-    version: 0.8.0
++-  ros2/rcl_logging:
++-    hash: 3955fc4fc37e46dc397c52cebd3e40732db1157d
++-    shallow_since: 1571871211 +0000
++-    type: git
++-    url: https://github.com/ros2/rcl_logging.git
++-    version: 0.3.3
++-  ros2/rclcpp:
++-    hash: 82202ae71f14fed3a487da90d8f4f74c07c7d1f7
++-    shallow_since: 1607116009 -0600
++-    type: git
++-    url: https://github.com/ros2/rclcpp.git
++-    version: 0.8.5
++-  ros2/rclpy:
++-    hash: 126a9dff544ca8ae82444ad45d65a12a9a6e08f3
++-    shallow_since: 1607119307 -0600
++-    type: git
++-    url: https://github.com/ros2/rclpy.git
++-    version: 0.8.5
++-  ros2/rcpputils:
++-    hash: 33e2edb1dafd9dc1952e7f219c9ceee58905b831
++-    shallow_since: 1573612278 -0800
++-    type: git
++-    url: https://github.com/ros2/rcpputils.git
++-    version: 0.2.1
++-  ros2/rcutils:
++-    hash: ef201364d5af13f74a9c368f271c762326d838be
++-    shallow_since: 1607117730 -0600
++-    type: git
++-    url: https://github.com/ros2/rcutils.git
++-    version: 0.8.5
++-  ros2/realtime_support:
++-    hash: a9534f8638d58d38c57a26fa9a97642e642d3662
++-    shallow_since: 1573652897 -0600
++-    type: git
++-    url: https://github.com/ros2/realtime_support.git
++-    version: 0.8.2
++-  ros2/rmw:
++-    hash: 813b94ddd5650444b312304ad156f3b5d9f05e39
++-    shallow_since: 1571879357 -0700
++-    type: git
++-    url: https://github.com/ros2/rmw.git
++-    version: 0.8.1
++-  ros2/rmw_connext:
++-    hash: 15609cf48bc6d76390f3de2c3a45a245fdfaa7cf
++-    shallow_since: 1607118481 -0600
++-    type: git
++-    url: https://github.com/ros2/rmw_connext.git
++-    version: 0.8.2
++-  ros2/rmw_cyclonedds:
++-    hash: 10b042d490e13ce0faf4971f92862c687cbe28f5
++-    shallow_since: 1600186908 -0500
++-    type: git
++-    url: https://github.com/ros2/rmw_cyclonedds.git
++-    version: de-0.7.0
++-  ros2/rmw_fastrtps:
++-    hash: 0f904a13c6e8b6b32a2cf263d7c4d96a40be0884
++-    shallow_since: 1607118401 -0600
++-    type: git
++-    url: https://github.com/ros2/rmw_fastrtps.git
++-    version: 0.8.2
++-  ros2/rmw_implementation:
++-    hash: bb349e334fbfb665406f090d3f1c0ac7e04404c3
++-    shallow_since: 1573704951 -0500
++-    type: git
++-    url: https://github.com/ros2/rmw_implementation.git
++-    version: 0.8.2
++-  ros2/rmw_opensplice:
++-    hash: 1213249ca15e38225b374ddcacc3e03769f0ec78
++-    shallow_since: 1571891055 -0500
++-    type: git
++-    url: https://github.com/ros2/rmw_opensplice.git
++-    version: 0.8.1
++-  ros2/ros1_bridge:
++-    hash: b5e4931cefce6cc3351b31b04b0399a6d3bacac4
++-    shallow_since: 1607538853 +0000
++-    type: git
++-    url: https://github.com/ros2/ros1_bridge.git
++-    version: 0.8.3
++-  ros2/ros2cli:
++-    hash: 5d5b855369085d02631bc5bdd6ffb7fae680eb5b
++-    shallow_since: 1607117614 -0600
++-    type: git
++-    url: https://github.com/ros2/ros2cli.git
++-    version: 0.8.8
++-  ros2/ros_testing:
++-    hash: c06a59a3826a61884f2c8cdcd8c5a66c104192be
++-    shallow_since: 1569529607 +0000
++-    type: git
++-    url: https://github.com/ros2/ros_testing.git
++-    version: 0.2.0
++-  ros2/rosbag2:
++-    hash: 2b41ea40717b9228c0b736b6ea247799a0cf369e
++-    shallow_since: 1574128275 -0800
++-    type: git
++-    url: https://github.com/ros2/rosbag2.git
++-    version: 0.2.4
++-  ros2/rosidl:
++-    hash: 5f79cdcb7830999b527c2370b4397a3cc587374a
++-    shallow_since: 1607117948 -0600
++-    type: git
++-    url: https://github.com/ros2/rosidl.git
++-    version: 0.8.3
++-  ros2/rosidl_dds:
++-    hash: e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc
++-    shallow_since: 1557357026 -0500
++-    type: git
++-    url: https://github.com/ros2/rosidl_dds.git
++-    version: 0.7.1
++-  ros2/rosidl_defaults:
++-    hash: 94a24327f83e624eff5eb45ec675a53d534b3ffb
++-    shallow_since: 1569521531 -0500
++-    type: git
++-    url: https://github.com/ros2/rosidl_defaults.git
++-    version: 0.8.0
++-  ros2/rosidl_python:
++-    hash: 7adf415f0461f1c70db0c52802895ec700569ced
++-    shallow_since: 1607119114 -0600
++-    type: git
++-    url: https://github.com/ros2/rosidl_python.git
++-    version: 0.8.2
++-  ros2/rosidl_runtime_py:
++-    hash: fc2ea02f857d6a8faa9bc7fd658220801cbf5748
++-    shallow_since: 1573249219 -0600
++-    type: git
++-    url: https://github.com/ros2/rosidl_runtime_py.git
++-    version: 0.8.2
++-  ros2/rosidl_typesupport:
++-    hash: b51759ea94bfdc58afc8831d4c847c5891d14bc3
++-    shallow_since: 1607118075 -0600
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport.git
++-    version: 0.8.1
++-  ros2/rosidl_typesupport_connext:
++-    hash: d38c0b61db924f8c0cc3d95334463849af539cb8
++-    shallow_since: 1607118949 -0600
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_connext.git
++-    version: 0.8.5
++-  ros2/rosidl_typesupport_fastrtps:
++-    hash: b1d037b2f589ac78443f892d77f610a96c5f3e96
++-    shallow_since: 1569446233 +0000
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps.git
++-    version: 0.8.0
++-  ros2/rosidl_typesupport_opensplice:
++-    hash: 23274d5cb4db102b153eee7366a394acb3eee38c
++-    shallow_since: 1570210077 -0700
++-    type: git
++-    url: https://github.com/ros2/rosidl_typesupport_opensplice.git
++-    version: 0.8.1
++-  ros2/rviz:
++-    hash: bd652f5e87d4cfad30bdc5457ab61c4286e8c85e
++-    shallow_since: 1606942491 +0000
++-    type: git
++-    url: https://github.com/ros2/rviz.git
++-    version: 7.0.7
++-  ros2/spdlog_vendor:
++-    hash: d78e5c8fa8cf87d0db0056e752b292f316e17929
++-    shallow_since: 1570123657 +0000
++-    type: git
++-    url: https://github.com/ros2/spdlog_vendor.git
++-    version: 1.0.1
++-  ros2/sros2:
++-    hash: aa15b4addd9a3b7c3fa45f82ad71407965fdb897
++-    shallow_since: 1592334052 +0200
++-    type: git
++-    url: https://github.com/ros2/sros2.git
++-    version: 0.8.2
++-  ros2/system_tests:
++-    hash: 1a54cb2a6c554ca89ff5a00af412cd552b84e243
++-    shallow_since: 1574294136 -0600
++-    type: git
++-    url: https://github.com/ros2/system_tests.git
++-    version: 0.8.0
++-  ros2/test_interface_files:
++-    hash: c4d710e3394ad09a71a257f5490688653fb441b3
++-    shallow_since: 1569343508 -0500
++-    type: git
++-    url: https://github.com/ros2/test_interface_files.git
++-    version: 0.8.0
++-  ros2/tinydir_vendor:
++-    hash: 9f1c63bc38b2928946fcc427a404faa4cacaeebb
++-    shallow_since: 1573612773 -0800
++-    type: git
++-    url: https://github.com/ros2/tinydir_vendor.git
++-    version: 1.1.1
++-  ros2/tinyxml2_vendor:
++-    hash: d0097aa9a8c2aa5990773dd81eb8b20d13d9fcf0
++-    shallow_since: 1547593812 -0800
++-    type: git
++-    url: https://github.com/ros2/tinyxml2_vendor.git
++-    version: 0.6.1
++-  ros2/tinyxml_vendor:
++-    hash: 3caa00bc33a5462e91eb5d44486ca3be4feaf62d
++-    shallow_since: 1554995391 -0700
++-    type: git
++-    url: https://github.com/ros2/tinyxml_vendor.git
++-    version: 0.7.0
++-  ros2/tlsf:
++-    hash: 1c4a13c3f76f79ce9f2a049a8b01cafbff775d4d
++-    shallow_since: 1529976968 +0000
++-    type: git
++-    url: https://github.com/ros2/tlsf.git
++-    version: 0.5.0
++-  ros2/unique_identifier_msgs:
++-    hash: 56c6f47aec363d47c66add1bb597db6cdaffc5d0
++-    shallow_since: 1587859523 -0700
++-    type: git
++-    url: https://github.com/ros2/unique_identifier_msgs.git
++-    version: 2.1.1
++-  ros2/urdf:
++-    hash: 9704679cf21e5b233df420f0cfb6dffab1741c42
++-    shallow_since: 1542738402 -0800
++-    type: git
++-    url: https://github.com/ros2/urdf.git
++-    version: 2.2.0
++-  ros2/yaml_cpp_vendor:
++-    hash: 54feb9dfcf88c6925ee16aed4d5d7eda1eea946c
++-    shallow_since: 1568908683 -0500
++-    type: git
++-    url: https://github.com/ros2/yaml_cpp_vendor.git
++-    version: 7.0.0
++diff --git a/repos/config/ros2_foxy.lock b/repos/config/ros2_foxy.lock
++deleted file mode 100644
++index 5a853da..0000000
++--- a/repos/config/ros2_foxy.lock
+++++ /dev/null
++@@ -1,598 +0,0 @@
++-#
++-#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
++-#
++-repositories:
++-  ament/ament_cmake:
++-    hash: cc47e150f5a278d0e6f3dd3748732bfaf944ac3d30ff53c71195f9bda9895c6e
++-    strip_prefix: ament_cmake-0.9.12
++-    type: http_archive
++-    url: https://github.com/ament/ament_cmake/archive/refs/tags/0.9.12.tar.gz
++-    version: 0.9.12
++-  ament/ament_index:
++-    hash: a3d2342039d3f8270ce910f13c087f4cc05fad16fa5ff28d874a15b3b5b345b6
++-    strip_prefix: ament_index-1.1.0
++-    type: http_archive
++-    url: https://github.com/ament/ament_index/archive/refs/tags/1.1.0.tar.gz
++-    version: 1.1.0
++-  ament/ament_lint:
++-    hash: e5f8b11691bc296aff8be0c46370c92e7cd1b6162603ee7990c2bb23d93309db
++-    strip_prefix: ament_lint-0.9.8
++-    type: http_archive
++-    url: https://github.com/ament/ament_lint/archive/refs/tags/0.9.8.tar.gz
++-    version: 0.9.8
++-  ament/ament_package:
++-    hash: 634fca3becf9567a36e9bc967cbd5189eed25604723f30b1c69273c111f36b1a
++-    strip_prefix: ament_package-0.9.5
++-    type: http_archive
++-    url: https://github.com/ament/ament_package/archive/refs/tags/0.9.5.tar.gz
++-    version: 0.9.5
++-  ament/google_benchmark_vendor:
++-    hash: b254da85b1c58a371a38e8342aa65bd3b00a4e2ef432a8ab6553eba5048106e7
++-    strip_prefix: google_benchmark_vendor-0.0.3
++-    type: http_archive
++-    url: https://github.com/ament/google_benchmark_vendor/archive/refs/tags/0.0.3.tar.gz
++-    version: 0.0.3
++-  ament/googletest:
++-    hash: 829df71f77d678b15456ebb41dcf38dacf2b1621e1e40abcfcdd4ad26b985720
++-    strip_prefix: googletest-1.8.9001
++-    type: http_archive
++-    url: https://github.com/ament/googletest/archive/refs/tags/1.8.9001.tar.gz
++-    version: 1.8.9001
++-  ament/uncrustify_vendor:
++-    hash: 38f0a52ab917900d81c21d7ff6b2a4f7b44bfe896f4e0e7b6aea96795610b917
++-    strip_prefix: uncrustify_vendor-1.4.0
++-    type: http_archive
++-    url: https://github.com/ament/uncrustify_vendor/archive/refs/tags/1.4.0.tar.gz
++-    version: 1.4.0
++-  eProsima/Fast-CDR:
++-    hash: e4a2e545703fbc33174daa352d2f0f2973cd00c06c17b87f67c4f139f36dc9dd
++-    strip_prefix: Fast-CDR-1.0.13
++-    type: http_archive
++-    url: https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.13.tar.gz
++-    version: v1.0.13
++-  eProsima/Fast-DDS:
++-    hash: 38aafd12e4defba7ebcb08bcf15674325bbb69c9cf2e93bd0f56c95d78a761ea
++-    strip_prefix: Fast-DDS-2.1.3
++-    type: http_archive
++-    url: https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.1.3.tar.gz
++-    version: v2.1.3
++-  eProsima/foonathan_memory_vendor:
++-    hash: b10278c877e274fe751b4b3eebeefabc34efe264c28850d05f1c22b310a84562
++-    strip_prefix: foonathan_memory_vendor-1.2.0
++-    type: http_archive
++-    url: https://github.com/eProsima/foonathan_memory_vendor/archive/refs/tags/v1.2.0.tar.gz
++-    version: v1.2.0
++-  eclipse-cyclonedds/cyclonedds:
++-    hash: ff3a8545c78c0019014bbb906da2f44184e919a4f9985995014a0b08238d86e5
++-    strip_prefix: cyclonedds-0.7.0
++-    type: http_archive
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.7.0.tar.gz
++-    version: 0.7.0
++-  osrf/osrf_pycommon:
++-    hash: 79ecd4c267e2eb0effd376528226581d66cbdb81daa1d8b78c81bb0007b21c69
++-    strip_prefix: osrf_pycommon-0.1.11
++-    type: http_archive
++-    url: https://github.com/osrf/osrf_pycommon/archive/refs/tags/0.1.11.tar.gz
++-    version: 0.1.11
++-  osrf/osrf_testing_tools_cpp:
++-    hash: c62f1b5d392773a4661429d2f3163858af6a5cc3892b5933513f004890109b02
++-    strip_prefix: osrf_testing_tools_cpp-1.3.4
++-    type: http_archive
++-    url: https://github.com/osrf/osrf_testing_tools_cpp/archive/refs/tags/1.3.4.tar.gz
++-    version: 1.3.4
++-  ros-perception/laser_geometry:
++-    hash: 387c30d258f23c2c76884b7517d318b1f4dd9ccb4cf5de825833b4bede0c7ddb
++-    strip_prefix: laser_geometry-2.2.0
++-    type: http_archive
++-    url: https://github.com/ros-perception/laser_geometry/archive/refs/tags/2.2.0.tar.gz
++-    version: 2.2.0
++-  ros-planning/navigation_msgs:
++-    hash: 121d024c6fe421c0f8af725cf3fbb0ca3ef305abb712f094b4a1c22b1369d103
++-    strip_prefix: navigation_msgs-2.0.2
++-    type: http_archive
++-    url: https://github.com/ros-planning/navigation_msgs/archive/refs/tags/2.0.2.tar.gz
++-    version: 2.0.2
++-  ros-tooling/libstatistics_collector:
++-    hash: 3f8fbc7839e3c08b66110b37117e4f54aaf7b7772082580fb1598098590d0a9e
++-    strip_prefix: libstatistics_collector-1.0.2
++-    type: http_archive
++-    url: https://github.com/ros-tooling/libstatistics_collector/archive/refs/tags/1.0.2.tar.gz
++-    version: 1.0.2
++-  ros-visualization/interactive_markers:
++-    hash: acd0d8f9bd8e320354975cb708196260975cce81d11c52d0de0d6f2c1b574a24
++-    strip_prefix: interactive_markers-2.1.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/interactive_markers/archive/refs/tags/2.1.3.tar.gz
++-    version: 2.1.3
++-  ros-visualization/python_qt_binding:
++-    hash: df703274415a231bffe87f394c17e6da08c1ef8b0a495dbad24e15f265993251
++-    strip_prefix: python_qt_binding-1.0.6
++-    type: http_archive
++-    url: https://github.com/ros-visualization/python_qt_binding/archive/refs/tags/1.0.6.tar.gz
++-    version: 1.0.6
++-  ros-visualization/qt_gui_core:
++-    hash: fa30a9bb3bc141e593fc4d4d0e14bae9e429d8b094b5135b52eb715d53e04e10
++-    strip_prefix: qt_gui_core-1.1.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/qt_gui_core/archive/refs/tags/1.1.3.tar.gz
++-    version: 1.1.3
++-  ros-visualization/rqt:
++-    hash: 35c1f18e923d55e0b95fa13def53e092e6b39982679752267dbbd3684f0a3137
++-    strip_prefix: rqt-1.1.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt/archive/refs/tags/1.1.2.tar.gz
++-    version: 1.1.2
++-  ros-visualization/rqt_action:
++-    hash: dc67ca6ea25dd82540fd4fe1e9d9abd6bff8b50c97455d746a64b99046fb4c46
++-    strip_prefix: rqt_action-1.0.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_action/archive/refs/tags/1.0.2.tar.gz
++-    version: 1.0.2
++-  ros-visualization/rqt_console:
++-    hash: 1073cc0173fc9be9fc3f015fdc55ec6fe97a5aff3809496ef93e8421afffcc1c
++-    strip_prefix: rqt_console-1.1.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_console/archive/refs/tags/1.1.2.tar.gz
++-    version: 1.1.2
++-  ros-visualization/rqt_graph:
++-    hash: 1432db629ebad3b9bfee458a5c73171ff12a494d6724dae99b867a1cf992a069
++-    strip_prefix: rqt_graph-1.1.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_graph/archive/refs/tags/1.1.3.tar.gz
++-    version: 1.1.3
++-  ros-visualization/rqt_msg:
++-    hash: fd459c93e822d41916edc9b1c55017f6f462b9db1868db2e8eeeabe90d62572c
++-    strip_prefix: rqt_msg-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_msg/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/rqt_plot:
++-    hash: 3728fb1b694e4ea7c5458cfca308195b8de0fee31f85c5839ce5c52166f9ddd0
++-    strip_prefix: rqt_plot-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_plot/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/rqt_publisher:
++-    hash: 6165c7893bf9df8497e0b26c02ba3bd9ed7c61f79c89b5fc8a57f13f88aa217b
++-    strip_prefix: rqt_publisher-1.3.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_publisher/archive/refs/tags/1.3.0.tar.gz
++-    version: 1.3.0
++-  ros-visualization/rqt_py_console:
++-    hash: 1cb589b7c2b6bb445eef1cbfdceedd8d517b2f9d1b8cb2f22a767d612cba40b6
++-    strip_prefix: rqt_py_console-1.0.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_py_console/archive/refs/tags/1.0.2.tar.gz
++-    version: 1.0.2
++-  ros-visualization/rqt_reconfigure:
++-    hash: 2be8f32eeab024c32d452795a91957c72eb662e5930b77f60daaf4d0ed354fa7
++-    strip_prefix: rqt_reconfigure-1.0.8
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_reconfigure/archive/refs/tags/1.0.8.tar.gz
++-    version: 1.0.8
++-  ros-visualization/rqt_service_caller:
++-    hash: 5e3802f444b50594f3a7dc80977286609b88a50f1ad77f9208e45911889ae825
++-    strip_prefix: rqt_service_caller-1.0.5
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_service_caller/archive/refs/tags/1.0.5.tar.gz
++-    version: 1.0.5
++-  ros-visualization/rqt_shell:
++-    hash: 0308be57b7e1ed81d66035c21ce37d37ab00a599c85a7667d7487b8786805987
++-    strip_prefix: rqt_shell-1.0.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_shell/archive/refs/tags/1.0.2.tar.gz
++-    version: 1.0.2
++-  ros-visualization/rqt_srv:
++-    hash: 719a48657574e2abbdf3469773d894d542c5fbe15b2d81784868979c13fbf095
++-    strip_prefix: rqt_srv-1.0.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_srv/archive/refs/tags/1.0.3.tar.gz
++-    version: 1.0.3
++-  ros-visualization/rqt_top:
++-    hash: a459216881372b8d3da18e484f4ed1c4edb7b1dd3e066ec778c717f0d4ab8a42
++-    strip_prefix: rqt_top-1.0.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_top/archive/refs/tags/1.0.2.tar.gz
++-    version: 1.0.2
++-  ros-visualization/rqt_topic:
++-    hash: 30bc690fa6102759a629d10a03182517beeca747ff7fb6cb5f5d15dbb9a921b4
++-    strip_prefix: rqt_topic-1.3.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_topic/archive/refs/tags/1.3.0.tar.gz
++-    version: 1.3.0
++-  ros-visualization/tango_icons_vendor:
++-    hash: 918e3b3138bd2769b9781b0d7015132d815d540f8f2b8b1c16efbeda46b8916e
++-    strip_prefix: tango_icons_vendor-0.1.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/tango_icons_vendor/archive/refs/tags/0.1.0.tar.gz
++-    version: 0.1.0
++-  ros/class_loader:
++-    hash: 3cb3488410a9d5986e4b64cc9c754a81cc3b6fe41d6e376e5b5923806731358a
++-    strip_prefix: class_loader-2.0.3
++-    type: http_archive
++-    url: https://github.com/ros/class_loader/archive/refs/tags/2.0.3.tar.gz
++-    version: 2.0.3
++-  ros/kdl_parser:
++-    hash: 91b5e3e55f2b1fe746e2f39b2d06dd72334e3eeda30c086fdfd7e026ce369885
++-    strip_prefix: kdl_parser-2.4.1
++-    type: http_archive
++-    url: https://github.com/ros/kdl_parser/archive/refs/tags/2.4.1.tar.gz
++-    version: 2.4.1
++-  ros/pluginlib:
++-    hash: f0659a828bc77c588c26237c3998752a3172a93dbc84e3200dccf084e5611bae
++-    strip_prefix: pluginlib-2.5.4
++-    type: http_archive
++-    url: https://github.com/ros/pluginlib/archive/refs/tags/2.5.4.tar.gz
++-    version: 2.5.4
++-  ros/resource_retriever:
++-    hash: a754feeb1018f488a639f13ed64e7dafe5a9322c235af0ca841ba4827a6b2924
++-    strip_prefix: resource_retriever-2.3.4
++-    type: http_archive
++-    url: https://github.com/ros/resource_retriever/archive/refs/tags/2.3.4.tar.gz
++-    version: 2.3.4
++-  ros/robot_state_publisher:
++-    hash: 28e86197f722b54e47b6bcdac5d3715a69702176c0a6f743b0570882e14a02ed
++-    strip_prefix: robot_state_publisher-2.4.5
++-    type: http_archive
++-    url: https://github.com/ros/robot_state_publisher/archive/refs/tags/2.4.5.tar.gz
++-    version: 2.4.5
++-  ros/ros_environment:
++-    hash: 2a4d5b38f7ddc2c77023b53c9997c789d54676cd4486ccd4eb0850b0da515c1b
++-    strip_prefix: ros_environment-2.5.1
++-    type: http_archive
++-    url: https://github.com/ros/ros_environment/archive/refs/tags/2.5.1.tar.gz
++-    version: 2.5.1
++-  ros/ros_tutorials:
++-    hash: 94836061109633c9f6774a4ecb6be7eeba57077560c4c0eefd24664e431a343f
++-    strip_prefix: ros_tutorials-1.2.6
++-    type: http_archive
++-    url: https://github.com/ros/ros_tutorials/archive/refs/tags/1.2.6.tar.gz
++-    version: 1.2.6
++-  ros/urdfdom:
++-    hash: a0ec5819efc7747f22a12ccab5e2e7c4739f1f498cb4d1ee55be771f19df1510
++-    strip_prefix: urdfdom-2.3.3
++-    type: http_archive
++-    url: https://github.com/ros/urdfdom/archive/refs/tags/2.3.3.tar.gz
++-    version: 2.3.3
++-  ros/urdfdom_headers:
++-    hash: 76a68657c38e54bb45bddc4bd7d823a3b04edcd08064a56d8e7d46b9912035ac
++-    strip_prefix: urdfdom_headers-1.0.5
++-    type: http_archive
++-    url: https://github.com/ros/urdfdom_headers/archive/refs/tags/1.0.5.tar.gz
++-    version: 1.0.5
++-  ros2/ament_cmake_ros:
++-    hash: 6d7d8e4612e155953327d40a7c4d6c6c57ab02f6accfc21969bae679618a5560
++-    strip_prefix: ament_cmake_ros-0.9.2
++-    type: http_archive
++-    url: https://github.com/ros2/ament_cmake_ros/archive/refs/tags/0.9.2.tar.gz
++-    version: 0.9.2
++-  ros2/common_interfaces:
++-    hash: 8cfe9b00f0dc75e6e5e2fae8de0b2c84564ce43b94c68b227e317d4dcfe77073
++-    strip_prefix: common_interfaces-2.0.5
++-    type: http_archive
++-    url: https://github.com/ros2/common_interfaces/archive/refs/tags/2.0.5.tar.gz
++-    version: 2.0.5
++-  ros2/console_bridge_vendor:
++-    hash: d6fa9351b465fe882808ce8db7d8784a2a72bf866d524f5fba0ea1569fa286e2
++-    strip_prefix: console_bridge_vendor-1.2.4
++-    type: http_archive
++-    url: https://github.com/ros2/console_bridge_vendor/archive/refs/tags/1.2.4.tar.gz
++-    version: 1.2.4
++-  ros2/demos:
++-    hash: 5bf103f0f2d17732f2605677899a50e6aaae0af5884490e06f8ba0e713ca13c2
++-    strip_prefix: demos-0.9.4
++-    type: http_archive
++-    url: https://github.com/ros2/demos/archive/refs/tags/0.9.4.tar.gz
++-    version: 0.9.4
++-  ros2/eigen3_cmake_module:
++-    hash: 15d85f7c96fc14c48484e3d2e8484581e1077cf64d593b5e1fb4096700824b43
++-    strip_prefix: eigen3_cmake_module-0.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/eigen3_cmake_module/archive/refs/tags/0.1.1.tar.gz
++-    version: 0.1.1
++-  ros2/example_interfaces:
++-    hash: 6e9c7ead1346e0fc82d4a5b7bfe48d4c0fca746c9bc9e3f035efb0589cf83be7
++-    strip_prefix: example_interfaces-0.9.1
++-    type: http_archive
++-    url: https://github.com/ros2/example_interfaces/archive/refs/tags/0.9.1.tar.gz
++-    version: 0.9.1
++-  ros2/examples:
++-    hash: 2d92cb703992de91b1f6d71a8a5ef6eb4e9b292fd7975c7f06ad1463bafd270a
++-    strip_prefix: examples-0.9.4
++-    type: http_archive
++-    url: https://github.com/ros2/examples/archive/refs/tags/0.9.4.tar.gz
++-    version: 0.9.4
++-  ros2/geometry2:
++-    hash: ed7cf4ba0899d106870fa8fe86ff8212632fed6dc57268b6e72afcf3b035b3bd
++-    strip_prefix: geometry2-0.13.14
++-    type: http_archive
++-    url: https://github.com/ros2/geometry2/archive/refs/tags/0.13.14.tar.gz
++-    version: 0.13.14
++-  ros2/launch:
++-    hash: 4f63d41cb3ed61c01f632346bdc7f0d5bd75a598b7c601e747214cdf947cd409
++-    strip_prefix: launch-0.10.10
++-    type: http_archive
++-    url: https://github.com/ros2/launch/archive/refs/tags/0.10.10.tar.gz
++-    version: 0.10.10
++-  ros2/launch_ros:
++-    hash: afd6f1b31a6bc985682cf2753ea96056e1132eeb0ac5d0f063ab60515f79a2ce
++-    strip_prefix: launch_ros-0.11.7
++-    type: http_archive
++-    url: https://github.com/ros2/launch_ros/archive/refs/tags/0.11.7.tar.gz
++-    version: 0.11.7
++-  ros2/libyaml_vendor:
++-    hash: 813f23c58c2b3f5bd8ca4a755203dfafb882385f1e62b4d198276052690206df
++-    strip_prefix: libyaml_vendor-1.0.4
++-    type: http_archive
++-    url: https://github.com/ros2/libyaml_vendor/archive/refs/tags/1.0.4.tar.gz
++-    version: 1.0.4
++-  ros2/message_filters:
++-    hash: 99adbb3d32dbd09d1aad7379ce05e88ade026076b6bd98c5c87dd39eef3c45e5
++-    strip_prefix: message_filters-3.2.7
++-    type: http_archive
++-    url: https://github.com/ros2/message_filters/archive/refs/tags/3.2.7.tar.gz
++-    version: 3.2.7
++-  ros2/mimick_vendor:
++-    hash: fe8d39b26a05f77cadcf0c4d68a9ffe8ace494f3b608378812c5bf577a6b7e65
++-    strip_prefix: mimick_vendor-0.2.6
++-    type: http_archive
++-    url: https://github.com/ros2/mimick_vendor/archive/refs/tags/0.2.6.tar.gz
++-    version: 0.2.6
++-  ros2/orocos_kinematics_dynamics:
++-    hash: 8cb951d4351193575250263756029cc727232d4e0b838151269451a50cbd41eb
++-    strip_prefix: orocos_kinematics_dynamics-3.3.5
++-    type: http_archive
++-    url: https://github.com/ros2/orocos_kinematics_dynamics/archive/refs/tags/3.3.5.tar.gz
++-    version: 3.3.5
++-  ros2/performance_test_fixture:
++-    hash: 28d6039ef9fcc9281efce60d42c769d014a6a82f0a228d5bf887868282a2d770
++-    strip_prefix: performance_test_fixture-0.0.9
++-    type: http_archive
++-    url: https://github.com/ros2/performance_test_fixture/archive/refs/tags/0.0.9.tar.gz
++-    version: 0.0.9
++-  ros2/python_cmake_module:
++-    hash: 970334bcfa231568ba6d055a4022b85b5643c9c1b665c0115d6ca73944780564
++-    strip_prefix: python_cmake_module-0.8.1
++-    type: http_archive
++-    url: https://github.com/ros2/python_cmake_module/archive/refs/tags/0.8.1.tar.gz
++-    version: 0.8.1
++-  ros2/rcl:
++-    hash: e0b6f1607104093fc3eced0ccaf9c4c0a91c8a05560596273a767dccc6ccf2f3
++-    strip_prefix: rcl-1.1.14
++-    type: http_archive
++-    url: https://github.com/ros2/rcl/archive/refs/tags/1.1.14.tar.gz
++-    version: 1.1.14
++-  ros2/rcl_interfaces:
++-    hash: bb603420186394cc4e7a5f6da44d62d530f01e3246a8f78e952d21bf2d41a45b
++-    strip_prefix: rcl_interfaces-1.0.0
++-    type: http_archive
++-    url: https://github.com/ros2/rcl_interfaces/archive/refs/tags/1.0.0.tar.gz
++-    version: 1.0.0
++-  ros2/rcl_logging:
++-    hash: c7a4a8f22b77269fe99ad43c1e075bf2a3f42513bfb2531fd9e5fe9f146e6e63
++-    strip_prefix: rcl_logging-1.1.0
++-    type: http_archive
++-    url: https://github.com/ros2/rcl_logging/archive/refs/tags/1.1.0.tar.gz
++-    version: 1.1.0
++-  ros2/rclcpp:
++-    hash: 8c4112c5273c206bb6cc1b765337f1bbd23243d307a40f3b4e667ccef9cd7505
++-    strip_prefix: rclcpp-2.4.3
++-    type: http_archive
++-    url: https://github.com/ros2/rclcpp/archive/refs/tags/2.4.3.tar.gz
++-    version: 2.4.3
++-  ros2/rclpy:
++-    hash: 109cd8093ff0207efe7ef71005faed9e7821a6b8d502bccec5211d9ce90ff53b
++-    strip_prefix: rclpy-1.0.13
++-    type: http_archive
++-    url: https://github.com/ros2/rclpy/archive/refs/tags/1.0.13.tar.gz
++-    version: 1.0.13
++-  ros2/rcpputils:
++-    hash: 778b39bb3589c16e3b6ece1ea4c3fb52898099ce712db4113d7d07d2d3e9833d
++-    strip_prefix: rcpputils-1.3.2
++-    type: http_archive
++-    url: https://github.com/ros2/rcpputils/archive/refs/tags/1.3.2.tar.gz
++-    version: 1.3.2
++-  ros2/rcutils:
++-    hash: f772dbace29be191aa83a9ae74a8502b6cba7836df0d311977225efe1699c97d
++-    strip_prefix: rcutils-1.1.5
++-    type: http_archive
++-    url: https://github.com/ros2/rcutils/archive/refs/tags/1.1.5.tar.gz
++-    version: 1.1.5
++-  ros2/realtime_support:
++-    hash: 304918e2eadc8452f45048cec2d7fd1de7caac78a4fc43ac127ea554fb8f768c
++-    strip_prefix: realtime_support-0.9.0
++-    type: http_archive
++-    url: https://github.com/ros2/realtime_support/archive/refs/tags/0.9.0.tar.gz
++-    version: 0.9.0
++-  ros2/rmw:
++-    hash: b26eb2e14c456b55a860eaae5345a23f7eed732a4fab0865ebc2ef39ee65dd6d
++-    strip_prefix: rmw-1.0.4
++-    type: http_archive
++-    url: https://github.com/ros2/rmw/archive/refs/tags/1.0.4.tar.gz
++-    version: 1.0.4
++-  ros2/rmw_connext:
++-    hash: b2508d6a7bd1ba677c1bceec5e349d26aecaa3cd1efc88c63897d3314c04cbf1
++-    strip_prefix: rmw_connext-1.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_connext/archive/refs/tags/1.0.3.tar.gz
++-    version: 1.0.3
++-  ros2/rmw_cyclonedds:
++-    hash: 1f2c42000c2e179834060170856be4cb04e6ab6dfbc301086218c49b56dc693f
++-    strip_prefix: rmw_cyclonedds-0.7.11
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_cyclonedds/archive/refs/tags/0.7.11.tar.gz
++-    version: 0.7.11
++-  ros2/rmw_dds_common:
++-    hash: 34e46de0e2858af57d996b5d17fbfd76b58b1c37b64321d2c6bafaf4198d64db
++-    strip_prefix: rmw_dds_common-1.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_dds_common/archive/refs/tags/1.0.3.tar.gz
++-    version: 1.0.3
++-  ros2/rmw_fastrtps:
++-    hash: db97bb95c2c22dd07a1baf01af49bbf319b682994f70c5307d4bbc7ba020be1a
++-    strip_prefix: rmw_fastrtps-1.3.2
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_fastrtps/archive/refs/tags/1.3.2.tar.gz
++-    version: 1.3.2
++-  ros2/rmw_implementation:
++-    hash: d22bb94ba7e72f63e06ff80913c77ad95267ad3da31088d27d0d0a6575bfe538
++-    strip_prefix: rmw_implementation-1.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_implementation/archive/refs/tags/1.0.3.tar.gz
++-    version: 1.0.3
++-  ros2/ros1_bridge:
++-    hash: d63b5c92f080fce55ee6986e3f3630d99fd3ffbe7f1e56e56348dd72250da2f6
++-    strip_prefix: ros1_bridge-0.9.7
++-    type: http_archive
++-    url: https://github.com/ros2/ros1_bridge/archive/refs/tags/0.9.7.tar.gz
++-    version: 0.9.7
++-  ros2/ros2_tracing:
++-    hash: 552f35e1dbdc30cdd5ddeeccf278f8fc50811f15f3d2eb98e25a28fadac0ae8f
++-    strip_prefix: ros2_tracing-1.0.5
++-    type: http_archive
++-    url: https://github.com/ros2/ros2_tracing/archive/refs/tags/1.0.5.tar.gz
++-    version: 1.0.5
++-  ros2/ros2cli:
++-    hash: bdba1238c028c0c5102e62754b51126ad35c606905874620fd0718e7372f758d
++-    strip_prefix: ros2cli-0.9.13
++-    type: http_archive
++-    url: https://github.com/ros2/ros2cli/archive/refs/tags/0.9.13.tar.gz
++-    version: 0.9.13
++-  ros2/ros2cli_common_extensions:
++-    hash: 5f019ebb88f214c788caedbe33257ae290a5956c5af93332c02d4e0946aaa702
++-    strip_prefix: ros2cli_common_extensions-0.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/ros2cli_common_extensions/archive/refs/tags/0.1.1.tar.gz
++-    version: 0.1.1
++-  ros2/ros_testing:
++-    hash: 1def68962286e95dcbce54445f5589429d7d6fb44b580183356c3281b3670798
++-    strip_prefix: ros_testing-0.2.1
++-    type: http_archive
++-    url: https://github.com/ros2/ros_testing/archive/refs/tags/0.2.1.tar.gz
++-    version: 0.2.1
++-  ros2/rosbag2:
++-    hash: 9856b06c225522fbadf262231b96ba8557bf29688e0cf70d431e1c1ac299ff33
++-    strip_prefix: rosbag2-0.3.11
++-    type: http_archive
++-    url: https://github.com/ros2/rosbag2/archive/refs/tags/0.3.11.tar.gz
++-    version: 0.3.11
++-  ros2/rosidl:
++-    hash: 7acf68ee029bba805ff48ebf19b6c895ec64378e3676caafab62700aa4797db4
++-    strip_prefix: rosidl-1.3.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl/archive/refs/tags/1.3.1.tar.gz
++-    version: 1.3.1
++-  ros2/rosidl_dds:
++-    hash: c158bb43caa1fd9ae0dfb23397e28643c9cdbb4673c9aa6f9fe9e5e2dfad893e
++-    strip_prefix: rosidl_dds-0.7.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_dds/archive/refs/tags/0.7.1.tar.gz
++-    version: 0.7.1
++-  ros2/rosidl_defaults:
++-    hash: 9b80033b28589e881957a5267d7f6c983f794c360f82c28b8ab36a4547094cc3
++-    strip_prefix: rosidl_defaults-1.0.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_defaults/archive/refs/tags/1.0.1.tar.gz
++-    version: 1.0.1
++-  ros2/rosidl_python:
++-    hash: ffbfce6556f36b763fd4ba7bdfdc535cad1990eedabaa88f58c53bc77f0ccf12
++-    strip_prefix: rosidl_python-0.9.7
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_python/archive/refs/tags/0.9.7.tar.gz
++-    version: 0.9.7
++-  ros2/rosidl_runtime_py:
++-    hash: b171a9358ed30df2f702f64c4618872c22802287dbf7b6d27310bd6c8a550dcf
++-    strip_prefix: rosidl_runtime_py-0.9.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_runtime_py/archive/refs/tags/0.9.1.tar.gz
++-    version: 0.9.1
++-  ros2/rosidl_typesupport:
++-    hash: 7e0b46bfdc2040d7dda295641cfb40f9981ca4155c561e164e1c20017a7bc40f
++-    strip_prefix: rosidl_typesupport-1.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_typesupport/archive/refs/tags/1.0.3.tar.gz
++-    version: 1.0.3
++-  ros2/rosidl_typesupport_connext:
++-    hash: 521f4de1cc22d9f6eaa51774ae88ccc269291d7b4cbee371a27a04aa179018cb
++-    strip_prefix: rosidl_typesupport_connext-1.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_typesupport_connext/archive/refs/tags/1.0.3.tar.gz
++-    version: 1.0.3
++-  ros2/rosidl_typesupport_fastrtps:
++-    hash: 496108424f8bd628901a50f504f9ebee05f284bbc73e244824be6d103e14c0f5
++-    strip_prefix: rosidl_typesupport_fastrtps-1.0.4
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps/archive/refs/tags/1.0.4.tar.gz
++-    version: 1.0.4
++-  ros2/rpyutils:
++-    hash: 8b321fd04ffc65b7be2e8d6e4dde6e632bac291021dc5adc67077c9cac601243
++-    strip_prefix: rpyutils-0.2.0
++-    type: http_archive
++-    url: https://github.com/ros2/rpyutils/archive/refs/tags/0.2.0.tar.gz
++-    version: 0.2.0
++-  ros2/rviz:
++-    hash: 92f2eb70dc085a97e2acc059f1d4446a66ca1551db6b65804b43227eaad2d060
++-    strip_prefix: rviz-8.2.8
++-    type: http_archive
++-    url: https://github.com/ros2/rviz/archive/refs/tags/8.2.8.tar.gz
++-    version: 8.2.8
++-  ros2/spdlog_vendor:
++-    hash: d2c9b3ac17788040d8539a4520643f237af97ebded9682c741cd2063b85a0636
++-    strip_prefix: spdlog_vendor-1.1.3
++-    type: http_archive
++-    url: https://github.com/ros2/spdlog_vendor/archive/refs/tags/1.1.3.tar.gz
++-    version: 1.1.3
++-  ros2/sros2:
++-    hash: 06c405f417216b459dae5cfddd5dec5bf31bf420e9930dccb1f7e94341daf6fe
++-    strip_prefix: sros2-0.9.5
++-    type: http_archive
++-    url: https://github.com/ros2/sros2/archive/refs/tags/0.9.5.tar.gz
++-    version: 0.9.5
++-  ros2/system_tests:
++-    hash: 0d9522a35c2b88df66313e7842bf112410098a6d4fb3476a515069a157121e1c
++-    strip_prefix: system_tests-0.9.2
++-    type: http_archive
++-    url: https://github.com/ros2/system_tests/archive/refs/tags/0.9.2.tar.gz
++-    version: 0.9.2
++-  ros2/test_interface_files:
++-    hash: a48120dbf44ad536f209654e20eda8fe03b826568c2b53fd591937b5718302a3
++-    strip_prefix: test_interface_files-0.8.1
++-    type: http_archive
++-    url: https://github.com/ros2/test_interface_files/archive/refs/tags/0.8.1.tar.gz
++-    version: 0.8.1
++-  ros2/tinyxml2_vendor:
++-    hash: 4ecbfc55d99e4f28d3cc1d8992399812a9e3bb8ba01169d846fba0b54ed1a744
++-    strip_prefix: tinyxml2_vendor-0.7.4
++-    type: http_archive
++-    url: https://github.com/ros2/tinyxml2_vendor/archive/refs/tags/0.7.4.tar.gz
++-    version: 0.7.4
++-  ros2/tinyxml_vendor:
++-    hash: 25db4b255a7fba9a6c8373ff876caba2454378a87031d1cb1502ff1925e4d8b0
++-    strip_prefix: tinyxml_vendor-0.8.2
++-    type: http_archive
++-    url: https://github.com/ros2/tinyxml_vendor/archive/refs/tags/0.8.2.tar.gz
++-    version: 0.8.2
++-  ros2/tlsf:
++-    hash: d62978fa4791d55afb3bcc4920b09c2942f99453c751ed90d42df86861c8b896
++-    strip_prefix: tlsf-0.5.0
++-    type: http_archive
++-    url: https://github.com/ros2/tlsf/archive/refs/tags/0.5.0.tar.gz
++-    version: 0.5.0
++-  ros2/unique_identifier_msgs:
++-    hash: aa0f5a440cface1dd85cf05d97cadb812b2796973882d02a7e795ae70b64b9a0
++-    strip_prefix: unique_identifier_msgs-2.1.3
++-    type: http_archive
++-    url: https://github.com/ros2/unique_identifier_msgs/archive/refs/tags/2.1.3.tar.gz
++-    version: 2.1.3
++-  ros2/urdf:
++-    hash: 391a1148bb69fffb59264ff2b8030e885899cb4dffc936e7afa08802aead14a2
++-    strip_prefix: urdf-2.4.0
++-    type: http_archive
++-    url: https://github.com/ros2/urdf/archive/refs/tags/2.4.0.tar.gz
++-    version: 2.4.0
++-  ros2/yaml_cpp_vendor:
++-    hash: 4efd8a94b1f29db9992c90a2c6f9acffb0d8938221bfaac6ff094748bdff9ec5
++-    strip_prefix: yaml_cpp_vendor-7.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/yaml_cpp_vendor/archive/refs/tags/7.0.3.tar.gz
++-    version: 7.0.3
++diff --git a/repos/config/ros2_humble.lock b/repos/config/ros2_humble.lock
++deleted file mode 100644
++index 673ad8e..0000000
++--- a/repos/config/ros2_humble.lock
+++++ /dev/null
++@@ -1,622 +0,0 @@
++-#
++-#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
++-#
++-repositories:
++-  ament/ament_cmake:
++-    hash: 7f343f90844d47ef225e401e643aa46376aaeeb53d3fdb257be6e98ce75cf36c
++-    strip_prefix: ament_cmake-1.3.5
++-    type: http_archive
++-    url: https://github.com/ament/ament_cmake/archive/refs/tags/1.3.5.tar.gz
++-    version: 1.3.5
++-  ament/ament_index:
++-    hash: e66896e255653508cb2bdecd7789f8dd5a03d7d2b4a1dd37445821a5679c447c
++-    strip_prefix: ament_index-1.4.0
++-    type: http_archive
++-    url: https://github.com/ament/ament_index/archive/refs/tags/1.4.0.tar.gz
++-    version: 1.4.0
++-  ament/ament_lint:
++-    hash: 875b3261631d34082eed2f8f07386e3b64d564ba9d494288cb88d4fe09e8402b
++-    strip_prefix: ament_lint-0.12.8
++-    type: http_archive
++-    url: https://github.com/ament/ament_lint/archive/refs/tags/0.12.8.tar.gz
++-    version: 0.12.8
++-  ament/ament_package:
++-    hash: 85da59b1d067c8040b378d0bef47e32198defb5edc2e2ba251479cc24992553b
++-    strip_prefix: ament_package-0.14.0
++-    type: http_archive
++-    url: https://github.com/ament/ament_package/archive/refs/tags/0.14.0.tar.gz
++-    version: 0.14.0
++-  ament/google_benchmark_vendor:
++-    hash: 4efc38011ca059c10323281a915fb57aef368b4b2dd4a2a9f3c72507b8602ef3
++-    strip_prefix: google_benchmark_vendor-0.1.2
++-    type: http_archive
++-    url: https://github.com/ament/google_benchmark_vendor/archive/refs/tags/0.1.2.tar.gz
++-    version: 0.1.2
++-  ament/googletest:
++-    hash: e3f1f2bb6d0727ed7c8c6971c5e924a7d75fbdc22a08fdcfc0a663264ee5499b
++-    strip_prefix: googletest-1.10.9004
++-    type: http_archive
++-    url: https://github.com/ament/googletest/archive/refs/tags/1.10.9004.tar.gz
++-    version: 1.10.9004
++-  ament/uncrustify_vendor:
++-    hash: 94ce058f994f543baae20e8e78e1f12b21b5b14472a3454142329ac002de5359
++-    strip_prefix: uncrustify_vendor-2.0.2
++-    type: http_archive
++-    url: https://github.com/ament/uncrustify_vendor/archive/refs/tags/2.0.2.tar.gz
++-    version: 2.0.2
++-  eProsima/Fast-CDR:
++-    hash: ecd688ab89ff1c03b9031c314891ae60995e2e73d919b93569eb840d6e87dec2
++-    strip_prefix: Fast-CDR-1.0.24
++-    type: http_archive
++-    url: https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.24.tar.gz
++-    version: v1.0.24
++-  eProsima/Fast-DDS:
++-    hash: 2234b9fb7c34cc642a76bb221483f6e0839c954de8ff1b3854557e85cc8ade60
++-    strip_prefix: Fast-DDS-2.6.6
++-    type: http_archive
++-    url: https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.6.6.tar.gz
++-    version: v2.6.6
++-  eProsima/foonathan_memory_vendor:
++-    hash: 982d11615214497bd7c713f3463af27567c76bed06b9b61021bc24694fd11c4a
++-    strip_prefix: foonathan_memory_vendor-1.3.1
++-    type: http_archive
++-    url: https://github.com/eProsima/foonathan_memory_vendor/archive/refs/tags/v1.3.1.tar.gz
++-    version: v1.3.1
++-  eclipse-cyclonedds/cyclonedds:
++-    hash: bc79696209febfe66d97e7af6b11e92f9db663caf608a922b6c201b1d6a5eb62
++-    strip_prefix: cyclonedds-0.10.3
++-    type: http_archive
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.10.3.tar.gz
++-    version: 0.10.3
++-  eclipse-iceoryx/iceoryx:
++-    hash: 8f391696daf2e63da9437aab8d7154371df630fc93876479f2e84c693fc1ba5a
++-    strip_prefix: iceoryx-2.0.3
++-    type: http_archive
++-    url: https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.3.tar.gz
++-    version: v2.0.3
++-  ignition/ignition_cmake2_vendor:
++-    hash: 5b13472e33db9c9bb631b037d1c6b0ccedfcf5e38e16157024cc641215a43b32
++-    strip_prefix: gz_cmake2_vendor-0.0.2
++-    type: http_archive
++-    url: https://github.com/ignition-release/ignition_cmake2_vendor/archive/refs/tags/0.0.2.tar.gz
++-    version: 0.0.2
++-  ignition/ignition_math6_vendor:
++-    hash: d357a43e8265db9a9e886b01ca53cc9692c81b7e9f7d99abc99df982efd5a1be
++-    strip_prefix: gz_math6_vendor-0.0.2
++-    type: http_archive
++-    url: https://github.com/ignition-release/ignition_math6_vendor/archive/refs/tags/0.0.2.tar.gz
++-    version: 0.0.2
++-  osrf/osrf_pycommon:
++-    hash: 1bb4f9a91c6b02fab67be27e63841bf05f49dc32970149562a0c7ea85b3a2b9c
++-    strip_prefix: osrf_pycommon-2.0.2
++-    type: http_archive
++-    url: https://github.com/osrf/osrf_pycommon/archive/refs/tags/2.0.2.tar.gz
++-    version: 2.0.2
++-  osrf/osrf_testing_tools_cpp:
++-    hash: ec2bbc8cf59e48acd858006423d0872c0950eda24efccb67a1ad47191fc47ff4
++-    strip_prefix: osrf_testing_tools_cpp-1.5.2
++-    type: http_archive
++-    url: https://github.com/osrf/osrf_testing_tools_cpp/archive/refs/tags/1.5.2.tar.gz
++-    version: 1.5.2
++-  ros-perception/image_common:
++-    hash: bf878db599ccca96e239aef428e60e58e02db32d3ddf7a62c4a2cc340aa9540a
++-    strip_prefix: image_common-3.1.7
++-    type: http_archive
++-    url: https://github.com/ros-perception/image_common/archive/refs/tags/3.1.7.tar.gz
++-    version: 3.1.7
++-  ros-perception/laser_geometry:
++-    hash: fe836029a0e960d8b2095b2cd3ce993b556fc2dd6ce73df5dfe266f90ba62017
++-    strip_prefix: laser_geometry-2.4.0
++-    type: http_archive
++-    url: https://github.com/ros-perception/laser_geometry/archive/refs/tags/2.4.0.tar.gz
++-    version: 2.4.0
++-  ros-planning/navigation_msgs:
++-    hash: 4de38585745387d0a6557c28c66cca88dd4cfdf9d2e15871669fa8ecd2657f03
++-    strip_prefix: navigation_msgs-2.1.0
++-    type: http_archive
++-    url: https://github.com/ros-planning/navigation_msgs/archive/refs/tags/2.1.0.tar.gz
++-    version: 2.1.0
++-  ros-tooling/keyboard_handler:
++-    hash: 36e64e9e1927a6026e1b45cafc4c8efd32db274bfab5da0edd273a583f3c73f4
++-    strip_prefix: keyboard_handler-0.0.5
++-    type: http_archive
++-    url: https://github.com/ros-tooling/keyboard_handler/archive/refs/tags/0.0.5.tar.gz
++-    version: 0.0.5
++-  ros-tooling/libstatistics_collector:
++-    hash: 12e9e52e2b342e471a31ad41db18e72795ac2b0faf56a54adcb74a24de630fa3
++-    strip_prefix: libstatistics_collector-1.3.1
++-    type: http_archive
++-    url: https://github.com/ros-tooling/libstatistics_collector/archive/refs/tags/1.3.1.tar.gz
++-    version: 1.3.1
++-  ros-visualization/interactive_markers:
++-    hash: 5e532f93f82e88d669d0883911d3f8d21b33f289970abd19a5cd7392a89bf69d
++-    strip_prefix: interactive_markers-2.3.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/interactive_markers/archive/refs/tags/2.3.2.tar.gz
++-    version: 2.3.2
++-  ros-visualization/python_qt_binding:
++-    hash: ec9dabfd91352830b49e4e429d7d3ec63eb733c29375d6f0c54c713af736e2c8
++-    strip_prefix: python_qt_binding-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/python_qt_binding/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/qt_gui_core:
++-    hash: f6ac634e5ea5107f190febdc5ed0064a55b27baa201795a58066638ac5ba49e6
++-    strip_prefix: qt_gui_core-2.2.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/qt_gui_core/archive/refs/tags/2.2.2.tar.gz
++-    version: 2.2.2
++-  ros-visualization/rqt:
++-    hash: 98f199fb868e127257106fc9f292cdc23baa501d9b1e97e365f2494bc706d849
++-    strip_prefix: rqt-1.1.5
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt/archive/refs/tags/1.1.5.tar.gz
++-    version: 1.1.5
++-  ros-visualization/rqt_action:
++-    hash: 51befe0c28ca2a02f304defb3a9c7cb7f7a5a2da9b296dce40271b5643112991
++-    strip_prefix: rqt_action-2.0.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_action/archive/refs/tags/2.0.1.tar.gz
++-    version: 2.0.1
++-  ros-visualization/rqt_bag:
++-    hash: c3bffc73d88e6cb16939a10903351ac69a819596d4c07f1bb735f42917f88cf6
++-    strip_prefix: rqt_bag-1.1.4
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_bag/archive/refs/tags/1.1.4.tar.gz
++-    version: 1.1.4
++-  ros-visualization/rqt_console:
++-    hash: 4f76b11a1a3d5066282d868eae0d83d288d72ea7352f7749d6ba3286dc0e414f
++-    strip_prefix: rqt_console-2.0.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_console/archive/refs/tags/2.0.2.tar.gz
++-    version: 2.0.2
++-  ros-visualization/rqt_graph:
++-    hash: b0e60900879b785e3ae9100c7749cd67f3ecfcaa6ffd16cc142ba18bfe9a0ede
++-    strip_prefix: rqt_graph-1.3.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_graph/archive/refs/tags/1.3.0.tar.gz
++-    version: 1.3.0
++-  ros-visualization/rqt_msg:
++-    hash: 42c593d6e54fc99bad734e675332d34b1d2cafd5cacea5175a5bdc2aa8455770
++-    strip_prefix: rqt_msg-1.2.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_msg/archive/refs/tags/1.2.0.tar.gz
++-    version: 1.2.0
++-  ros-visualization/rqt_plot:
++-    hash: b9e4d23892f26a75081ae999b61f2c92ee99a20f017189c40555a85790a83334
++-    strip_prefix: rqt_plot-1.1.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_plot/archive/refs/tags/1.1.2.tar.gz
++-    version: 1.1.2
++-  ros-visualization/rqt_publisher:
++-    hash: 140cdfa21eaf16e78892f56fbb5264ad1849f759b5f7716ef6289157100d2fae
++-    strip_prefix: rqt_publisher-1.5.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_publisher/archive/refs/tags/1.5.0.tar.gz
++-    version: 1.5.0
++-  ros-visualization/rqt_py_console:
++-    hash: 1cb589b7c2b6bb445eef1cbfdceedd8d517b2f9d1b8cb2f22a767d612cba40b6
++-    strip_prefix: rqt_py_console-1.0.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_py_console/archive/refs/tags/1.0.2.tar.gz
++-    version: 1.0.2
++-  ros-visualization/rqt_reconfigure:
++-    hash: b6717de7819875484319a96a46d4001b71ab9bda5716e6d12343cf2a09843b99
++-    strip_prefix: rqt_reconfigure-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_reconfigure/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/rqt_service_caller:
++-    hash: 5e3802f444b50594f3a7dc80977286609b88a50f1ad77f9208e45911889ae825
++-    strip_prefix: rqt_service_caller-1.0.5
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_service_caller/archive/refs/tags/1.0.5.tar.gz
++-    version: 1.0.5
++-  ros-visualization/rqt_shell:
++-    hash: 0308be57b7e1ed81d66035c21ce37d37ab00a599c85a7667d7487b8786805987
++-    strip_prefix: rqt_shell-1.0.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_shell/archive/refs/tags/1.0.2.tar.gz
++-    version: 1.0.2
++-  ros-visualization/rqt_srv:
++-    hash: 719a48657574e2abbdf3469773d894d542c5fbe15b2d81784868979c13fbf095
++-    strip_prefix: rqt_srv-1.0.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_srv/archive/refs/tags/1.0.3.tar.gz
++-    version: 1.0.3
++-  ros-visualization/rqt_topic:
++-    hash: 8476832e52311e434b36804cec87f67c7066b17e07f5963b3f3268afabce42ca
++-    strip_prefix: rqt_topic-1.5.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_topic/archive/refs/tags/1.5.0.tar.gz
++-    version: 1.5.0
++-  ros-visualization/tango_icons_vendor:
++-    hash: 1402e81d5a34916b90b8bb30a9dd7a131b1a98df9f5754f311dfd35d32561971
++-    strip_prefix: tango_icons_vendor-0.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/tango_icons_vendor/archive/refs/tags/0.1.1.tar.gz
++-    version: 0.1.1
++-  ros/class_loader:
++-    hash: a85a99b93fcad7c8d9686672b8e3793200b1da9d8feab7ab3a9962e34ab1f675
++-    strip_prefix: class_loader-2.2.0
++-    type: http_archive
++-    url: https://github.com/ros/class_loader/archive/refs/tags/2.2.0.tar.gz
++-    version: 2.2.0
++-  ros/kdl_parser:
++-    hash: f28da9bd7eaa8995f4b67bc9c8321d7467043aa43e01b918aa239b8b9971bf56
++-    strip_prefix: kdl_parser-2.6.4
++-    type: http_archive
++-    url: https://github.com/ros/kdl_parser/archive/refs/tags/2.6.4.tar.gz
++-    version: 2.6.4
++-  ros/pluginlib:
++-    hash: 74188b886f9bbe7e857d21f3bb50b480e7c0e5adab97c10563dc17013600198b
++-    strip_prefix: pluginlib-5.1.0
++-    type: http_archive
++-    url: https://github.com/ros/pluginlib/archive/refs/tags/5.1.0.tar.gz
++-    version: 5.1.0
++-  ros/resource_retriever:
++-    hash: a7de4f63babcdaafa7c8af69942ce31105c763ae8a4467ed77a69b4ab80d2dc8
++-    strip_prefix: resource_retriever-3.1.1
++-    type: http_archive
++-    url: https://github.com/ros/resource_retriever/archive/refs/tags/3.1.1.tar.gz
++-    version: 3.1.1
++-  ros/robot_state_publisher:
++-    hash: f349756d8db6d6fc79dcc869acaa749175f2ad20ea74c738ed72cd1f96cd97b6
++-    strip_prefix: robot_state_publisher-3.0.2
++-    type: http_archive
++-    url: https://github.com/ros/robot_state_publisher/archive/refs/tags/3.0.2.tar.gz
++-    version: 3.0.2
++-  ros/ros_environment:
++-    hash: 4f67c3c8b91ad568aa5c02b710678f32aa7e6a01e962d4300fee2311ea31f06f
++-    strip_prefix: ros_environment-3.2.2
++-    type: http_archive
++-    url: https://github.com/ros/ros_environment/archive/refs/tags/3.2.2.tar.gz
++-    version: 3.2.2
++-  ros/ros_tutorials:
++-    hash: e87349defac08978cf47c6ae0a743b488a89195b00b1eb73a2f5fd0a74430dca
++-    strip_prefix: ros_tutorials-1.4.2
++-    type: http_archive
++-    url: https://github.com/ros/ros_tutorials/archive/refs/tags/1.4.2.tar.gz
++-    version: 1.4.2
++-  ros/urdfdom:
++-    hash: 1072b2a304295eb299ed70d99914eb2fbf8843c3257e5e51defc5dd457ee6211
++-    strip_prefix: urdfdom-3.0.2
++-    type: http_archive
++-    url: https://github.com/ros/urdfdom/archive/refs/tags/3.0.2.tar.gz
++-    version: 3.0.2
++-  ros/urdfdom_headers:
++-    hash: 1acd50b976f642de9dc0fde532eb8d77ea09f4de12ebfbd9d88b0cd2891278fd
++-    strip_prefix: urdfdom_headers-1.0.6
++-    type: http_archive
++-    url: https://github.com/ros/urdfdom_headers/archive/refs/tags/1.0.6.tar.gz
++-    version: 1.0.6
++-  ros2/ament_cmake_ros:
++-    hash: 01c778f18315ad13efd02e24200ff04f1e72359096c0967dba45e45bc479b3c6
++-    strip_prefix: ament_cmake_ros-0.10.0
++-    type: http_archive
++-    url: https://github.com/ros2/ament_cmake_ros/archive/refs/tags/0.10.0.tar.gz
++-    version: 0.10.0
++-  ros2/common_interfaces:
++-    hash: f4be9343a4c028fcf5403d90c120bca78aea1bbe2a04ae9838a7f73c347366c6
++-    strip_prefix: common_interfaces-4.2.3
++-    type: http_archive
++-    url: https://github.com/ros2/common_interfaces/archive/refs/tags/4.2.3.tar.gz
++-    version: 4.2.3
++-  ros2/console_bridge_vendor:
++-    hash: 624e5166bc495d2dcfbe1fd3e0b7c8b5ebc20429b3455b1e5673337f66aa83ad
++-    strip_prefix: console_bridge_vendor-1.4.1
++-    type: http_archive
++-    url: https://github.com/ros2/console_bridge_vendor/archive/refs/tags/1.4.1.tar.gz
++-    version: 1.4.1
++-  ros2/demos:
++-    hash: d8afc21488675cc2ac537969a560064bad5a1d6115d7d631a01c5b3eeada58f8
++-    strip_prefix: demos-0.20.3
++-    type: http_archive
++-    url: https://github.com/ros2/demos/archive/refs/tags/0.20.3.tar.gz
++-    version: 0.20.3
++-  ros2/eigen3_cmake_module:
++-    hash: 15d85f7c96fc14c48484e3d2e8484581e1077cf64d593b5e1fb4096700824b43
++-    strip_prefix: eigen3_cmake_module-0.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/eigen3_cmake_module/archive/refs/tags/0.1.1.tar.gz
++-    version: 0.1.1
++-  ros2/example_interfaces:
++-    hash: 7ee9b0223529fddce6cc85ebc981edec35f594d0565399086e773530ea9d6a52
++-    strip_prefix: example_interfaces-0.9.3
++-    type: http_archive
++-    url: https://github.com/ros2/example_interfaces/archive/refs/tags/0.9.3.tar.gz
++-    version: 0.9.3
++-  ros2/examples:
++-    hash: 71c75c775964f2e1f910dac55b3429adcde04f9960afbd651a7f7a7b662c0807
++-    strip_prefix: examples-0.15.1
++-    type: http_archive
++-    url: https://github.com/ros2/examples/archive/refs/tags/0.15.1.tar.gz
++-    version: 0.15.1
++-  ros2/geometry2:
++-    hash: cdcd4596379672cd90548e0f68029d894396e018b9fa95383b09e78c08b8febb
++-    strip_prefix: geometry2-0.25.4
++-    type: http_archive
++-    url: https://github.com/ros2/geometry2/archive/refs/tags/0.25.4.tar.gz
++-    version: 0.25.4
++-  ros2/launch:
++-    hash: 41ba52c876ab4b2301406e442cd7503ae877aaa33c7f5fcf86010bf2a57db606
++-    strip_prefix: launch-1.0.4
++-    type: http_archive
++-    url: https://github.com/ros2/launch/archive/refs/tags/1.0.4.tar.gz
++-    version: 1.0.4
++-  ros2/launch_ros:
++-    hash: bd051a2f92774931714e9bf4abbeba7645f2917e818d93a6e39ec693e474a16f
++-    strip_prefix: launch_ros-0.19.6
++-    type: http_archive
++-    url: https://github.com/ros2/launch_ros/archive/refs/tags/0.19.6.tar.gz
++-    version: 0.19.6
++-  ros2/libyaml_vendor:
++-    hash: fbcd5f2921e68f1fb5eb7d44e9d3449dee3e9dba730648f919bad79aa4855cff
++-    strip_prefix: libyaml_vendor-1.2.2
++-    type: http_archive
++-    url: https://github.com/ros2/libyaml_vendor/archive/refs/tags/1.2.2.tar.gz
++-    version: 1.2.2
++-  ros2/message_filters:
++-    hash: bd86a6f099393f10f208a757abc6c2bccf8fc6f684216cffd73f67f5f23b8fd6
++-    strip_prefix: message_filters-4.3.3
++-    type: http_archive
++-    url: https://github.com/ros2/message_filters/archive/refs/tags/4.3.3.tar.gz
++-    version: 4.3.3
++-  ros2/mimick_vendor:
++-    hash: 445a326aba0796868ddf65ca4d8c6166dc27208f21f2a65440ffeea9214d195a
++-    strip_prefix: mimick_vendor-0.2.8
++-    type: http_archive
++-    url: https://github.com/ros2/mimick_vendor/archive/refs/tags/0.2.8.tar.gz
++-    version: 0.2.8
++-  ros2/orocos_kdl_vendor:
++-    hash: a315b3121d3a0761d821c15fa1a8939a65eb99073943795e56d52c08bf75ee0d
++-    strip_prefix: orocos_kdl_vendor-0.2.5
++-    type: http_archive
++-    url: https://github.com/ros2/orocos_kdl_vendor/archive/refs/tags/0.2.5.tar.gz
++-    version: 0.2.5
++-  ros2/performance_test_fixture:
++-    hash: 28d6039ef9fcc9281efce60d42c769d014a6a82f0a228d5bf887868282a2d770
++-    strip_prefix: performance_test_fixture-0.0.9
++-    type: http_archive
++-    url: https://github.com/ros2/performance_test_fixture/archive/refs/tags/0.0.9.tar.gz
++-    version: 0.0.9
++-  ros2/pybind11_vendor:
++-    hash: af7ef176068f8043800f2bcc22e97db71f592619ac17252b972dcff9e6b11c0e
++-    strip_prefix: pybind11_vendor-2.4.2
++-    type: http_archive
++-    url: https://github.com/ros2/pybind11_vendor/archive/refs/tags/2.4.2.tar.gz
++-    version: 2.4.2
++-  ros2/python_cmake_module:
++-    hash: ad29e461ee43bfd7fce0b8986abced92ba31970bc2ba8fb45f5276140e5f61f2
++-    strip_prefix: python_cmake_module-0.10.0
++-    type: http_archive
++-    url: https://github.com/ros2/python_cmake_module/archive/refs/tags/0.10.0.tar.gz
++-    version: 0.10.0
++-  ros2/rcl:
++-    hash: 00de985ff9c5ea5fee1524bccf948c32dbd0610b73297a602cc2a4c7f3a35a4a
++-    strip_prefix: rcl-5.3.5
++-    type: http_archive
++-    url: https://github.com/ros2/rcl/archive/refs/tags/5.3.5.tar.gz
++-    version: 5.3.5
++-  ros2/rcl_interfaces:
++-    hash: e267048c9f78aabed4b4be11bb028c8488127587e5065c3b3daff3550df25875
++-    strip_prefix: rcl_interfaces-1.2.1
++-    type: http_archive
++-    url: https://github.com/ros2/rcl_interfaces/archive/refs/tags/1.2.1.tar.gz
++-    version: 1.2.1
++-  ros2/rcl_logging:
++-    hash: f711a7677cb68c927650e5e9f6bbb5d013dd9ae30736209f9b70f9c6485170f6
++-    strip_prefix: rcl_logging-2.3.1
++-    type: http_archive
++-    url: https://github.com/ros2/rcl_logging/archive/refs/tags/2.3.1.tar.gz
++-    version: 2.3.1
++-  ros2/rclcpp:
++-    hash: 3308f806a2e92dbeabdda36edfff3f32e303fdc34b29088adf0d2f53cbc0bd9c
++-    strip_prefix: rclcpp-16.0.6
++-    type: http_archive
++-    url: https://github.com/ros2/rclcpp/archive/refs/tags/16.0.6.tar.gz
++-    version: 16.0.6
++-  ros2/rclpy:
++-    hash: deba02252ba279310a34e1b7f100a08c5dc189b1cf1920764547996b9c961b3f
++-    strip_prefix: rclpy-3.3.10
++-    type: http_archive
++-    url: https://github.com/ros2/rclpy/archive/refs/tags/3.3.10.tar.gz
++-    version: 3.3.10
++-  ros2/rcpputils:
++-    hash: 57524f5f0b95a55add358259b859ad44d4c7cb1ed5188d87be92eab78a765a33
++-    strip_prefix: rcpputils-2.4.1
++-    type: http_archive
++-    url: https://github.com/ros2/rcpputils/archive/refs/tags/2.4.1.tar.gz
++-    version: 2.4.1
++-  ros2/rcutils:
++-    hash: c34d9ba3c9b22810e0f0b94e11b1ae8b3b9c38e970dcc9236884727f68ef7bad
++-    strip_prefix: rcutils-5.1.3
++-    type: http_archive
++-    url: https://github.com/ros2/rcutils/archive/refs/tags/5.1.3.tar.gz
++-    version: 5.1.3
++-  ros2/realtime_support:
++-    hash: f607f0eccb647a7b20fb04538c735b09c5ca13f39943575a654fa7fc12e8b39f
++-    strip_prefix: realtime_support-0.13.0
++-    type: http_archive
++-    url: https://github.com/ros2/realtime_support/archive/refs/tags/0.13.0.tar.gz
++-    version: 0.13.0
++-  ros2/rmw:
++-    hash: 3042de743e86ca36997ecd3b3da8319e6d3853dd5366d4ae4055dd6ad38e89b3
++-    strip_prefix: rmw-6.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/rmw/archive/refs/tags/6.1.1.tar.gz
++-    version: 6.1.1
++-  ros2/rmw_connextdds:
++-    hash: 262af67376298c19cb5fc23c0b285c2e21d60190ba3c48e51c4dd9944d514261
++-    strip_prefix: rmw_connextdds-0.11.2
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_connextdds/archive/refs/tags/0.11.2.tar.gz
++-    version: 0.11.2
++-  ros2/rmw_cyclonedds:
++-    hash: 58ef4fe3fd18eb723906df77eb10df1e69222b451e479c6ec85426ba48e16a8a
++-    strip_prefix: rmw_cyclonedds-1.3.4
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_cyclonedds/archive/refs/tags/1.3.4.tar.gz
++-    version: 1.3.4
++-  ros2/rmw_dds_common:
++-    hash: 85dd9f586d53b658e5389a388fe3d99a884ba06f567a59f9908ecb96e29132ef
++-    strip_prefix: rmw_dds_common-1.6.0
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_dds_common/archive/refs/tags/1.6.0.tar.gz
++-    version: 1.6.0
++-  ros2/rmw_fastrtps:
++-    hash: 7b6976219d129a318c3a28fec50bc463e30603bd31f16208c0ef3c46a7435d09
++-    strip_prefix: rmw_fastrtps-6.2.4
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_fastrtps/archive/refs/tags/6.2.4.tar.gz
++-    version: 6.2.4
++-  ros2/rmw_implementation:
++-    hash: 46067d692a9606c12132980cad8dbf00f9cac7bda358f2ce14a96c877e04aee9
++-    strip_prefix: rmw_implementation-2.8.2
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_implementation/archive/refs/tags/2.8.2.tar.gz
++-    version: 2.8.2
++-  ros2/ros2_tracing:
++-    hash: 261672e689e583c90b35d97ccea90ffec649ac55a0f045da46cbc3f69b657c5a
++-    strip_prefix: ros2_tracing-4.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/ros2_tracing/archive/refs/tags/4.1.1.tar.gz
++-    version: 4.1.1
++-  ros2/ros2cli:
++-    hash: dd862da3ff65ef4603377da21f5842d2775d55cbf89f04dfa6d42b70e28473bd
++-    strip_prefix: ros2cli-0.18.7
++-    type: http_archive
++-    url: https://github.com/ros2/ros2cli/archive/refs/tags/0.18.7.tar.gz
++-    version: 0.18.7
++-  ros2/ros2cli_common_extensions:
++-    hash: 5f019ebb88f214c788caedbe33257ae290a5956c5af93332c02d4e0946aaa702
++-    strip_prefix: ros2cli_common_extensions-0.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/ros2cli_common_extensions/archive/refs/tags/0.1.1.tar.gz
++-    version: 0.1.1
++-  ros2/ros_testing:
++-    hash: f52dc8d48e3e525597e96e5316e882a03cbed6b2d3024699219c0afc0283a38b
++-    strip_prefix: ros_testing-0.4.0
++-    type: http_archive
++-    url: https://github.com/ros2/ros_testing/archive/refs/tags/0.4.0.tar.gz
++-    version: 0.4.0
++-  ros2/rosbag2:
++-    hash: b8f10a4bb4562651c5df50b3e787ee87e2f6b30d29afe5a9044ba8acf96bc523
++-    strip_prefix: rosbag2-0.15.8
++-    type: http_archive
++-    url: https://github.com/ros2/rosbag2/archive/refs/tags/0.15.8.tar.gz
++-    version: 0.15.8
++-  ros2/rosidl:
++-    hash: 5fef4012e2dd5d1ea6921d8bb676a95806c44f1072709b0371d75b261d8139f8
++-    strip_prefix: rosidl-3.1.5
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl/archive/refs/tags/3.1.5.tar.gz
++-    version: 3.1.5
++-  ros2/rosidl_dds:
++-    hash: 5eaff06098483a0c7a54f8d998e74115e5d70b23e9c7bfff800804dcb0fb9f6a
++-    strip_prefix: rosidl_dds-0.8.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_dds/archive/refs/tags/0.8.1.tar.gz
++-    version: 0.8.1
++-  ros2/rosidl_defaults:
++-    hash: 3826d8df0402e2580606310fbf57b719ef8e17c460ab4f0367d2c600297fc66a
++-    strip_prefix: rosidl_defaults-1.2.0
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_defaults/archive/refs/tags/1.2.0.tar.gz
++-    version: 1.2.0
++-  ros2/rosidl_python:
++-    hash: 4bb38b6718a0c23aa6d799548c4cfd021ba320294673e75eaf3137821e1234d1
++-    strip_prefix: rosidl_python-0.14.4
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_python/archive/refs/tags/0.14.4.tar.gz
++-    version: 0.14.4
++-  ros2/rosidl_runtime_py:
++-    hash: 4006ed60e2544eb390a6231c3e7a676d1605601260417b4b207ef94424a38b26
++-    strip_prefix: rosidl_runtime_py-0.9.3
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_runtime_py/archive/refs/tags/0.9.3.tar.gz
++-    version: 0.9.3
++-  ros2/rosidl_typesupport:
++-    hash: ab4b5cbe2db3f03b2e91bc999bf618467b696bb316f91fc6002590d00cad23fd
++-    strip_prefix: rosidl_typesupport-2.0.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_typesupport/archive/refs/tags/2.0.1.tar.gz
++-    version: 2.0.1
++-  ros2/rosidl_typesupport_fastrtps:
++-    hash: 41deed571ab95f7d2a191af6e4536536f13266df059b0b11f6469be8e44cf304
++-    strip_prefix: rosidl_typesupport_fastrtps-2.2.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps/archive/refs/tags/2.2.1.tar.gz
++-    version: 2.2.1
++-  ros2/rpyutils:
++-    hash: f87d8c0a2b1a5c28b722f168d7170076e6d82e68c5cb31cff74f15a9fa251fb9
++-    strip_prefix: rpyutils-0.2.1
++-    type: http_archive
++-    url: https://github.com/ros2/rpyutils/archive/refs/tags/0.2.1.tar.gz
++-    version: 0.2.1
++-  ros2/rviz:
++-    hash: 77b08203c3ea781c1a43b050b3f21193ab5c54bb0179d12bf8e688eee84d8e98
++-    strip_prefix: rviz-11.2.8
++-    type: http_archive
++-    url: https://github.com/ros2/rviz/archive/refs/tags/11.2.8.tar.gz
++-    version: 11.2.8
++-  ros2/spdlog_vendor:
++-    hash: 3f9f0cbce8d6e8dd61c0f2d6462973edb16cb5c27de4f40eb5bf2a94ebb5e48f
++-    strip_prefix: spdlog_vendor-1.3.1
++-    type: http_archive
++-    url: https://github.com/ros2/spdlog_vendor/archive/refs/tags/1.3.1.tar.gz
++-    version: 1.3.1
++-  ros2/sros2:
++-    hash: b7cc3ab698e1dc4f09c45a6a14053b2c1b4cf30a9d43e1ec1718ce74d80c15cb
++-    strip_prefix: sros2-0.10.4
++-    type: http_archive
++-    url: https://github.com/ros2/sros2/archive/refs/tags/0.10.4.tar.gz
++-    version: 0.10.4
++-  ros2/system_tests:
++-    hash: d17b31af3da15aaab7ccdfd84745b2875f5979645226059acded6aef06b1f8a8
++-    strip_prefix: system_tests-0.12.3
++-    type: http_archive
++-    url: https://github.com/ros2/system_tests/archive/refs/tags/0.12.3.tar.gz
++-    version: 0.12.3
++-  ros2/test_interface_files:
++-    hash: 5f2df28f9b04e9edcef772b4d717222b098890739a49e6e0596afbf0d33ec75f
++-    strip_prefix: test_interface_files-0.9.1
++-    type: http_archive
++-    url: https://github.com/ros2/test_interface_files/archive/refs/tags/0.9.1.tar.gz
++-    version: 0.9.1
++-  ros2/tinyxml2_vendor:
++-    hash: 748a5e4d31566530e66b80c84e30e882789b9c9944c8777f19d745d184d9e411
++-    strip_prefix: tinyxml2_vendor-0.7.5
++-    type: http_archive
++-    url: https://github.com/ros2/tinyxml2_vendor/archive/refs/tags/0.7.5.tar.gz
++-    version: 0.7.5
++-  ros2/tinyxml_vendor:
++-    hash: 082e1168c25d90681a2e6973452aee4822eb6d29bc1e3ee61f31c87c82a28a33
++-    strip_prefix: tinyxml_vendor-0.8.3
++-    type: http_archive
++-    url: https://github.com/ros2/tinyxml_vendor/archive/refs/tags/0.8.3.tar.gz
++-    version: 0.8.3
++-  ros2/tlsf:
++-    hash: d4e5b0f2e06d37b7038a17b9423b06d1b63884f930af20786d4ac9d4af5a776c
++-    strip_prefix: tlsf-0.7.0
++-    type: http_archive
++-    url: https://github.com/ros2/tlsf/archive/refs/tags/0.7.0.tar.gz
++-    version: 0.7.0
++-  ros2/unique_identifier_msgs:
++-    hash: ccedcb7c2b6d927fc4f654cceab299a8cb55082953867754795c6ea2ccdd68a9
++-    strip_prefix: unique_identifier_msgs-2.2.1
++-    type: http_archive
++-    url: https://github.com/ros2/unique_identifier_msgs/archive/refs/tags/2.2.1.tar.gz
++-    version: 2.2.1
++-  ros2/urdf:
++-    hash: a762eb57dc7f60b9ada0240fd7c609f0dc5028ef0b4b65972daf91e009e52cf6
++-    strip_prefix: urdf-2.6.0
++-    type: http_archive
++-    url: https://github.com/ros2/urdf/archive/refs/tags/2.6.0.tar.gz
++-    version: 2.6.0
++-  ros2/yaml_cpp_vendor:
++-    hash: 404880afaf66890f3c3b79e83c5b433cd4be2aa01a2ce024df501f0488570842
++-    strip_prefix: yaml_cpp_vendor-8.0.2
++-    type: http_archive
++-    url: https://github.com/ros2/yaml_cpp_vendor/archive/refs/tags/8.0.2.tar.gz
++-    version: 8.0.2
++diff --git a/repos/config/ros2_iron.lock b/repos/config/ros2_iron.lock
++deleted file mode 100644
++index 9a87afa..0000000
++--- a/repos/config/ros2_iron.lock
+++++ /dev/null
++@@ -1,640 +0,0 @@
++-#
++-#   To update, call `bazel run //repos/config:repos_lock.update` with the right distro set in the WORKSPACE
++-#
++-repositories:
++-  ament/ament_cmake:
++-    hash: c2b6c6556fef3a11ada6ed1582aad1e96d0c99f80ce8d44e9fc4b8cceab80295
++-    strip_prefix: ament_cmake-2.0.3
++-    type: http_archive
++-    url: https://github.com/ament/ament_cmake/archive/refs/tags/2.0.3.tar.gz
++-    version: 2.0.3
++-  ament/ament_index:
++-    hash: 148bc65f5d12700ada5d76b93ba66a05b99c4fe4221f294bceb292c15f08a38c
++-    strip_prefix: ament_index-1.5.2
++-    type: http_archive
++-    url: https://github.com/ament/ament_index/archive/refs/tags/1.5.2.tar.gz
++-    version: 1.5.2
++-  ament/ament_lint:
++-    hash: 4abea3d56fe234a12db71d2e68a79f046cfe64e27a7bd8603832f239f5a9a176
++-    strip_prefix: ament_lint-0.14.2
++-    type: http_archive
++-    url: https://github.com/ament/ament_lint/archive/refs/tags/0.14.2.tar.gz
++-    version: 0.14.2
++-  ament/ament_package:
++-    hash: 0d237006f51dafa32486583696558b178cc2bc114b556fcd13af366f749513f3
++-    strip_prefix: ament_package-0.15.3
++-    type: http_archive
++-    url: https://github.com/ament/ament_package/archive/refs/tags/0.15.3.tar.gz
++-    version: 0.15.3
++-  ament/google_benchmark_vendor:
++-    hash: 4864c4b43709e17ebda8f08cba66e1bbaa23e22613d22b0febbfb1e3d9f576e9
++-    strip_prefix: google_benchmark_vendor-0.3.0
++-    type: http_archive
++-    url: https://github.com/ament/google_benchmark_vendor/archive/refs/tags/0.3.0.tar.gz
++-    version: 0.3.0
++-  ament/googletest:
++-    hash: 3ade05c790816b12d88ffed584dc2bf39346fb1bde328d20c5566a1e17b79f30
++-    strip_prefix: googletest-1.10.9005
++-    type: http_archive
++-    url: https://github.com/ament/googletest/archive/refs/tags/1.10.9005.tar.gz
++-    version: 1.10.9005
++-  ament/uncrustify_vendor:
++-    hash: 157addbd01a71468771a53274ba34382ab2717394b5c6bbcbb308e0779cc9f6a
++-    strip_prefix: uncrustify_vendor-2.1.2
++-    type: http_archive
++-    url: https://github.com/ament/uncrustify_vendor/archive/refs/tags/2.1.2.tar.gz
++-    version: 2.1.2
++-  eProsima/Fast-CDR:
++-    hash: a9bc8fd31a2c2b95e6d2fb46e6ce1ad733e86dc4442f733479e33ed9cdc54bf6
++-    strip_prefix: Fast-CDR-1.0.27
++-    type: http_archive
++-    url: https://github.com/eProsima/Fast-CDR/archive/refs/tags/v1.0.27.tar.gz
++-    version: v1.0.27
++-  eProsima/Fast-DDS:
++-    hash: 68fe3db6bb03823eb0d707eb6c8087049be7a7494571092c16e2489497def022
++-    strip_prefix: Fast-DDS-2.10.2
++-    type: http_archive
++-    url: https://github.com/eProsima/Fast-DDS/archive/refs/tags/v2.10.2.tar.gz
++-    version: v2.10.2
++-  eProsima/foonathan_memory_vendor:
++-    hash: bd72f3dd66a2a66c46bc28eff32de618462ddfee8e3e98b8ec3efee4ffbae880
++-    strip_prefix: foonathan_memory_vendor-1.3.0
++-    type: http_archive
++-    url: https://github.com/eProsima/foonathan_memory_vendor/archive/refs/tags/v1.3.0.tar.gz
++-    version: v1.3.0
++-  eclipse-cyclonedds/cyclonedds:
++-    hash: bc79696209febfe66d97e7af6b11e92f9db663caf608a922b6c201b1d6a5eb62
++-    strip_prefix: cyclonedds-0.10.3
++-    type: http_archive
++-    url: https://github.com/eclipse-cyclonedds/cyclonedds/archive/refs/tags/0.10.3.tar.gz
++-    version: 0.10.3
++-  eclipse-iceoryx/iceoryx:
++-    hash: 8f391696daf2e63da9437aab8d7154371df630fc93876479f2e84c693fc1ba5a
++-    strip_prefix: iceoryx-2.0.3
++-    type: http_archive
++-    url: https://github.com/eclipse-iceoryx/iceoryx/archive/refs/tags/v2.0.3.tar.gz
++-    version: v2.0.3
++-  gazebo-release/gz_cmake2_vendor:
++-    hash: 56c578263240deea251e0e288a967db60ea2b56b58ee6d7f86f9fd059189a309
++-    strip_prefix: gz_cmake2_vendor-0.1.0
++-    type: http_archive
++-    url: https://github.com/gazebo-release/gz_cmake2_vendor/archive/refs/tags/0.1.0.tar.gz
++-    version: 0.1.0
++-  gazebo-release/gz_math6_vendor:
++-    hash: f99105bd9ee4290cbed70efea578917fdcc1cf1a5ebf8010e1b7af6daaec2840
++-    strip_prefix: gz_math6_vendor-0.1.0
++-    type: http_archive
++-    url: https://github.com/gazebo-release/gz_math6_vendor/archive/refs/tags/0.1.0.tar.gz
++-    version: 0.1.0
++-  osrf/osrf_pycommon:
++-    hash: a1b00e27f0190b46a5ab92974e8a34ac47537ffd6639428ccb3c0919d4a11537
++-    strip_prefix: osrf_pycommon-2.1.2
++-    type: http_archive
++-    url: https://github.com/osrf/osrf_pycommon/archive/refs/tags/2.1.2.tar.gz
++-    version: 2.1.2
++-  osrf/osrf_testing_tools_cpp:
++-    hash: 30e5cfe7f74e718377430376de13c672f189b3e0fff1ba89ea97122e3064e99e
++-    strip_prefix: osrf_testing_tools_cpp-1.6.0
++-    type: http_archive
++-    url: https://github.com/osrf/osrf_testing_tools_cpp/archive/refs/tags/1.6.0.tar.gz
++-    version: 1.6.0
++-  ros-perception/image_common:
++-    hash: be3eee5e6ba899098e395f338fc524aab93744ac1b3a9a58a32f72fc1b469127
++-    strip_prefix: image_common-4.2.2
++-    type: http_archive
++-    url: https://github.com/ros-perception/image_common/archive/refs/tags/4.2.2.tar.gz
++-    version: 4.2.2
++-  ros-perception/laser_geometry:
++-    hash: 71fb1b2f1fb08e071efb0e482f140a0d881e95b0433a01c5e5185ca0499b2376
++-    strip_prefix: laser_geometry-2.5.0
++-    type: http_archive
++-    url: https://github.com/ros-perception/laser_geometry/archive/refs/tags/2.5.0.tar.gz
++-    version: 2.5.0
++-  ros-planning/navigation_msgs:
++-    hash: af395b89e190da5ed4818f680e67d5a0cf320e5c21fb5f50d23603d5b945f115
++-    strip_prefix: navigation_msgs-2.2.0
++-    type: http_archive
++-    url: https://github.com/ros-planning/navigation_msgs/archive/refs/tags/2.2.0.tar.gz
++-    version: 2.2.0
++-  ros-tooling/keyboard_handler:
++-    hash: 2bb52d551a09a8c001009e9cce98459e36ac1faf3e8b4d7d47238d2f6451f81f
++-    strip_prefix: keyboard_handler-0.1.0
++-    type: http_archive
++-    url: https://github.com/ros-tooling/keyboard_handler/archive/refs/tags/0.1.0.tar.gz
++-    version: 0.1.0
++-  ros-tooling/libstatistics_collector:
++-    hash: e3cae09351a29eeb3ba10aa2ecfe5fc8a1307de48bc68c4d34b2cacff3fce1b5
++-    strip_prefix: libstatistics_collector-1.5.1
++-    type: http_archive
++-    url: https://github.com/ros-tooling/libstatistics_collector/archive/refs/tags/1.5.1.tar.gz
++-    version: 1.5.1
++-  ros-visualization/interactive_markers:
++-    hash: b739b64496992644939df7f9d36587e944445e0e94dca2c227dd2ef8ebfceaef
++-    strip_prefix: interactive_markers-2.4.0
++-    type: http_archive
++-    url: https://github.com/ros-visualization/interactive_markers/archive/refs/tags/2.4.0.tar.gz
++-    version: 2.4.0
++-  ros-visualization/python_qt_binding:
++-    hash: cad340c5978f97a1d1d209bd0a91b2840bdfe6cc752674e0d845dbb736007f8f
++-    strip_prefix: python_qt_binding-1.2.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/python_qt_binding/archive/refs/tags/1.2.3.tar.gz
++-    version: 1.2.3
++-  ros-visualization/qt_gui_core:
++-    hash: f1e3796581cc342416c9cfbae5b4be19a2ca9415368a3704d37320253238a06a
++-    strip_prefix: qt_gui_core-2.4.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/qt_gui_core/archive/refs/tags/2.4.2.tar.gz
++-    version: 2.4.2
++-  ros-visualization/rqt:
++-    hash: 5ec59f9e01ded168d7aa65b1ac0193193b35d02f6a960ae588730505a71ebaf1
++-    strip_prefix: rqt-1.3.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt/archive/refs/tags/1.3.3.tar.gz
++-    version: 1.3.3
++-  ros-visualization/rqt_action:
++-    hash: 1ae559b72680b0578dbe13ccea3b5221f7e8a2425092c7b822b75bad5a420e2e
++-    strip_prefix: rqt_action-2.1.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_action/archive/refs/tags/2.1.2.tar.gz
++-    version: 2.1.2
++-  ros-visualization/rqt_bag:
++-    hash: 6ac08b2606d0ffa78f3c58eea611f3c11cbac64ce317f5005a94bbac79cf121c
++-    strip_prefix: rqt_bag-1.3.4
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_bag/archive/refs/tags/1.3.4.tar.gz
++-    version: 1.3.4
++-  ros-visualization/rqt_console:
++-    hash: 7d691a4d6c9d1c9d6fb3da28778cb62618675ac6227be96c0ca505906a59c790
++-    strip_prefix: rqt_console-2.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_console/archive/refs/tags/2.1.1.tar.gz
++-    version: 2.1.1
++-  ros-visualization/rqt_graph:
++-    hash: e2464d9b4bc261e974d96fcd5255279b653c95108c70a8f951c1aae168dea616
++-    strip_prefix: rqt_graph-1.4.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_graph/archive/refs/tags/1.4.2.tar.gz
++-    version: 1.4.2
++-  ros-visualization/rqt_msg:
++-    hash: 3a318bff7c7d85fc86fa052f83de5d8359d7f8477574bd15dd3e2aab7911e4cd
++-    strip_prefix: rqt_msg-1.3.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_msg/archive/refs/tags/1.3.1.tar.gz
++-    version: 1.3.1
++-  ros-visualization/rqt_plot:
++-    hash: d2436d19179806919d124619c7345a515e41c0b350754b1344eb8cdd99691513
++-    strip_prefix: rqt_plot-1.2.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_plot/archive/refs/tags/1.2.3.tar.gz
++-    version: 1.2.3
++-  ros-visualization/rqt_publisher:
++-    hash: bbccdf7be70d0fa6f3d1e9cc71c97c4983bb201af60adc8f9b973dd7e2d168aa
++-    strip_prefix: rqt_publisher-1.6.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_publisher/archive/refs/tags/1.6.3.tar.gz
++-    version: 1.6.3
++-  ros-visualization/rqt_py_console:
++-    hash: 76b5359a366c60b472cd23e02f6a58c0eb54d3ed31f4c427ca8c53c7d5cef320
++-    strip_prefix: rqt_py_console-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_py_console/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/rqt_reconfigure:
++-    hash: 4678b4617f17b7919e613af4ce6b7c51398c9727820414c8de5ea6f0792b1264
++-    strip_prefix: rqt_reconfigure-1.3.3
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_reconfigure/archive/refs/tags/1.3.3.tar.gz
++-    version: 1.3.3
++-  ros-visualization/rqt_service_caller:
++-    hash: db3bce8077421b1ee55b592c4f5f89f3f7e2aadcba833b1d6fb698319de76d18
++-    strip_prefix: rqt_service_caller-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_service_caller/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/rqt_shell:
++-    hash: 461fd796de437b834a28ec6d33b4ce9fa5fa93cd87aaeefd9a2c5b0fb330e900
++-    strip_prefix: rqt_shell-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_shell/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/rqt_srv:
++-    hash: c609f12eca2879bb35eef915e78a017e02160c7bf53a989568d2c6b38513b609
++-    strip_prefix: rqt_srv-1.1.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_srv/archive/refs/tags/1.1.1.tar.gz
++-    version: 1.1.1
++-  ros-visualization/rqt_topic:
++-    hash: 2b564554edf778a928dbc3bd16d9c1ba7e1933118755a9f8b77e74a874e88d53
++-    strip_prefix: rqt_topic-1.6.1
++-    type: http_archive
++-    url: https://github.com/ros-visualization/rqt_topic/archive/refs/tags/1.6.1.tar.gz
++-    version: 1.6.1
++-  ros-visualization/tango_icons_vendor:
++-    hash: 08b40ec1061c355389e57ecbed1bb76c5ced1f348b62b54b469cb3ad863e3788
++-    strip_prefix: tango_icons_vendor-0.2.2
++-    type: http_archive
++-    url: https://github.com/ros-visualization/tango_icons_vendor/archive/refs/tags/0.2.2.tar.gz
++-    version: 0.2.2
++-  ros/class_loader:
++-    hash: 474267bf0a4d18cf2ff0d696841a7399047797471e752be818933e4d1eab042c
++-    strip_prefix: class_loader-2.5.0
++-    type: http_archive
++-    url: https://github.com/ros/class_loader/archive/refs/tags/2.5.0.tar.gz
++-    version: 2.5.0
++-  ros/kdl_parser:
++-    hash: 0a7849d3cc1d30926b1d92fb1182424b0cba450b2bbaa16120c0cf7ec534d02f
++-    strip_prefix: kdl_parser-2.9.0
++-    type: http_archive
++-    url: https://github.com/ros/kdl_parser/archive/refs/tags/2.9.0.tar.gz
++-    version: 2.9.0
++-  ros/pluginlib:
++-    hash: fa51490338fcc85ae116c1c992d3d6428270de36983f284523c2bdf732c39556
++-    strip_prefix: pluginlib-5.2.2
++-    type: http_archive
++-    url: https://github.com/ros/pluginlib/archive/refs/tags/5.2.2.tar.gz
++-    version: 5.2.2
++-  ros/resource_retriever:
++-    hash: d2bf40bcadb820a19c2deccdc6a58a60e22bd9a87b118df9f1ee6be07ceb9eed
++-    strip_prefix: resource_retriever-3.2.2
++-    type: http_archive
++-    url: https://github.com/ros/resource_retriever/archive/refs/tags/3.2.2.tar.gz
++-    version: 3.2.2
++-  ros/robot_state_publisher:
++-    hash: 4e903b567895e92770e6501866eb87f63290523f8ba07995deeebb3ceda918ab
++-    strip_prefix: robot_state_publisher-3.2.0
++-    type: http_archive
++-    url: https://github.com/ros/robot_state_publisher/archive/refs/tags/3.2.0.tar.gz
++-    version: 3.2.0
++-  ros/ros_environment:
++-    hash: 89a81c5431b6dcb7d6103cebdfff39a8cc75ecbe06cdc9803170a3235c3f4928
++-    strip_prefix: ros_environment-4.1.1
++-    type: http_archive
++-    url: https://github.com/ros/ros_environment/archive/refs/tags/4.1.1.tar.gz
++-    version: 4.1.1
++-  ros/ros_tutorials:
++-    hash: 22f66f84c1d6affb51ae1c1a6f47505661a962b8c221a59a4860fcb69b3c6352
++-    strip_prefix: ros_tutorials-1.6.1
++-    type: http_archive
++-    url: https://github.com/ros/ros_tutorials/archive/refs/tags/1.6.1.tar.gz
++-    version: 1.6.1
++-  ros/urdfdom:
++-    hash: dd69b2077b8fc1bd2b67022c1dc861cd896ac882df065aa08cabdf2f945a9ac0
++-    strip_prefix: urdfdom-3.1.1
++-    type: http_archive
++-    url: https://github.com/ros/urdfdom/archive/refs/tags/3.1.1.tar.gz
++-    version: 3.1.1
++-  ros/urdfdom_headers:
++-    hash: 01b91c2f7cb42b0033cbdf559684a60001f9927e5d0a5a3682a344cc354f1d39
++-    strip_prefix: urdfdom_headers-1.1.0
++-    type: http_archive
++-    url: https://github.com/ros/urdfdom_headers/archive/refs/tags/1.1.0.tar.gz
++-    version: 1.1.0
++-  ros2/ament_cmake_ros:
++-    hash: 8cff1fbc298920709c7efa92f56fc00902a906ff6bab5c52be9df26971a8a9ca
++-    strip_prefix: ament_cmake_ros-0.11.2
++-    type: http_archive
++-    url: https://github.com/ros2/ament_cmake_ros/archive/refs/tags/0.11.2.tar.gz
++-    version: 0.11.2
++-  ros2/common_interfaces:
++-    hash: fb3c8c4eb9afe15e94ec8e9fb5bd05c6de71782370cfd6d453da416621c55212
++-    strip_prefix: common_interfaces-5.0.0
++-    type: http_archive
++-    url: https://github.com/ros2/common_interfaces/archive/refs/tags/5.0.0.tar.gz
++-    version: 5.0.0
++-  ros2/console_bridge_vendor:
++-    hash: 62aef22f5d30a95415852f5a4c786b18c9df7785ced820d8d5c837218c2c8e8f
++-    strip_prefix: console_bridge_vendor-1.6.0
++-    type: http_archive
++-    url: https://github.com/ros2/console_bridge_vendor/archive/refs/tags/1.6.0.tar.gz
++-    version: 1.6.0
++-  ros2/demos:
++-    hash: 50fe887912e11e497d78d4bfdf5b44fe4a24bad927e3e36b7976376a1dc5e714
++-    strip_prefix: demos-0.27.1
++-    type: http_archive
++-    url: https://github.com/ros2/demos/archive/refs/tags/0.27.1.tar.gz
++-    version: 0.27.1
++-  ros2/eigen3_cmake_module:
++-    hash: 5d14617e3df89214e19a209110c22e222fdf94332e3814e10aaf19424bc7a999
++-    strip_prefix: eigen3_cmake_module-0.2.2
++-    type: http_archive
++-    url: https://github.com/ros2/eigen3_cmake_module/archive/refs/tags/0.2.2.tar.gz
++-    version: 0.2.2
++-  ros2/example_interfaces:
++-    hash: 53b82d16975d73d037b5d958d2d9594446c0fb03061639cc0f9f51500146bbad
++-    strip_prefix: example_interfaces-0.10.2
++-    type: http_archive
++-    url: https://github.com/ros2/example_interfaces/archive/refs/tags/0.10.2.tar.gz
++-    version: 0.10.2
++-  ros2/examples:
++-    hash: 324a70655cc7b35ad9665732733e4d59a967d2e4c1a3ad88b83088fc26f4e92f
++-    strip_prefix: examples-0.18.0
++-    type: http_archive
++-    url: https://github.com/ros2/examples/archive/refs/tags/0.18.0.tar.gz
++-    version: 0.18.0
++-  ros2/geometry2:
++-    hash: c08308e55dc41e702b08938e651d4bfa7a9b099b20902af737eab8af2b2c2168
++-    strip_prefix: geometry2-0.31.5
++-    type: http_archive
++-    url: https://github.com/ros2/geometry2/archive/refs/tags/0.31.5.tar.gz
++-    version: 0.31.5
++-  ros2/launch:
++-    hash: a9460a982564eb3a60e30888e8e11c58a1275f256301583cc6cfef6ea01d5897
++-    strip_prefix: launch-2.0.2
++-    type: http_archive
++-    url: https://github.com/ros2/launch/archive/refs/tags/2.0.2.tar.gz
++-    version: 2.0.2
++-  ros2/launch_ros:
++-    hash: 9f60c4afc250e384cee751fad73846a33d240deda21cbe7116bfe0da9d06bcd8
++-    strip_prefix: launch_ros-0.24.0
++-    type: http_archive
++-    url: https://github.com/ros2/launch_ros/archive/refs/tags/0.24.0.tar.gz
++-    version: 0.24.0
++-  ros2/libyaml_vendor:
++-    hash: 857d78b0fd870167b1361f8cab4fb73e5b0453341dc55b6b0aad531807fc608d
++-    strip_prefix: libyaml_vendor-1.5.0
++-    type: http_archive
++-    url: https://github.com/ros2/libyaml_vendor/archive/refs/tags/1.5.0.tar.gz
++-    version: 1.5.0
++-  ros2/message_filters:
++-    hash: 4831217bdd605610d2d3e99e9b0bc08b616b6ba457384ed35754d0dcc99f5a5d
++-    strip_prefix: message_filters-4.7.0
++-    type: http_archive
++-    url: https://github.com/ros2/message_filters/archive/refs/tags/4.7.0.tar.gz
++-    version: 4.7.0
++-  ros2/mimick_vendor:
++-    hash: cb7bf9dd7ebb016b930caa0211f272386121af8c6dc821d81d08edcc14c802bf
++-    strip_prefix: mimick_vendor-0.3.2
++-    type: http_archive
++-    url: https://github.com/ros2/mimick_vendor/archive/refs/tags/0.3.2.tar.gz
++-    version: 0.3.2
++-  ros2/orocos_kdl_vendor:
++-    hash: 978fd57cc12b9312d24b7b3af6539146f9cf886dfa540ce437c87759e6ac2aa5
++-    strip_prefix: orocos_kdl_vendor-0.3.4
++-    type: http_archive
++-    url: https://github.com/ros2/orocos_kdl_vendor/archive/refs/tags/0.3.4.tar.gz
++-    version: 0.3.4
++-  ros2/performance_test_fixture:
++-    hash: 3fe3c7bd50ffacf4c4a0aaefb9b06be60586bbc2f6c0f61a81994effefb11570
++-    strip_prefix: performance_test_fixture-0.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/performance_test_fixture/archive/refs/tags/0.1.1.tar.gz
++-    version: 0.1.1
++-  ros2/pybind11_vendor:
++-    hash: fc5b2ab7f4e4e0faac2b882d3b8c354eeba0757991e51021cf1fab58ae9df33d
++-    strip_prefix: pybind11_vendor-3.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/pybind11_vendor/archive/refs/tags/3.0.3.tar.gz
++-    version: 3.0.3
++-  ros2/python_cmake_module:
++-    hash: 3660a48dc3d70f2a9a37ce56650d6c339102a06b9a5c822a405a93b61f26205f
++-    strip_prefix: python_cmake_module-0.10.2
++-    type: http_archive
++-    url: https://github.com/ros2/python_cmake_module/archive/refs/tags/0.10.2.tar.gz
++-    version: 0.10.2
++-  ros2/rcl:
++-    hash: eab9fa9df1b130e390f38d1b2c20111154db710d111f1b5078dd6b6243b48719
++-    strip_prefix: rcl-6.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/rcl/archive/refs/tags/6.0.3.tar.gz
++-    version: 6.0.3
++-  ros2/rcl_interfaces:
++-    hash: f11a84e58231eb8afeb5398ea5705d6896fc7e68b80d111b1a0fa992cc981f9d
++-    strip_prefix: rcl_interfaces-1.6.0
++-    type: http_archive
++-    url: https://github.com/ros2/rcl_interfaces/archive/refs/tags/1.6.0.tar.gz
++-    version: 1.6.0
++-  ros2/rcl_logging:
++-    hash: 1f9286326683270d97420efbf2e552cb0e0afa80e26225dcc058f788a4491af6
++-    strip_prefix: rcl_logging-2.5.1
++-    type: http_archive
++-    url: https://github.com/ros2/rcl_logging/archive/refs/tags/2.5.1.tar.gz
++-    version: 2.5.1
++-  ros2/rclcpp:
++-    hash: 2dee67d9d168060341016ff4710879dcda5b16e52e48c7de6afa4463c2b7ea19
++-    strip_prefix: rclcpp-21.0.3
++-    type: http_archive
++-    url: https://github.com/ros2/rclcpp/archive/refs/tags/21.0.3.tar.gz
++-    version: 21.0.3
++-  ros2/rclpy:
++-    hash: d972bbe7e271cc7a0e85830252552cd25c136ace3f132a5acefba2b684e78083
++-    strip_prefix: rclpy-4.1.3
++-    type: http_archive
++-    url: https://github.com/ros2/rclpy/archive/refs/tags/4.1.3.tar.gz
++-    version: 4.1.3
++-  ros2/rcpputils:
++-    hash: a3379a610840bec655a8a2650df0438812f8ab6d44e6ca5bdc1156c933631017
++-    strip_prefix: rcpputils-2.6.1
++-    type: http_archive
++-    url: https://github.com/ros2/rcpputils/archive/refs/tags/2.6.1.tar.gz
++-    version: 2.6.1
++-  ros2/rcutils:
++-    hash: 6ee6c151c1763b19fb3481db3e55b72e0a65abc35e4c1bf62c4784663e309ca6
++-    strip_prefix: rcutils-6.2.1
++-    type: http_archive
++-    url: https://github.com/ros2/rcutils/archive/refs/tags/6.2.1.tar.gz
++-    version: 6.2.1
++-  ros2/realtime_support:
++-    hash: 4406f870e9ddbe6acb485d1c1c8fb3e18beb593591107f68b0a28848265f4b37
++-    strip_prefix: realtime_support-0.15.0
++-    type: http_archive
++-    url: https://github.com/ros2/realtime_support/archive/refs/tags/0.15.0.tar.gz
++-    version: 0.15.0
++-  ros2/rmw:
++-    hash: 8233d20a6d3789cf80cc932bf1718498e324313e6143af5ffa3f408c63ce47b0
++-    strip_prefix: rmw-7.1.0
++-    type: http_archive
++-    url: https://github.com/ros2/rmw/archive/refs/tags/7.1.0.tar.gz
++-    version: 7.1.0
++-  ros2/rmw_connextdds:
++-    hash: 35da85c543ff296c3e2014f62c560491a1b698fc01fa3727d539837f8999c174
++-    strip_prefix: rmw_connextdds-0.14.1
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_connextdds/archive/refs/tags/0.14.1.tar.gz
++-    version: 0.14.1
++-  ros2/rmw_cyclonedds:
++-    hash: f638e82ed026926133d5f43887b2efb252da4b4783fe2d9db9b56e1fdecaa23f
++-    strip_prefix: rmw_cyclonedds-1.6.0
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_cyclonedds/archive/refs/tags/1.6.0.tar.gz
++-    version: 1.6.0
++-  ros2/rmw_dds_common:
++-    hash: 4ca5670170f5f0c5564839ee2d9089c86d1a876d9454969153566c6419d75c5c
++-    strip_prefix: rmw_dds_common-2.0.1
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_dds_common/archive/refs/tags/2.0.1.tar.gz
++-    version: 2.0.1
++-  ros2/rmw_fastrtps:
++-    hash: 4a2f240bf09f91cd7acf2b706df3e6536ab0e56edb5a502a43c4948cc2cf8910
++-    strip_prefix: rmw_fastrtps-7.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_fastrtps/archive/refs/tags/7.1.1.tar.gz
++-    version: 7.1.1
++-  ros2/rmw_implementation:
++-    hash: 7c4013a226654c97648ab59af86520b0f755a12a6d806b46b32335ae2e468bd4
++-    strip_prefix: rmw_implementation-2.12.0
++-    type: http_archive
++-    url: https://github.com/ros2/rmw_implementation/archive/refs/tags/2.12.0.tar.gz
++-    version: 2.12.0
++-  ros2/ros2_tracing:
++-    hash: 7b3c16120a58927f43dc083b5b187604d7686c7a61a08baa394e08b5e7b30ead
++-    strip_prefix: ros2_tracing-6.3.1
++-    type: http_archive
++-    url: https://github.com/ros2/ros2_tracing/archive/refs/tags/6.3.1.tar.gz
++-    version: 6.3.1
++-  ros2/ros2cli:
++-    hash: 19b8ef30edd9dc73f1b0d7abcce0f20ce2ae836f29a0c83009e7fb958db2cea4
++-    strip_prefix: ros2cli-0.25.3
++-    type: http_archive
++-    url: https://github.com/ros2/ros2cli/archive/refs/tags/0.25.3.tar.gz
++-    version: 0.25.3
++-  ros2/ros2cli_common_extensions:
++-    hash: 3bd8e4c049d904db8b2f2fcaa5858598b07d9a55b785f565f03ad65d0ea328a6
++-    strip_prefix: ros2cli_common_extensions-0.2.2
++-    type: http_archive
++-    url: https://github.com/ros2/ros2cli_common_extensions/archive/refs/tags/0.2.2.tar.gz
++-    version: 0.2.2
++-  ros2/ros_testing:
++-    hash: 776c812ae782c805466bdf383e36e9355111f6076a45e1a5982e74edbf00f6f1
++-    strip_prefix: ros_testing-0.5.2
++-    type: http_archive
++-    url: https://github.com/ros2/ros_testing/archive/refs/tags/0.5.2.tar.gz
++-    version: 0.5.2
++-  ros2/rosbag2:
++-    hash: 4f56edc8947ecffbdbff26c78ead62c3aaa3237c7e39bca6c6601ad3f215a824
++-    strip_prefix: rosbag2-0.22.3
++-    type: http_archive
++-    url: https://github.com/ros2/rosbag2/archive/refs/tags/0.22.3.tar.gz
++-    version: 0.22.3
++-  ros2/rosidl:
++-    hash: 8b83d6bb56f290548961f37d9174807b148fbd38921c1eaddb48eb08616b8767
++-    strip_prefix: rosidl-4.0.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl/archive/refs/tags/4.0.1.tar.gz
++-    version: 4.0.1
++-  ros2/rosidl_core:
++-    hash: 4b217d14438c52e48495044b732b676376311ee75b061dda4524abc9e9f89481
++-    strip_prefix: rosidl_core-0.1.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_core/archive/refs/tags/0.1.1.tar.gz
++-    version: 0.1.1
++-  ros2/rosidl_dds:
++-    hash: 9d206455ec46778f5528828ee4033b1e0c4d85104a7b0de57c993dc79ddf3f74
++-    strip_prefix: rosidl_dds-0.10.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_dds/archive/refs/tags/0.10.1.tar.gz
++-    version: 0.10.1
++-  ros2/rosidl_defaults:
++-    hash: 6393d8106623ccb06baa7492da5d29415faedb74f4d936833928f3d3e277990d
++-    strip_prefix: rosidl_defaults-1.5.0
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_defaults/archive/refs/tags/1.5.0.tar.gz
++-    version: 1.5.0
++-  ros2/rosidl_dynamic_typesupport:
++-    hash: 18cab4d1c59e84e5d374997a592856f733eaa90b6bc7257f95aa01d337a26e68
++-    strip_prefix: rosidl_dynamic_typesupport-0.0.4
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_dynamic_typesupport/archive/refs/tags/0.0.4.tar.gz
++-    version: 0.0.4
++-  ros2/rosidl_dynamic_typesupport_fastrtps:
++-    hash: c16a4cfcf10f6ea22047dfc68fa8264357cf402a7f43c291378b633bf7d617a2
++-    strip_prefix: rosidl_dynamic_typesupport_fastrtps-0.0.2
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_dynamic_typesupport_fastrtps/archive/refs/tags/0.0.2.tar.gz
++-    version: 0.0.2
++-  ros2/rosidl_python:
++-    hash: 424539f63d426f79ac5942766fcb04e56d805ce44c7611ba604df04b5088046e
++-    strip_prefix: rosidl_python-0.18.0
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_python/archive/refs/tags/0.18.0.tar.gz
++-    version: 0.18.0
++-  ros2/rosidl_runtime_py:
++-    hash: 0d6a82d5f68a204971c81be94a7c0620a237456f1c41c132929894cebe89a340
++-    strip_prefix: rosidl_runtime_py-0.12.0
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_runtime_py/archive/refs/tags/0.12.0.tar.gz
++-    version: 0.12.0
++-  ros2/rosidl_typesupport:
++-    hash: e711d7eb0f10d5f3522c960407304268abfbcc4282ad700fca43eff30465d8b0
++-    strip_prefix: rosidl_typesupport-3.0.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_typesupport/archive/refs/tags/3.0.1.tar.gz
++-    version: 3.0.1
++-  ros2/rosidl_typesupport_fastrtps:
++-    hash: 9976b2125b14e811ab91b403971b6bf96c0ef511fb53326fb6cfed75a21c5a05
++-    strip_prefix: rosidl_typesupport_fastrtps-3.0.1
++-    type: http_archive
++-    url: https://github.com/ros2/rosidl_typesupport_fastrtps/archive/refs/tags/3.0.1.tar.gz
++-    version: 3.0.1
++-  ros2/rpyutils:
++-    hash: 0199f411887d8819d5787b30e0a3a0f806d7d6444be385f02bcd296d00aaa30a
++-    strip_prefix: rpyutils-0.3.2
++-    type: http_archive
++-    url: https://github.com/ros2/rpyutils/archive/refs/tags/0.3.2.tar.gz
++-    version: 0.3.2
++-  ros2/rviz:
++-    hash: cb0bc1bfe1447469d6a57b85a32da11116d0d8f2b642ddf78e3cd5a9409dcec4
++-    strip_prefix: rviz-12.4.4
++-    type: http_archive
++-    url: https://github.com/ros2/rviz/archive/refs/tags/12.4.4.tar.gz
++-    version: 12.4.4
++-  ros2/spdlog_vendor:
++-    hash: e531a692f181a709c748e228a7ece3ee7efefacfb04e35740abd5657ee62303a
++-    strip_prefix: spdlog_vendor-1.4.4
++-    type: http_archive
++-    url: https://github.com/ros2/spdlog_vendor/archive/refs/tags/1.4.4.tar.gz
++-    version: 1.4.4
++-  ros2/sros2:
++-    hash: b5810459526f46d377a07a992becf895f3a18bbd5c22bb7c31c74cad13dd0b6e
++-    strip_prefix: sros2-0.11.3
++-    type: http_archive
++-    url: https://github.com/ros2/sros2/archive/refs/tags/0.11.3.tar.gz
++-    version: 0.11.3
++-  ros2/system_tests:
++-    hash: 92b749ba5dd629253df0de91714eafc16b3d72322c3f196d0204b222a2a7d462
++-    strip_prefix: system_tests-0.15.2
++-    type: http_archive
++-    url: https://github.com/ros2/system_tests/archive/refs/tags/0.15.2.tar.gz
++-    version: 0.15.2
++-  ros2/test_interface_files:
++-    hash: 20bfbc6f5ca5d5ceb4a3bbfea0eebb5d0cde7f95d4893f0acbf1f699ce8b0cca
++-    strip_prefix: test_interface_files-0.10.2
++-    type: http_archive
++-    url: https://github.com/ros2/test_interface_files/archive/refs/tags/0.10.2.tar.gz
++-    version: 0.10.2
++-  ros2/tinyxml2_vendor:
++-    hash: 6b0ee498aee3c91def08a39e15d8ba57910ac0e702aedf5e4e1f3b75a86b06a7
++-    strip_prefix: tinyxml2_vendor-0.8.3
++-    type: http_archive
++-    url: https://github.com/ros2/tinyxml2_vendor/archive/refs/tags/0.8.3.tar.gz
++-    version: 0.8.3
++-  ros2/tinyxml_vendor:
++-    hash: 771eecfd2fd0c37f82f735ea520ddc76817c909ee48192ee63dece2e7c74861a
++-    strip_prefix: tinyxml_vendor-0.9.2
++-    type: http_archive
++-    url: https://github.com/ros2/tinyxml_vendor/archive/refs/tags/0.9.2.tar.gz
++-    version: 0.9.2
++-  ros2/tlsf:
++-    hash: 272004c0f82334f246904be7d9ea92f2328c0d71d79fe5b27e625a4a265363a7
++-    strip_prefix: tlsf-0.8.2
++-    type: http_archive
++-    url: https://github.com/ros2/tlsf/archive/refs/tags/0.8.2.tar.gz
++-    version: 0.8.2
++-  ros2/unique_identifier_msgs:
++-    hash: d2c6f69de9ee41782aee78dcea6aac16e2cebbed66c4740a756043f749c15b52
++-    strip_prefix: unique_identifier_msgs-2.3.2
++-    type: http_archive
++-    url: https://github.com/ros2/unique_identifier_msgs/archive/refs/tags/2.3.2.tar.gz
++-    version: 2.3.2
++-  ros2/urdf:
++-    hash: 87b981685016310eb2de8548c5e4717114634a408207a09c3c6043c7d6876d3a
++-    strip_prefix: urdf-2.8.2
++-    type: http_archive
++-    url: https://github.com/ros2/urdf/archive/refs/tags/2.8.2.tar.gz
++-    version: 2.8.2
++-  ros2/yaml_cpp_vendor:
++-    hash: d63d1a8443b89bbd1c7919ab3ed46527d08e6b242ad7d6b850b490c208c64f12
++-    strip_prefix: yaml_cpp_vendor-8.1.2
++-    type: http_archive
++-    url: https://github.com/ros2/yaml_cpp_vendor/archive/refs/tags/8.1.2.tar.gz
++-    version: 8.1.2
++diff --git a/repos/config/setup_dashing.lock.bzl b/repos/config/setup_dashing.lock.bzl
++new file mode 100644
++index 0000000..32b64f3
++--- /dev/null
+++++ b/repos/config/setup_dashing.lock.bzl
++@@ -0,0 +1,241 @@
+++#
+++# DO NOT EDIT THIS FILE MANUALLY!
+++#
+++# To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
+++load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
+++load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
+++
+++def setup():
+++    pass
+++
+++
+++    _maybe(
+++        name = "ament.ament_index",
+++        branch = "0.7.2",
+++        build_files = {
+++            "@rules_ros//repos:ament.ament_index/ament_index_cpp.BUILD": "ament_index_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ament.ament_index/ament_index_python.BUILD": "ament_index_python/BUILD.bazel",
+++        },
+++        commit = "9d42ba13d7694ad8da5b1622e433e691996c4502",
+++        remote = "https://github.com/ament/ament_index.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1571244457 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-CDR",
+++        branch = "v1.0.13",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "174f6ff1d3a227c5c900a4587ee32fa888267f5e",
+++        remote = "https://github.com/eProsima/Fast-CDR.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1585310200 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eclipse-cyclonedds.cyclonedds",
+++        branch = "0.7.0",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "c261053186c455abc63ca5ac7d56c0808a59c364",
+++        remote = "https://github.com/eclipse-cyclonedds/cyclonedds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1596471565 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.common_interfaces",
+++        branch = "0.7.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.common_interfaces/std_msgs.BUILD": "std_msgs/BUILD.bazel",
+++        },
+++        commit = "30dbc60b45e22f2c88a4c46493388fdad3916845",
+++        remote = "https://github.com/ros2/common_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1621610616 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl",
+++        branch = "0.7.10",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl/rcl.BUILD": "rcl/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl/rcl_yaml_param_parser.BUILD": "rcl_yaml_param_parser/BUILD.bazel",
+++        },
+++        commit = "f28fd0d5ee8e13a4955dbe84bd336eeee7e2be5d",
+++        remote = "https://github.com/ros2/rcl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1621608437 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_interfaces",
+++        branch = "0.7.4",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_interfaces/rcl_interfaces.BUILD": "rcl_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/rosgraph_msgs.BUILD": "rosgraph_msgs/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/builtin_interfaces.BUILD": "builtin_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/statistics_msgs.BUILD": "statistics_msgs/BUILD.bazel",
+++        },
+++        commit = "bfa9c43dd7d8cfc5c6fcba8a164d8ef317a386d7",
+++        remote = "https://github.com/ros2/rcl_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1559174983 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_logging",
+++        branch = "0.2.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_logging/rcl_logging_interface.BUILD": "rcl_logging_interface/BUILD.bazel",
+++        },
+++        commit = "6b1880038fed2893557c931a202c16b974637e42",
+++        remote = "https://github.com/ros2/rcl_logging.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1557360130 -0500",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rclcpp",
+++        branch = "0.7.16",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rclcpp/build_interfaces.py": "rclcpp/build_interfaces.py",
+++            "@rules_ros//repos:ros2.rclcpp/rclcpp.BUILD": "rclcpp/BUILD.bazel",
+++        },
+++        commit = "403aac966271132feadffca93dcfb24f6ab90efb",
+++        remote = "https://github.com/ros2/rclcpp.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1621608557 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcpputils",
+++        branch = "0.1.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcpputils/rcpputils.BUILD": "BUILD.bazel",
+++        },
+++        commit = "f8e638eb72bfbacea18ca1cf67c4f7d48561d9b2",
+++        remote = "https://github.com/ros2/rcpputils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1564532092 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcutils",
+++        branch = "0.7.6",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcutils/root.BUILD": "BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcutils/build_logging_macros.py": "build_logging_macros.py",
+++        },
+++        commit = "f868e5cb0eaeb9ae9fc984f6783922f375411007",
+++        remote = "https://github.com/ros2/rcutils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1606260966 -0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rmw",
+++        branch = "0.7.2",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rmw/rmw.BUILD": "rmw/BUILD.bazel",
+++        },
+++        commit = "8652949435267cdf0fd65368f621146dea9a85eb",
+++        remote = "https://github.com/ros2/rmw.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1560370615 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2cli",
+++        branch = "0.7.11",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2cli/ros2cli.BUILD": "ros2cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2pkg.BUILD": "ros2pkg/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2run.BUILD": "ros2run/BUILD.bazel",
+++        },
+++        commit = "8ff79e6cfc88a8d973c854a6709404eed6db47e0",
+++        remote = "https://github.com/ros2/ros2cli.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1594441053 -0400",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl",
+++        branch = "0.7.10",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_c.BUILD": "rosidl_runtime_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_cpp.BUILD": "rosidl_runtime_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_adapter.BUILD": "rosidl_adapter/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cli.BUILD": "rosidl_cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_parser.BUILD": "rosidl_parser/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cmake.BUILD": "rosidl_cmake/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_typesupport_interface.BUILD": "rosidl_typesupport_interface/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_c.BUILD": "rosidl_generator_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_cpp.BUILD": "rosidl_generator_cpp/BUILD.bazel",
+++        },
+++        commit = "407b652ac8ca23beea2f1f24575dd57f0c9b4401",
+++        remote = "https://github.com/ros2/rosidl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1606259638 -0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_dds",
+++        branch = "0.7.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD": "rosidl_generator_dds_idl/BUILD.bazel",
+++        },
+++        commit = "e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc",
+++        remote = "https://github.com/ros2/rosidl_dds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1557357026 -0500",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_typesupport",
+++        branch = "0.7.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD": "rosidl_typesupport_c/BUILD.bazel",
+++        },
+++        commit = "38eb801f1f856a503676bb79875786b3a3b6d92d",
+++        remote = "https://github.com/ros2/rosidl_typesupport.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1557357026 -0700",
+++    )
+++
+++
+++    print("WARNING: Unknown repo type None for repo @eProsima.Fast-DDS")
+++
+++
+++    print("WARNING: Unknown repo type None for repo @eProsima.foonathan_memory_vendor")
+++
+++
+++    print("WARNING: Unknown repo type None for repo @eclipse-iceoryx.iceoryx")
+++
+++
+++    print("WARNING: Unknown repo type None for repo @ros-tooling.libstatistics_collector")
+++
+++
+++    print("WARNING: Unknown repo type None for repo @ros2.ros2_tracing")
+++
++diff --git a/repos/config/setup_eloquent.lock.bzl b/repos/config/setup_eloquent.lock.bzl
++new file mode 100644
++index 0000000..65ea6b0
++--- /dev/null
+++++ b/repos/config/setup_eloquent.lock.bzl
++@@ -0,0 +1,261 @@
+++#
+++# DO NOT EDIT THIS FILE MANUALLY!
+++#
+++# To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
+++load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
+++load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
+++
+++def setup():
+++    pass
+++
+++
+++    _maybe(
+++        name = "ament.ament_index",
+++        branch = "0.7.2",
+++        build_files = {
+++            "@rules_ros//repos:ament.ament_index/ament_index_cpp.BUILD": "ament_index_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ament.ament_index/ament_index_python.BUILD": "ament_index_python/BUILD.bazel",
+++        },
+++        commit = "9d42ba13d7694ad8da5b1622e433e691996c4502",
+++        remote = "https://github.com/ament/ament_index.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1571244457 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-CDR",
+++        branch = "v1.0.11",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "cc27c2490b694e97ca1bbcc169172fd63209bb90",
+++        remote = "https://github.com/eProsima/Fast-CDR.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1566903518 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-DDS",
+++        branch = "v1.9.3",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "b5ae9e9c9ea7ce49c64c0ef3f6c96a3dc563b16f",
+++        remote = "https://github.com/eProsima/Fast-DDS.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1573725955 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.foonathan_memory_vendor",
+++        branch = "v0.3.0",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "017ff0bdfd2c93930bf525a01f8663a032337a14",
+++        remote = "https://github.com/eProsima/foonathan_memory_vendor.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1569302929 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "eclipse-cyclonedds.cyclonedds",
+++        branch = "0.7.0",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "c261053186c455abc63ca5ac7d56c0808a59c364",
+++        remote = "https://github.com/eclipse-cyclonedds/cyclonedds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1596471565 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.common_interfaces",
+++        branch = "0.8.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.common_interfaces/std_msgs.BUILD": "std_msgs/BUILD.bazel",
+++        },
+++        commit = "81663c07b93889c3d0afda9b99cd5f1c7c98c1f2",
+++        remote = "https://github.com/ros2/common_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1571867898 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl",
+++        branch = "0.8.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl/rcl.BUILD": "rcl/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl/rcl_yaml_param_parser.BUILD": "rcl_yaml_param_parser/BUILD.bazel",
+++        },
+++        commit = "f5c01e4e2eb5d8f7fb16321f81815cd4b6b200bd",
+++        remote = "https://github.com/ros2/rcl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1607116198 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_interfaces",
+++        branch = "0.8.0",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_interfaces/rcl_interfaces.BUILD": "rcl_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/rosgraph_msgs.BUILD": "rosgraph_msgs/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/builtin_interfaces.BUILD": "builtin_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/statistics_msgs.BUILD": "statistics_msgs/BUILD.bazel",
+++        },
+++        commit = "93cedce2dacd25fa4f2969d022ccbe3f2903e3fe",
+++        remote = "https://github.com/ros2/rcl_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1569518728 -0500",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_logging",
+++        branch = "0.3.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_logging/rcl_logging_interface.BUILD": "rcl_logging_interface/BUILD.bazel",
+++        },
+++        commit = "3955fc4fc37e46dc397c52cebd3e40732db1157d",
+++        remote = "https://github.com/ros2/rcl_logging.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1571871211 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rclcpp",
+++        branch = "0.8.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rclcpp/build_interfaces.py": "rclcpp/build_interfaces.py",
+++            "@rules_ros//repos:ros2.rclcpp/rclcpp.BUILD": "rclcpp/BUILD.bazel",
+++        },
+++        commit = "82202ae71f14fed3a487da90d8f4f74c07c7d1f7",
+++        remote = "https://github.com/ros2/rclcpp.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1607116009 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcpputils",
+++        branch = "0.2.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcpputils/rcpputils.BUILD": "BUILD.bazel",
+++        },
+++        commit = "33e2edb1dafd9dc1952e7f219c9ceee58905b831",
+++        remote = "https://github.com/ros2/rcpputils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1573612278 -0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcutils",
+++        branch = "0.8.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcutils/root.BUILD": "BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcutils/build_logging_macros.py": "build_logging_macros.py",
+++        },
+++        commit = "ef201364d5af13f74a9c368f271c762326d838be",
+++        remote = "https://github.com/ros2/rcutils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1607117730 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rmw",
+++        branch = "0.8.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rmw/rmw.BUILD": "rmw/BUILD.bazel",
+++        },
+++        commit = "813b94ddd5650444b312304ad156f3b5d9f05e39",
+++        remote = "https://github.com/ros2/rmw.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1571879357 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2cli",
+++        branch = "0.8.8",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2cli/ros2cli.BUILD": "ros2cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2pkg.BUILD": "ros2pkg/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2run.BUILD": "ros2run/BUILD.bazel",
+++        },
+++        commit = "5d5b855369085d02631bc5bdd6ffb7fae680eb5b",
+++        remote = "https://github.com/ros2/ros2cli.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1607117614 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl",
+++        branch = "0.8.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_c.BUILD": "rosidl_runtime_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_cpp.BUILD": "rosidl_runtime_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_adapter.BUILD": "rosidl_adapter/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cli.BUILD": "rosidl_cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_parser.BUILD": "rosidl_parser/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cmake.BUILD": "rosidl_cmake/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_typesupport_interface.BUILD": "rosidl_typesupport_interface/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_c.BUILD": "rosidl_generator_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_cpp.BUILD": "rosidl_generator_cpp/BUILD.bazel",
+++        },
+++        commit = "5f79cdcb7830999b527c2370b4397a3cc587374a",
+++        remote = "https://github.com/ros2/rosidl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1607117948 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_dds",
+++        branch = "0.7.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD": "rosidl_generator_dds_idl/BUILD.bazel",
+++        },
+++        commit = "e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc",
+++        remote = "https://github.com/ros2/rosidl_dds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1557357026 -0500",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_typesupport",
+++        branch = "0.8.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD": "rosidl_typesupport_c/BUILD.bazel",
+++        },
+++        commit = "b51759ea94bfdc58afc8831d4c847c5891d14bc3",
+++        remote = "https://github.com/ros2/rosidl_typesupport.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1607118075 -0600",
+++    )
+++
+++
+++    print("WARNING: Unknown repo type None for repo @eclipse-iceoryx.iceoryx")
+++
+++
+++    print("WARNING: Unknown repo type None for repo @ros-tooling.libstatistics_collector")
+++
+++
+++    print("WARNING: Unknown repo type None for repo @ros2.ros2_tracing")
+++
++diff --git a/repos/config/setup_foxy.lock.bzl b/repos/config/setup_foxy.lock.bzl
++new file mode 100644
++index 0000000..c4de1a3
++--- /dev/null
+++++ b/repos/config/setup_foxy.lock.bzl
++@@ -0,0 +1,281 @@
+++#
+++# DO NOT EDIT THIS FILE MANUALLY!
+++#
+++# To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
+++load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
+++load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
+++
+++def setup():
+++    pass
+++
+++
+++    _maybe(
+++        name = "ament.ament_index",
+++        branch = "1.1.0",
+++        build_files = {
+++            "@rules_ros//repos:ament.ament_index/ament_index_cpp.BUILD": "ament_index_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ament.ament_index/ament_index_python.BUILD": "ament_index_python/BUILD.bazel",
+++        },
+++        commit = "07492c3ada0f835464ef55178080f3df93c22292",
+++        remote = "https://github.com/ament/ament_index.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1625088023 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-CDR",
+++        branch = "v1.0.13",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "174f6ff1d3a227c5c900a4587ee32fa888267f5e",
+++        remote = "https://github.com/eProsima/Fast-CDR.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1585310200 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-DDS",
+++        branch = "v2.1.3",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "680cb71c7f3a9fb4b7e348d7d68ee2dbf4dd6d8d",
+++        remote = "https://github.com/eProsima/Fast-DDS.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1674805970 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.foonathan_memory_vendor",
+++        branch = "v1.2.0",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "da062db05975d24a4b53de5a4122b47f6824997f",
+++        remote = "https://github.com/eProsima/foonathan_memory_vendor.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1637848987 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eclipse-cyclonedds.cyclonedds",
+++        branch = "0.7.0",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "c261053186c455abc63ca5ac7d56c0808a59c364",
+++        remote = "https://github.com/eclipse-cyclonedds/cyclonedds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1596471565 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros-tooling.libstatistics_collector",
+++        branch = "1.0.2",
+++        build_files = {
+++            "@rules_ros//repos:ros-tooling.libstatistics_collector/root.BUILD": "BUILD.bazel",
+++        },
+++        commit = "28e3c4634dc106b1e5209a776e9a56325f16c84a",
+++        remote = "https://github.com/ros-tooling/libstatistics_collector.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1678980793 -0400",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.common_interfaces",
+++        branch = "2.0.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.common_interfaces/std_msgs.BUILD": "std_msgs/BUILD.bazel",
+++        },
+++        commit = "6356bc82f3a034f5d2c61c6760df0007a6cadfb0",
+++        remote = "https://github.com/ros2/common_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1640218063 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl",
+++        branch = "1.1.14",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl/rcl.BUILD": "rcl/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl/rcl_yaml_param_parser.BUILD": "rcl_yaml_param_parser/BUILD.bazel",
+++        },
+++        commit = "287ccd9ed06ff5bdded4dfb1130920d592a71bb7",
+++        remote = "https://github.com/ros2/rcl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1658776609 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_interfaces",
+++        branch = "1.0.0",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_interfaces/rcl_interfaces.BUILD": "rcl_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/rosgraph_msgs.BUILD": "rosgraph_msgs/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/builtin_interfaces.BUILD": "builtin_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/statistics_msgs.BUILD": "statistics_msgs/BUILD.bazel",
+++        },
+++        commit = "48cb91129051a494f3b4b097dccd6c921bb50552",
+++        remote = "https://github.com/ros2/rcl_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1590522301 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_logging",
+++        branch = "1.1.0",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_logging/rcl_logging_interface.BUILD": "rcl_logging_interface/BUILD.bazel",
+++        },
+++        commit = "d22a6630f039bee97c6667394def926a5426a673",
+++        remote = "https://github.com/ros2/rcl_logging.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1618435530 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rclcpp",
+++        branch = "2.4.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rclcpp/build_interfaces.py": "rclcpp/build_interfaces.py",
+++            "@rules_ros//repos:ros2.rclcpp/rclcpp.BUILD": "rclcpp/BUILD.bazel",
+++        },
+++        commit = "b0c25d5f22237d42e2cedad05dbb2e5cc31a3cf4",
+++        remote = "https://github.com/ros2/rclcpp.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1685154213 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcpputils",
+++        branch = "1.3.2",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcpputils/rcpputils.BUILD": "BUILD.bazel",
+++        },
+++        commit = "f4ce24de0b9b6b2c0c3807d6ce43418d4e1db331",
+++        remote = "https://github.com/ros2/rcpputils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1630457027 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcutils",
+++        branch = "1.1.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcutils/root.BUILD": "BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcutils/build_logging_macros.py": "build_logging_macros.py",
+++        },
+++        commit = "7cc5a47ee5d85d605d2291c1b04ac570a4c0faf6",
+++        remote = "https://github.com/ros2/rcutils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1678961835 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rmw",
+++        branch = "1.0.4",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rmw/rmw.BUILD": "rmw/BUILD.bazel",
+++        },
+++        commit = "7fa45cb0d86fef00488e707b9ef37914d7ff0369",
+++        remote = "https://github.com/ros2/rmw.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1678961864 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2_tracing",
+++        branch = "1.0.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2_tracing/tracetools.BUILD": "tracetools/BUILD.bazel",
+++        },
+++        commit = "f10fb2c13775fa0220833c5fa4ff82660640362a",
+++        remote = "https://github.com/ros2/ros2_tracing.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1608651744 -0500",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2cli",
+++        branch = "0.9.13",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2cli/ros2cli.BUILD": "ros2cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2pkg.BUILD": "ros2pkg/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2run.BUILD": "ros2run/BUILD.bazel",
+++        },
+++        commit = "26715cbb0948258d6f04b94c909d035c5130456a",
+++        remote = "https://github.com/ros2/ros2cli.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1678961891 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl",
+++        branch = "1.3.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_c.BUILD": "rosidl_runtime_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_cpp.BUILD": "rosidl_runtime_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_adapter.BUILD": "rosidl_adapter/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cli.BUILD": "rosidl_cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_parser.BUILD": "rosidl_parser/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cmake.BUILD": "rosidl_cmake/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_typesupport_interface.BUILD": "rosidl_typesupport_interface/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_c.BUILD": "rosidl_generator_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_cpp.BUILD": "rosidl_generator_cpp/BUILD.bazel",
+++        },
+++        commit = "62bc7072d9078cfd7c63ebb1d12ca6e9732491b4",
+++        remote = "https://github.com/ros2/rosidl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1685154334 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_dds",
+++        branch = "0.7.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD": "rosidl_generator_dds_idl/BUILD.bazel",
+++        },
+++        commit = "e88b1d0e62a2dca0788142cf1fb266a3a3c3d7dc",
+++        remote = "https://github.com/ros2/rosidl_dds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1557357026 -0500",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_typesupport",
+++        branch = "1.0.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD": "rosidl_typesupport_c/BUILD.bazel",
+++        },
+++        commit = "08bec09e39f68a29ca15d8177f084118a47eaa92",
+++        remote = "https://github.com/ros2/rosidl_typesupport.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1685154344 +0000",
+++    )
+++
+++
+++    print("WARNING: Unknown repo type None for repo @eclipse-iceoryx.iceoryx")
+++
++diff --git a/repos/config/setup_humble.lock.bzl b/repos/config/setup_humble.lock.bzl
++new file mode 100644
++index 0000000..0d0b402
++--- /dev/null
+++++ b/repos/config/setup_humble.lock.bzl
++@@ -0,0 +1,291 @@
+++#
+++# DO NOT EDIT THIS FILE MANUALLY!
+++#
+++# To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
+++load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
+++load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
+++
+++def setup():
+++    pass
+++
+++
+++    _maybe(
+++        name = "ament.ament_index",
+++        branch = "1.4.0",
+++        build_files = {
+++            "@rules_ros//repos:ament.ament_index/ament_index_cpp.BUILD": "ament_index_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ament.ament_index/ament_index_python.BUILD": "ament_index_python/BUILD.bazel",
+++        },
+++        commit = "f019d6c40991799a13b18c9c3dcc583e3fde0381",
+++        remote = "https://github.com/ament/ament_index.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1646168510 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-CDR",
+++        branch = "v1.0.24",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "da2987299ee3104bb0393cf0afc8aad6fb848dc1",
+++        remote = "https://github.com/eProsima/Fast-CDR.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1647345218 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-DDS",
+++        branch = "v2.6.6",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "cffaa679ec8cd9c84b4d5b3fe1e3c22974d63be0",
+++        remote = "https://github.com/eProsima/Fast-DDS.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1691144938 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.foonathan_memory_vendor",
+++        branch = "v1.3.1",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "e91681a25711c1811b2eaf2ba1e6996e0d9ecc84",
+++        remote = "https://github.com/eProsima/foonathan_memory_vendor.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1683727792 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "eclipse-cyclonedds.cyclonedds",
+++        branch = "0.10.3",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "63b6eab0e0660009eaf5e54d10509ea587ce199e",
+++        remote = "https://github.com/eclipse-cyclonedds/cyclonedds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1679487279 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eclipse-iceoryx.iceoryx",
+++        branch = "v2.0.3",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "40ef24e9515940564af63987234d51dc7f02f6b3",
+++        remote = "https://github.com/eclipse-iceoryx/iceoryx.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1675094707 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros-tooling.libstatistics_collector",
+++        branch = "1.3.1",
+++        build_files = {
+++            "@rules_ros//repos:ros-tooling.libstatistics_collector/root.BUILD": "BUILD.bazel",
+++        },
+++        commit = "6d473eb7533a3db385512d5721e3a46ceb06f96f",
+++        remote = "https://github.com/ros-tooling/libstatistics_collector.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1677042096 -0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.common_interfaces",
+++        branch = "4.2.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.common_interfaces/std_msgs.BUILD": "std_msgs/BUILD.bazel",
+++        },
+++        commit = "f4eac72f0bbd70f7955a5f709d4a6705eb6ca7e8",
+++        remote = "https://github.com/ros2/common_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1673281597 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl",
+++        branch = "5.3.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl/rcl.BUILD": "rcl/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl/rcl_yaml_param_parser.BUILD": "rcl_yaml_param_parser/BUILD.bazel",
+++        },
+++        commit = "3804c35f6dd31d5ac54a1acb426bff253cce8272",
+++        remote = "https://github.com/ros2/rcl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1695130701 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_interfaces",
+++        branch = "1.2.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_interfaces/rcl_interfaces.BUILD": "rcl_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/rosgraph_msgs.BUILD": "rosgraph_msgs/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/builtin_interfaces.BUILD": "builtin_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/statistics_msgs.BUILD": "statistics_msgs/BUILD.bazel",
+++        },
+++        commit = "5e01a28f9866a564491480e12d8659a134678741",
+++        remote = "https://github.com/ros2/rcl_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1667833699 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_logging",
+++        branch = "2.3.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_logging/rcl_logging_interface.BUILD": "rcl_logging_interface/BUILD.bazel",
+++        },
+++        commit = "1b7a4e34884005f28eeb04065b5d94565c67b11d",
+++        remote = "https://github.com/ros2/rcl_logging.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1667833800 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rclcpp",
+++        branch = "16.0.6",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rclcpp/build_interfaces.py": "rclcpp/build_interfaces.py",
+++            "@rules_ros//repos:ros2.rclcpp/rclcpp.BUILD": "rclcpp/BUILD.bazel",
+++        },
+++        commit = "0f6b5449f66f131735a423be4a84d6f14751d3b2",
+++        remote = "https://github.com/ros2/rclcpp.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1695130763 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcpputils",
+++        branch = "2.4.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcpputils/rcpputils.BUILD": "BUILD.bazel",
+++        },
+++        commit = "3eb281afdc891855b5feb367c79ede1e2fbb0acb",
+++        remote = "https://github.com/ros2/rcpputils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1682457603 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcutils",
+++        branch = "5.1.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcutils/root.BUILD": "BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcutils/build_logging_macros.py": "build_logging_macros.py",
+++        },
+++        commit = "2d9d74e72ecd1eea240412be3dacd413dcb5f680",
+++        remote = "https://github.com/ros2/rcutils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1682457695 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rmw",
+++        branch = "6.1.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rmw/rmw.BUILD": "rmw/BUILD.bazel",
+++        },
+++        commit = "2a4ee718d0da004d5629f50afd2896fbd1f4aedd",
+++        remote = "https://github.com/ros2/rmw.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1667834517 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2_tracing",
+++        branch = "4.1.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2_tracing/tracetools.BUILD": "tracetools/BUILD.bazel",
+++        },
+++        commit = "548634dd2837d65c043436c8186614e924be5c6c",
+++        remote = "https://github.com/ros2/ros2_tracing.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1667834775 -0600",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2cli",
+++        branch = "0.18.7",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2cli/ros2cli.BUILD": "ros2cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2pkg.BUILD": "ros2pkg/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2run.BUILD": "ros2run/BUILD.bazel",
+++        },
+++        commit = "38d4fa97fa8091e211e190d70e9fa0b0e817689d",
+++        remote = "https://github.com/ros2/ros2cli.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1689700836 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl",
+++        branch = "3.1.5",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_c.BUILD": "rosidl_runtime_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_cpp.BUILD": "rosidl_runtime_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_adapter.BUILD": "rosidl_adapter/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cli.BUILD": "rosidl_cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_parser.BUILD": "rosidl_parser/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cmake.BUILD": "rosidl_cmake/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_typesupport_interface.BUILD": "rosidl_typesupport_interface/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_c.BUILD": "rosidl_generator_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_cpp.BUILD": "rosidl_generator_cpp/BUILD.bazel",
+++        },
+++        commit = "cf3b637605c8c1dc0b1266ca0090963e9186c7dd",
+++        remote = "https://github.com/ros2/rosidl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1689702714 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_dds",
+++        branch = "0.8.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD": "rosidl_generator_dds_idl/BUILD.bazel",
+++        },
+++        commit = "ab8497770c652edb40d6b1591118198cbcf14237",
+++        remote = "https://github.com/ros2/rosidl_dds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1648665003 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_typesupport",
+++        branch = "2.0.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD": "rosidl_typesupport_c/BUILD.bazel",
+++        },
+++        commit = "aa522c4bf1a1b6c10766b84ca6625a8c494c0928",
+++        remote = "https://github.com/ros2/rosidl_typesupport.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1689702809 +0000",
+++    )
+++
++diff --git a/repos/config/setup_iron.lock.bzl b/repos/config/setup_iron.lock.bzl
++new file mode 100644
++index 0000000..a381b54
++--- /dev/null
+++++ b/repos/config/setup_iron.lock.bzl
++@@ -0,0 +1,291 @@
+++#
+++# DO NOT EDIT THIS FILE MANUALLY!
+++#
+++# To update, call `bazel run @rules_ros//repos/config:repos_lock.update` with the right distro set in the WORKSPACE
+++#
+++
+++load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
+++load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
+++load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
+++
+++def setup():
+++    pass
+++
+++
+++    _maybe(
+++        name = "ament.ament_index",
+++        branch = "1.5.2",
+++        build_files = {
+++            "@rules_ros//repos:ament.ament_index/ament_index_cpp.BUILD": "ament_index_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ament.ament_index/ament_index_python.BUILD": "ament_index_python/BUILD.bazel",
+++        },
+++        commit = "ba818db036e82d5f752d17e3e6fe6e3efd583bfb",
+++        remote = "https://github.com/ament/ament_index.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1676390119 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-CDR",
+++        branch = "v1.0.27",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "5d782877435b569e0ed38541f362e212c9123dd4",
+++        remote = "https://github.com/eProsima/Fast-CDR.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1679466588 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.Fast-DDS",
+++        branch = "2.10.2",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "2be7879185bfa2b67d5a9777ddee0a7e637776f3",
+++        remote = "https://github.com/eProsima/Fast-DDS.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1692360029 +0200",
+++    )
+++
+++
+++    _maybe(
+++        name = "eProsima.foonathan_memory_vendor",
+++        branch = "v1.3.0",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "8db2afc097db4cebe414ae27cdb3af1480ae46e7",
+++        remote = "https://github.com/eProsima/foonathan_memory_vendor.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1676364830 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eclipse-cyclonedds.cyclonedds",
+++        branch = "0.10.3",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "63b6eab0e0660009eaf5e54d10509ea587ce199e",
+++        remote = "https://github.com/eclipse-cyclonedds/cyclonedds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1679487279 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "eclipse-iceoryx.iceoryx",
+++        branch = "v2.0.3",
+++        build_files = {
+++            "@rules_ros//repos:default.BUILD": "BUILD.bazel",
+++        },
+++        commit = "40ef24e9515940564af63987234d51dc7f02f6b3",
+++        remote = "https://github.com/eclipse-iceoryx/iceoryx.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1675094707 +0100",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros-tooling.libstatistics_collector",
+++        branch = "1.5.1",
+++        build_files = {
+++            "@rules_ros//repos:ros-tooling.libstatistics_collector/root.BUILD": "BUILD.bazel",
+++        },
+++        commit = "00b9371c15fdc9b3f42faee3cb718214b787eb13",
+++        remote = "https://github.com/ros-tooling/libstatistics_collector.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1681306122 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.common_interfaces",
+++        branch = "5.0.0",
+++        build_files = {
+++            "@rules_ros//repos:ros2.common_interfaces/std_msgs.BUILD": "std_msgs/BUILD.bazel",
+++        },
+++        commit = "86801a504b97f25a3b6e1c36e42a445500c98f79",
+++        remote = "https://github.com/ros2/common_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1681224748 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl",
+++        branch = "6.0.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl/rcl.BUILD": "rcl/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl/rcl_yaml_param_parser.BUILD": "rcl_yaml_param_parser/BUILD.bazel",
+++        },
+++        commit = "71ecc97db05490981f3e37ced27c66f8905879e8",
+++        remote = "https://github.com/ros2/rcl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1694151357 +0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_interfaces",
+++        branch = "1.6.0",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_interfaces/rcl_interfaces.BUILD": "rcl_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/rosgraph_msgs.BUILD": "rosgraph_msgs/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/builtin_interfaces.BUILD": "builtin_interfaces/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcl_interfaces/statistics_msgs.BUILD": "statistics_msgs/BUILD.bazel",
+++        },
+++        commit = "6d28b16a6f74485af03a2c4f043dd568e576c25e",
+++        remote = "https://github.com/ros2/rcl_interfaces.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1681820432 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcl_logging",
+++        branch = "2.5.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcl_logging/rcl_logging_interface.BUILD": "rcl_logging_interface/BUILD.bazel",
+++        },
+++        commit = "2bc49ab7ff557a45d4fa152e2f400e9ad2bb6a68",
+++        remote = "https://github.com/ros2/rcl_logging.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1681252296 -0700",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rclcpp",
+++        branch = "21.0.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rclcpp/build_interfaces.py": "rclcpp/build_interfaces.py",
+++            "@rules_ros//repos:ros2.rclcpp/rclcpp.BUILD": "rclcpp/BUILD.bazel",
+++        },
+++        commit = "45df3555d2daee48332f7dad1e6dabc7e4a7fd60",
+++        remote = "https://github.com/ros2/rclcpp.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1694151852 +0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcpputils",
+++        branch = "2.6.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcpputils/rcpputils.BUILD": "BUILD.bazel",
+++        },
+++        commit = "39b20134e571ba74baa7c77750eab586da90b7a5",
+++        remote = "https://github.com/ros2/rcpputils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1676322161 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rcutils",
+++        branch = "6.2.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rcutils/root.BUILD": "BUILD.bazel",
+++            "@rules_ros//repos:ros2.rcutils/build_logging_macros.py": "build_logging_macros.py",
+++        },
+++        commit = "04aa9804feb46403f0058f4b089134a6985e19d3",
+++        remote = "https://github.com/ros2/rcutils.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1681305660 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rmw",
+++        branch = "7.1.0",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rmw/rmw.BUILD": "rmw/BUILD.bazel",
+++        },
+++        commit = "17e3a94e447cd043dc20aec7dd620b5eb26241c6",
+++        remote = "https://github.com/ros2/rmw.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1681312425 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2_tracing",
+++        branch = "6.3.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2_tracing/tracetools.BUILD": "tracetools/BUILD.bazel",
+++        },
+++        commit = "fb240709fda0e0cc6c08f12ae8052d3a32221d29",
+++        remote = "https://github.com/ros2/ros2_tracing.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1683805768 +0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.ros2cli",
+++        branch = "0.25.3",
+++        build_files = {
+++            "@rules_ros//repos:ros2.ros2cli/ros2cli.BUILD": "ros2cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2pkg.BUILD": "ros2pkg/BUILD.bazel",
+++            "@rules_ros//repos:ros2.ros2cli/ros2run.BUILD": "ros2run/BUILD.bazel",
+++        },
+++        commit = "4d92fa27ca0d7796c1f792864fd98dd3b7437f8f",
+++        remote = "https://github.com/ros2/ros2cli.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1694153559 +0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl",
+++        branch = "4.0.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_c.BUILD": "rosidl_runtime_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_runtime_cpp.BUILD": "rosidl_runtime_cpp/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_adapter.BUILD": "rosidl_adapter/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cli.BUILD": "rosidl_cli/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_parser.BUILD": "rosidl_parser/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_cmake.BUILD": "rosidl_cmake/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_typesupport_interface.BUILD": "rosidl_typesupport_interface/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_c.BUILD": "rosidl_generator_c/BUILD.bazel",
+++            "@rules_ros//repos:ros2.rosidl/rosidl_generator_cpp.BUILD": "rosidl_generator_cpp/BUILD.bazel",
+++        },
+++        commit = "995917e9ce14d17821c04bf28d5a092111537842",
+++        remote = "https://github.com/ros2/rosidl.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1689270954 +0800",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_dds",
+++        branch = "0.10.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_dds/rosidl_generator_dds_idl.BUILD": "rosidl_generator_dds_idl/BUILD.bazel",
+++        },
+++        commit = "f074b295c316e9bbb9845344cc6ab882339e9305",
+++        remote = "https://github.com/ros2/rosidl_dds.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1676323645 +0000",
+++    )
+++
+++
+++    _maybe(
+++        name = "ros2.rosidl_typesupport",
+++        branch = "3.0.1",
+++        build_files = {
+++            "@rules_ros//repos:ros2.rosidl_typesupport/rosidl_typesupport_c.BUILD": "rosidl_typesupport_c/BUILD.bazel",
+++        },
+++        commit = "7cadef85a4f4e633d8598210ce99d47a3dde52a9",
+++        remote = "https://github.com/ros2/rosidl_typesupport.git",
+++        repo_rule = _git_repository,
+++        shallow_since = "1689271321 +0800",
+++    )
+++
++-- 
++2.34.1
++
++
++From 102736a8124cdb790315ef05daae5f1e86102d7e Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Thu, 19 Sep 2024 09:50:50 -0700
++Subject: [PATCH 25/27] Fix tar repo type for locking
++
++---
++ repos/config/detail/BUILD.bazel             |  1 +
++ repos/config/detail/generate_ros2_config.py |  6 +++---
++ repos/config/detail/lock_repos.py           | 23 +++++++++++----------
++ 3 files changed, 16 insertions(+), 14 deletions(-)
++
++diff --git a/repos/config/detail/BUILD.bazel b/repos/config/detail/BUILD.bazel
++index 927b7ea..498ad90 100644
++--- a/repos/config/detail/BUILD.bazel
+++++ b/repos/config/detail/BUILD.bazel
++@@ -16,6 +16,7 @@ load("@python_deps//:requirements.bzl", "requirement")
++ load("@ros2_config//:repos_index_file.bzl", "REPOS_INDEX_FILE")
++ load("@ros2_config//:repos_overlay_files.bzl", "REPOS_OVERLAY_FILES")
++ load("@ros2_config//:repos_setup_file.bzl", "REPOS_SETUP_FILE")
+++load("@rules_python//python:defs.bzl", "py_binary")
++ 
++ py_binary(
++     name = "repos_lock.update",
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 62c9011..89e5114 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -54,7 +54,7 @@ def build_load_command(repo, spec):
++ 
++ def build_http_archive_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++-    return f"""
+++    return f"""\
++     _maybe(
++         name = "{repo.replace('/','.')}",
++         build_files = {{
++@@ -69,7 +69,7 @@ def build_http_archive_load_command(repo, spec):
++ 
++ def build_local_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++-    return f"""
+++    return f"""\
++     _maybe(
++         name = "{repo.replace('/','.')}",
++         build_files = {{
++@@ -83,7 +83,7 @@ def build_local_load_command(repo, spec):
++ 
++ def build_git_load_command(repo, spec):
++     build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++-    return f"""
+++    return f"""\
++     _maybe(
++         name = "{repo.replace('/','.')}",
++         branch = "{spec['version']}",
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index 1bd8d0a..2981024 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -46,12 +46,7 @@ def main():
++     for repo, spec in repos["repositories"].items():
++         if not spec["type"] in REPO_TYPES:
++             raise ValueError(f"Repo type {spec['type']} not supported. Need one of {REPO_TYPES} instead.")
++-        if args.tar:
++-            # use tarballs
++-            additional_attributes = fetch_archive_details(spec['url'], spec['version'])
++-        else:
++-            # default: use git repositories
++-            additional_attributes = fetch_repo_details(spec['url'], spec['version'])
+++        additional_attributes = fetch_dependency_details(use_tar = args.tar, **spec)
++         add_attributes(repos["repositories"][repo], additional_attributes)
++         print("{}: {}".format(repo, [*additional_attributes.values()]))
++ 
++@@ -61,23 +56,29 @@ def main():
++         with open(args.setup_bzl, mode='w', encoding='utf8') as setup_bzl:
++             print_setup_file(yaml_files=[lock_file.name] + args.overlays, output_file=setup_bzl)
++ 
+++
+++def fetch_dependency_details(*, use_tar, type, **kwargs):
+++    if type == "tar" or use_tar:
+++        return fetch_archive_details(**kwargs)
+++    return fetch_repo_details(**kwargs)
+++
++ def add_attributes(dictionary, additional_attributes):
++     for k,v in additional_attributes.items():
++         dictionary[k] = v
++ 
++-def fetch_archive_details(url, tag):
+++def fetch_archive_details(url, version, **kwargs):
++     cwd = os.getcwd()
++     with tempfile.TemporaryDirectory() as tempdir:
++         url = url.rsplit(".git", 1)[0]
++         project = url.split('/')[-1]
++-        url += f"/archive/refs/tags/{tag}.tar.gz"
+++        url += f"/archive/refs/tags/{version}.tar.gz"
++         result = subprocess.run(
++             ["curl", "-L", "-f", "-o", "archive.tar.gz", url],
++             stdout=subprocess.PIPE,
++             encoding='utf8'
++         )
++         if result.returncode != 0:
++-            raise ValueError(f"Error loading {url}, {tag}: " + (result.stderr or ""))
+++            raise ValueError(f"Error loading {url}, {version}: " + (result.stderr or ""))
++ 
++         archive_bytes = Path('archive.tar.gz').read_bytes()
++         hash = hashlib.sha256(archive_bytes).hexdigest()
++@@ -101,12 +102,12 @@ def extract_archive_root_folder(path, origin):
++     return result.stdout.split('\n')[0].split('/')[0]
++ 
++ 
++-def fetch_repo_details(url, branch):
+++def fetch_repo_details(url, version, **kwargs):
++     cwd = os.getcwd()
++     with tempfile.TemporaryDirectory() as tempdir:
++         result = subprocess.run(
++             ["git", "clone", url, "--no-checkout", tempdir, "--depth", "1",
++-             "--branch", branch, "--bare", "-q"],
+++             "--branch", version, "--bare", "-q"],
++             capture_output = True,
++             encoding='utf8'
++         )
++-- 
++2.34.1
++
++
++From 2f60c98e311dbec2f3f5cb4793f4a793bdc53101 Mon Sep 17 00:00:00 2001
++From: "kilian.funk" <kilian.funk@apex.ai>
++Date: Thu, 19 Sep 2024 17:05:54 -0700
++Subject: [PATCH 26/27] Remove temp yaml files
++
++---
++ repos/config/detail/generate_ros2_config.py | 53 ++++++++++-----------
++ repos/config/detail/lock_repos.py           | 34 ++++++-------
++ 2 files changed, 41 insertions(+), 46 deletions(-)
++
++diff --git a/repos/config/detail/generate_ros2_config.py b/repos/config/detail/generate_ros2_config.py
++index 89e5114..184315b 100755
++--- a/repos/config/detail/generate_ros2_config.py
+++++ b/repos/config/detail/generate_ros2_config.py
++@@ -12,7 +12,6 @@
++ # See the License for the specific language governing permissions and
++ # limitations under the License.
++ 
++-import sys
++ import yaml
++ 
++ 
++@@ -23,9 +22,9 @@ HEADER = """#
++ #
++ 
++ load("@bazel_tools//tools/build_defs/repo:utils.bzl", _maybe = "maybe")
++-load("@rules_ros//repos/config/detail:git_repository.bzl", _git_repository = "git_repository")
+++load("@rules_ros//repos/config/detail:git_repository.bzl", "git_repository")
++ load("@rules_ros//repos/config/detail:http_archive.bzl", "http_archive")
++-load("@rules_ros//repos/config/detail:new_local_repository.bzl", _new_local_repository = "new_local_repository")
+++load("@rules_ros//repos/config/detail:new_local_repository.bzl", "new_local_repository")
++ 
++ def setup():
++     pass
++@@ -40,26 +39,32 @@ def print_setup(repos, output_file):
++ 
++ 
++ def build_load_command(repo, spec):
++-    if spec.get('type') == "git":
++-        return build_git_load_command(repo, spec)
++-    if spec.get('type') == "http_archive":
++-        return build_http_archive_load_command(repo, spec)
++-    if spec.get('type') == "local":
++-        return build_local_load_command(repo, spec)
++-    else:
+++    builder = {
+++        "git": build_git_load_command,
+++        "http_archive": build_http_archive_load_command,
+++        "local": build_local_load_command,
+++    }
+++    if spec.get('type') not in builder.keys():
++         return f"""
++     print("WARNING: Unknown repo type {spec.get('type')} for repo @{repo.replace('/', '.')}")
++ """
+++    return builder[spec.get('type')](repo, spec)
+++
+++
+++def build_build_files_attr(build_files):
+++    if not build_files:
+++        return ""
+++    content = '\n'.join(f"            '{k}': '{v}'," for k,v in build_files.items())
+++    return f"""build_files = {{
+++{content}
+++        }},"""
++ 
++ 
++ def build_http_archive_load_command(repo, spec):
++-    build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""\
++     _maybe(
++         name = "{repo.replace('/','.')}",
++-        build_files = {{
++-{build_files}
++-        }},
+++        {build_build_files_attr(spec['bazel'])}
++         url = "{spec['url']}",
++         sha256 = "{spec['hash']}",
++         strip_prefix = "{spec['strip_prefix']}",
++@@ -68,31 +73,25 @@ def build_http_archive_load_command(repo, spec):
++ """
++ 
++ def build_local_load_command(repo, spec):
++-    build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""\
++     _maybe(
++         name = "{repo.replace('/','.')}",
++-        build_files = {{
++-{build_files}
++-        }},
+++        {build_build_files_attr(spec['bazel'])}
++         path = "{spec['path']}",
++         sha256 = "{spec['hash']}",
++-        repo_rule = _new_local_repository,
+++        repo_rule = new_local_repository,
++     )
++ """
++ 
++ def build_git_load_command(repo, spec):
++-    build_files = "\n".join([f'            "{k}": "{v}",' for k,v in spec['bazel'].items()])
++     return f"""\
++     _maybe(
++         name = "{repo.replace('/','.')}",
++         branch = "{spec['version']}",
++-        build_files = {{
++-{build_files}
++-        }},
+++        {build_build_files_attr(spec['bazel'])}
++         commit = "{spec['hash']}",
++         remote = "{spec['url']}",
++-        repo_rule = _git_repository,
+++        repo_rule = git_repository,
++         shallow_since = "{spec['shallow_since']}",
++     )
++ """
++@@ -106,11 +105,7 @@ def merge_dict(origin, to_add):
++             origin[key]=value
++ 
++ 
++-def print_setup_file(yaml_files, output_file):
++-    if len(yaml_files) < 1:
++-        raise ValueError("At least one YAML file is required as input.")
++-
++-    repos = {}
+++def print_setup_file(repos, yaml_files, output_file):
++     for input_path in yaml_files:
++         with (open(input_path,"r")) as repo_file:
++             merge_dict(repos, yaml.safe_load(repo_file)["repositories"])
++diff --git a/repos/config/detail/lock_repos.py b/repos/config/detail/lock_repos.py
++index 2981024..08eebc4 100755
++--- a/repos/config/detail/lock_repos.py
+++++ b/repos/config/detail/lock_repos.py
++@@ -50,45 +50,45 @@ def main():
++         add_attributes(repos["repositories"][repo], additional_attributes)
++         print("{}: {}".format(repo, [*additional_attributes.values()]))
++ 
++-    with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf8') as lock_file:
++-        yaml.dump(repos, lock_file, default_flow_style=False, allow_unicode=True)
++-
++-        with open(args.setup_bzl, mode='w', encoding='utf8') as setup_bzl:
++-            print_setup_file(yaml_files=[lock_file.name] + args.overlays, output_file=setup_bzl)
+++    with open(args.setup_bzl, mode='w', encoding='utf8') as setup_bzl:
+++        print_setup_file(repos = repos["repositories"], yaml_files=args.overlays, output_file=setup_bzl)
++ 
++ 
++ def fetch_dependency_details(*, use_tar, type, **kwargs):
++     if type == "tar" or use_tar:
++-        return fetch_archive_details(**kwargs)
++-    return fetch_repo_details(**kwargs)
+++        return fetch_http_details(type = type, **kwargs)
+++    return fetch_git_details(type = type, **kwargs)
++ 
++ def add_attributes(dictionary, additional_attributes):
++     for k,v in additional_attributes.items():
++         dictionary[k] = v
++ 
++-def fetch_archive_details(url, version, **kwargs):
++-    cwd = os.getcwd()
+++def fetch_http_details(*, type, version = None, url = None, **kwargs):
+++    forward_type = "http_archive"
+++    if "sha256" in kwargs:
+++        return { "type": forward_type}
++     with tempfile.TemporaryDirectory() as tempdir:
++-        url = url.rsplit(".git", 1)[0]
++-        project = url.split('/')[-1]
++-        url += f"/archive/refs/tags/{version}.tar.gz"
+++        archive_filename = Path(tempdir) / "archive.tar.gz"
+++        if type == "git":
+++            url = url.rsplit(".git", 1)[0]
+++            url += f"/archive/refs/tags/{version}.tar.gz"
++         result = subprocess.run(
++-            ["curl", "-L", "-f", "-o", "archive.tar.gz", url],
+++            ["curl", "-L", "-f", "-o", archive_filename, url],
++             stdout=subprocess.PIPE,
++             encoding='utf8'
++         )
++         if result.returncode != 0:
++             raise ValueError(f"Error loading {url}, {version}: " + (result.stderr or ""))
++ 
++-        archive_bytes = Path('archive.tar.gz').read_bytes()
+++        archive_bytes = archive_filename.read_bytes()
++         hash = hashlib.sha256(archive_bytes).hexdigest()
++-        strip_prefix = extract_archive_root_folder("archive.tar.gz", url)
+++        strip_prefix = extract_archive_root_folder(archive_filename, url)
++ 
++     return {
++         "hash":hash,
++         "url": url,
++         "strip_prefix": strip_prefix,
++-        "type": "http_archive",
+++        "type": forward_type,
++     }
++ 
++ def extract_archive_root_folder(path, origin):
++@@ -102,7 +102,7 @@ def extract_archive_root_folder(path, origin):
++     return result.stdout.split('\n')[0].split('/')[0]
++ 
++ 
++-def fetch_repo_details(url, version, **kwargs):
+++def fetch_git_details(url, version, **kwargs):
++     cwd = os.getcwd()
++     with tempfile.TemporaryDirectory() as tempdir:
++         result = subprocess.run(
++-- 
++2.34.1
++
++
++From 62a75641a0909673f60870a07fb9abcb42338b74 Mon Sep 17 00:00:00 2001
++From: Revati Naik <revati.naik@apex.ai>
++Date: Tue, 11 Feb 2025 11:27:10 -0800
++Subject: [PATCH 27/27] Create a MACRO for the py_binary rule
++
++---
++ repos/config/defs.bzl                       |  3 ++-
++ repos/config/detail/generate_repos_lock.bzl | 24 +++++++++++++++++++++
++ repos/config/detail/ros2_config.bzl         | 20 +++++++++++++++--
++ 3 files changed, 44 insertions(+), 3 deletions(-)
++ create mode 100644 repos/config/detail/generate_repos_lock.bzl
++
++diff --git a/repos/config/defs.bzl b/repos/config/defs.bzl
++index ed10d70..ef35ef9 100644
++--- a/repos/config/defs.bzl
+++++ b/repos/config/defs.bzl
++@@ -46,11 +46,12 @@ def configure_ros2(*, name = "ros2_config", repos_index_overlays = [], distro):
++         fail("repos_index_overlays needs to be a list of *.repos files")
++     _configure_ros2(name = name, distro_src = distro_src, repos_index_overlays = repos_index_overlays)
++ 
++-def configure_repos(*, name = "ros2_config", repos_index, repos_index_overlays = [], setup_file):
+++def configure_repos(*, name, repos_index, setup_file, repos_index_overlays = []):
++     """Configure ROS 2 repositories based on the custom *.repos file."""
++ 
++     if not type(repos_index_overlays) == type([]):
++         fail("repos_index_overlays needs to be a list of *.repos files")
+++
++     ros2_config(
++         name = name,
++         repos_index = repos_index,
++diff --git a/repos/config/detail/generate_repos_lock.bzl b/repos/config/detail/generate_repos_lock.bzl
++new file mode 100644
++index 0000000..0d9bdf5
++--- /dev/null
+++++ b/repos/config/detail/generate_repos_lock.bzl
++@@ -0,0 +1,24 @@
+++load("@python_deps//:requirements.bzl", "requirement")
+++load("@rules_python//python:defs.bzl", "py_binary")
+++
+++def generate_repos_lock(name, repos_file, setup_file, overlay_files):
+++    """Macro to create a py_binary for generating repos_lock.update"""
+++
+++    py_binary(
+++        name = name,
+++        srcs = [
+++            Label("generate_ros2_config.py"),
+++            Label("lock_repos.py"),
+++        ],
+++        args = [
+++            "$(execpath {})".format(repos_file),
+++            "$(execpath {})".format(setup_file),
+++        ] + ["$(execpath {})".format(f) for f in overlay_files],
+++        data = [
+++            repos_file,
+++            setup_file,
+++        ] + overlay_files,
+++        main = Label("lock_repos.py"),
+++        visibility = ["//visibility:public"],
+++        deps = [requirement("pyyaml")],
+++    )
++\ No newline at end of file
++diff --git a/repos/config/detail/ros2_config.bzl b/repos/config/detail/ros2_config.bzl
++index 0e9102c..7fa83e3 100644
++--- a/repos/config/detail/ros2_config.bzl
+++++ b/repos/config/detail/ros2_config.bzl
++@@ -30,13 +30,29 @@ _archive_attrs = {
++     ),
++ }
++ 
+++BUILD_FILE_CONTENT = """\
+++load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "generate_repos_lock")
+++
+++generate_repos_lock(
+++    name = "repos_lock.update",
+++    repos_file = ":repos_index_file.repos",  # Custom repos file
+++    setup_file = ":repos_setup_file.bzl",  # Custom setup file
+++    overlay_files = [
+++        ":repos_overlay_files.repos",
+++    ],
+++)
+++
+++exports_files(glob(["**/*"]))
+++"""
+++
+++
++ def _ros2_config_impl(ctx):
++     ctx.file("repos_index_file.bzl", content = "REPOS_INDEX_FILE = '{}'".format(ctx.attr.repos_index))
++-    ctx.file("repos_overlay_files.bzl", content = "REPOS_OVERLAY_FILES = {}".format(["{}".format(l) for l in ctx.attr.repos_index_overlays]))
+++    ctx.file("repos_overlay_files.bzl", content = "REPOS_OVERLAY_FILES = {}".format(["{}".format(i) for i in ctx.attr.repos_index_overlays]))
++     ctx.file("repos_setup_file.bzl", content = "REPOS_SETUP_FILE = '{}'".format(ctx.attr.setup_file))
++     ctx.symlink(ctx.attr.setup_file, "setup.bzl")
++     ctx.file("WORKSPACE", content = "workspace(name = {})".format(ctx.name), executable = False)
++-    ctx.file("BUILD.bazel", content = "exports_files(glob(['**/*']))", executable = False)
+++    ctx.file("BUILD.bazel", content = BUILD_FILE_CONTENT, executable = False)
++ 
++     return update_attrs(ctx.attr, _archive_attrs.keys(), {})
++ 
++-- 
++2.34.1
++
+-- 
+2.34.1
+

--- a/repos/config/BUILD.bazel
+++ b/repos/config/BUILD.bazel
@@ -16,5 +16,5 @@ exports_files(["bazel.repos"] + glob(["*.lock.bzl"]))
 
 alias(
     name = "repos_lock.update",
-    actual = "//repos/config/detail:repos_lock.update",
+    actual = "@ros2_config//:repos_lock.update",
 )

--- a/repos/config/defs.bzl
+++ b/repos/config/defs.bzl
@@ -46,11 +46,12 @@ def configure_ros2(*, name = "ros2_config", repos_index_overlays = [], distro):
         fail("repos_index_overlays needs to be a list of *.repos files")
     _configure_ros2(name = name, distro_src = distro_src, repos_index_overlays = repos_index_overlays)
 
-def configure_repos(*, name = "ros2_config", repos_index, repos_index_overlays = [], setup_file):
+def configure_repos(*, name, repos_index, setup_file, repos_index_overlays = []):
     """Configure ROS 2 repositories based on the custom *.repos file."""
 
     if not type(repos_index_overlays) == type([]):
         fail("repos_index_overlays needs to be a list of *.repos files")
+
     ros2_config(
         name = name,
         repos_index = repos_index,

--- a/repos/config/detail/BUILD.bazel
+++ b/repos/config/detail/BUILD.bazel
@@ -12,5 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-exports_files(["generate_ros2_config.py", "lock_repos.py"])
+exports_files([
+    "generate_ros2_config.py",
+    "lock_repos.py",
+])

--- a/repos/config/detail/BUILD.bazel
+++ b/repos/config/detail/BUILD.bazel
@@ -49,3 +49,5 @@ sh_test(
         REPOS_SETUP_FILE,
     ],
 )
+
+exports_files(["generate_ros2_config.py", "lock_repos.py"])

--- a/repos/config/detail/BUILD.bazel
+++ b/repos/config/detail/BUILD.bazel
@@ -12,42 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@python_deps//:requirements.bzl", "requirement")
-load("@ros2_config//:repos_index_file.bzl", "REPOS_INDEX_FILE")
-load("@ros2_config//:repos_overlay_files.bzl", "REPOS_OVERLAY_FILES")
-load("@ros2_config//:repos_setup_file.bzl", "REPOS_SETUP_FILE")
-load("@rules_python//python:defs.bzl", "py_binary")
-
-py_binary(
-    name = "repos_lock.update",
-    srcs = [
-        "generate_ros2_config.py",
-        "lock_repos.py",
-    ],
-    args = [
-        "$(execpath {})".format(REPOS_INDEX_FILE),
-        "$(execpath {})".format(REPOS_SETUP_FILE),
-    ] + ["$(execpath {})".format(f) for f in REPOS_OVERLAY_FILES],
-    data = [
-        REPOS_INDEX_FILE,
-        REPOS_SETUP_FILE,
-    ] + REPOS_OVERLAY_FILES,
-    main = "lock_repos.py",
-    visibility = ["//visibility:public"],
-    deps = [requirement("pyyaml")],
-)
-
-sh_test(
-    name = "test_repos_index_sha256",
-    srcs = ["test/test_repos_index_sha256.sh"],
-    args = [
-        "$(execpath {})".format(REPOS_INDEX_FILE),
-        "$(execpath {})".format(REPOS_SETUP_FILE),
-    ],
-    data = [
-        REPOS_INDEX_FILE,
-        REPOS_SETUP_FILE,
-    ],
-)
 
 exports_files(["generate_ros2_config.py", "lock_repos.py"])

--- a/repos/config/detail/generate_repos_lock.bzl
+++ b/repos/config/detail/generate_repos_lock.bzl
@@ -1,0 +1,24 @@
+load("@python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary")
+
+def generate_repos_lock(name, repos_file, setup_file, overlay_files):
+    """Macro to create a py_binary for generating repos_lock.update"""
+
+    py_binary(
+        name = name,
+        srcs = [
+            Label("generate_ros2_config.py"),
+            Label("lock_repos.py"),
+        ],
+        args = [
+            "$(execpath {})".format(repos_file),
+            "$(execpath {})".format(setup_file),
+        ] + ["$(execpath {})".format(f) for f in overlay_files],
+        data = [
+            repos_file,
+            setup_file,
+        ] + overlay_files,
+        main = Label("lock_repos.py"),
+        visibility = ["//visibility:public"],
+        deps = [requirement("pyyaml")],
+    )

--- a/repos/config/detail/generate_repos_lock.bzl
+++ b/repos/config/detail/generate_repos_lock.bzl
@@ -1,4 +1,7 @@
 load("@python_deps//:requirements.bzl", "requirement")
+load("@ros2_config//:repos_index_file.bzl", "REPOS_INDEX_FILE")
+load("@ros2_config//:repos_overlay_files.bzl", "REPOS_OVERLAY_FILES")
+load("@ros2_config//:repos_setup_file.bzl", "REPOS_SETUP_FILE")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 def generate_repos_lock(name, repos_file, setup_file, overlay_files):
@@ -6,19 +9,13 @@ def generate_repos_lock(name, repos_file, setup_file, overlay_files):
 
     py_binary(
         name = name,
-        srcs = [
-            Label("generate_ros2_config.py"),
-            Label("lock_repos.py"),
-        ],
+        srcs = ["lock_repos.py", "generate_ros2_config.py"],
+        main = "lock_repos.py",
+        data = [REPOS_INDEX_FILE, REPOS_SETUP_FILE] + REPOS_OVERLAY_FILES,
         args = [
-            "$(execpath {})".format(repos_file),
-            "$(execpath {})".format(setup_file),
-        ] + ["$(execpath {})".format(f) for f in overlay_files],
-        data = [
-            repos_file,
-            setup_file,
-        ] + overlay_files,
-        main = Label("lock_repos.py"),
-        visibility = ["//visibility:public"],
+            "$(execpath {})".format(REPOS_INDEX_FILE),
+            "$(execpath {})".format(REPOS_SETUP_FILE),
+        ] + ["$(execpath {})".format(f) for f in REPOS_OVERLAY_FILES],
         deps = [requirement("pyyaml")],
+        visibility = ["//visibility:public"],
     )

--- a/repos/config/detail/generate_repos_lock.bzl
+++ b/repos/config/detail/generate_repos_lock.bzl
@@ -1,21 +1,18 @@
 load("@python_deps//:requirements.bzl", "requirement")
-load("@ros2_config//:repos_index_file.bzl", "REPOS_INDEX_FILE")
-load("@ros2_config//:repos_overlay_files.bzl", "REPOS_OVERLAY_FILES")
-load("@ros2_config//:repos_setup_file.bzl", "REPOS_SETUP_FILE")
 load("@rules_python//python:defs.bzl", "py_binary")
 
-def generate_repos_lock(name, repos_file, setup_file, overlay_files):
+def generate_repos_lock(*, name, repos_file, setup_file, overlay_files):
     """Macro to create a py_binary for generating repos_lock.update"""
 
     py_binary(
         name = name,
-        srcs = ["lock_repos.py", "generate_ros2_config.py"],
-        main = "lock_repos.py",
-        data = [REPOS_INDEX_FILE, REPOS_SETUP_FILE] + REPOS_OVERLAY_FILES,
+        srcs = [Label("lock_repos.py"), Label("generate_ros2_config.py")],
+        main = Label("lock_repos.py"),
+        data = [repos_file, setup_file] + overlay_files,
         args = [
-            "$(execpath {})".format(REPOS_INDEX_FILE),
-            "$(execpath {})".format(REPOS_SETUP_FILE),
-        ] + ["$(execpath {})".format(f) for f in REPOS_OVERLAY_FILES],
+            "$(execpath {})".format(repos_file),
+            "$(execpath {})".format(setup_file),
+        ] + ["$(execpath {})".format(f) for f in overlay_files],
         deps = [requirement("pyyaml")],
         visibility = ["//visibility:public"],
     )

--- a/repos/config/detail/generate_repos_lock.bzl
+++ b/repos/config/detail/generate_repos_lock.bzl
@@ -1,8 +1,8 @@
 load("@python_deps//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 
-def generate_repos_lock(*, name, repos_file, setup_file, overlay_files):
-    """Macro to create a py_binary for generating repos_lock.update"""
+def repos_lock_updater(*, name, repos_file, setup_file, overlay_files):
+    """Executable rule for updating the `setup_file` from a `repos_file` and `overlay_files`."""
 
     py_binary(
         name = name,

--- a/repos/config/detail/ros2_config.bzl
+++ b/repos/config/detail/ros2_config.bzl
@@ -31,12 +31,12 @@ _archive_attrs = {
 }
 
 BUILD_FILE_CONTENT = """\
-load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "generate_repos_lock")
+load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "repos_lock_updater")
 
-generate_repos_lock(
+repos_lock_updater(
     name = "repos_lock.update",
-    repos_file = "ros.repos",  # Custom repos file
-    setup_file = "setup.bzl",  # Custom setup file
+    repos_file = "ros.repos",
+    setup_file = "setup.bzl",
     overlay_files = [
 {overlays}
     ],

--- a/repos/config/detail/ros2_config.bzl
+++ b/repos/config/detail/ros2_config.bzl
@@ -48,15 +48,23 @@ exports_files(glob(["**/*"]))
 def _ros2_config_impl(ctx):
     ctx.symlink(ctx.attr.repos_index, "ros.repos")
     ctx.symlink(ctx.attr.setup_file, "setup.bzl")
-    i = 0
     overlay_files = []
-    for file in ctx.attr.repos_index_overlays:
-        filname = "overlay_{}.bzl".format(i)
-        ctx.symlink(file, filname)
-        i += 1
-        overlay_files.append(filname)
-    ctx.file("WORKSPACE", content = "workspace(name = {})".format(ctx.name), executable = False)
-    ctx.file("BUILD.bazel", content = BUILD_FILE_CONTENT.format(overlays="\n".join(['        "{}",'.format(filename) for filename in overlay_files])), executable = False)
+    for i, file in enumerate(ctx.attr.repos_index_overlays):
+        filename = "overlay_{}.bzl".format(i)
+        ctx.symlink(file, filename)
+        overlay_files.append(filename)
+    ctx.file(
+        "WORKSPACE",
+        content = "workspace(name = {})".format(ctx.name),
+        executable = False
+    )
+    ctx.file(
+        "BUILD.bazel",
+        content = BUILD_FILE_CONTENT.format(
+            overlays="\n".join(['        "{}",'.format(filename) for filename in overlay_files])
+        ),
+        executable = False
+    )
 
     return update_attrs(ctx.attr, _archive_attrs.keys(), {})
 

--- a/repos/config/detail/ros2_config.bzl
+++ b/repos/config/detail/ros2_config.bzl
@@ -35,10 +35,10 @@ load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "generate_repos_
 
 generate_repos_lock(
     name = "repos_lock.update",
-    repos_file = ":repos_index_file.repos",  # Custom repos file
+    repos_file = ":repos_index_file.bzl",  # Custom repos file
     setup_file = ":repos_setup_file.bzl",  # Custom setup file
     overlay_files = [
-        ":repos_overlay_files.repos",
+        ":repos_overlay_files.bzl",
     ],
 )
 

--- a/repos/config/detail/ros2_config.bzl
+++ b/repos/config/detail/ros2_config.bzl
@@ -30,13 +30,29 @@ _archive_attrs = {
     ),
 }
 
+BUILD_FILE_CONTENT = """\
+load("@rules_ros//repos/config/detail:generate_repos_lock.bzl", "generate_repos_lock")
+
+generate_repos_lock(
+    name = "repos_lock.update",
+    repos_file = ":repos_index_file.repos",  # Custom repos file
+    setup_file = ":repos_setup_file.bzl",  # Custom setup file
+    overlay_files = [
+        ":repos_overlay_files.repos",
+    ],
+)
+
+exports_files(glob(["**/*"]))
+"""
+
+
 def _ros2_config_impl(ctx):
     ctx.file("repos_index_file.bzl", content = "REPOS_INDEX_FILE = '{}'".format(ctx.attr.repos_index))
     ctx.file("repos_overlay_files.bzl", content = "REPOS_OVERLAY_FILES = {}".format(["{}".format(i) for i in ctx.attr.repos_index_overlays]))
     ctx.file("repos_setup_file.bzl", content = "REPOS_SETUP_FILE = '{}'".format(ctx.attr.setup_file))
     ctx.symlink(ctx.attr.setup_file, "setup.bzl")
     ctx.file("WORKSPACE", content = "workspace(name = {})".format(ctx.name), executable = False)
-    ctx.file("BUILD.bazel", content = "exports_files(glob(['**/*']))", executable = False)
+    ctx.file("BUILD.bazel", content = BUILD_FILE_CONTENT, executable = False)
 
     return update_attrs(ctx.attr, _archive_attrs.keys(), {})
 

--- a/repos/config/detail/ros2_config.bzl
+++ b/repos/config/detail/ros2_config.bzl
@@ -56,14 +56,14 @@ def _ros2_config_impl(ctx):
     ctx.file(
         "WORKSPACE",
         content = "workspace(name = {})".format(ctx.name),
-        executable = False
+        executable = False,
     )
     ctx.file(
         "BUILD.bazel",
         content = BUILD_FILE_CONTENT.format(
-            overlays="\n".join(['        "{}",'.format(filename) for filename in overlay_files])
+            overlays = "\n".join(['        "{}",'.format(filename) for filename in overlay_files]),
         ),
-        executable = False
+        executable = False,
     )
 
     return update_attrs(ctx.attr, _archive_attrs.keys(), {})


### PR DESCRIPTION
Fixed the hard-coded paths in the repo locking functionality that always pointed to `@ros2_config` external workspace.

User now has an option to provide the config workspace name.